### PR TITLE
The beginnings of stars!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Declarations
 .PHONY: all clean
 
-all: clean tests plots vera_plots
+all: clean tests plots #vera_plots
 tests: mcfacts_sim
 
 ######## Definitions ########
@@ -21,7 +21,7 @@ HERE=./
 #### Scripts ####
 MCFACTS_SIM_EXE = ${HERE}/scripts/mcfacts_sim.py
 POPULATION_PLOTS_EXE = ${HERE}/scripts/population_plots.py
-VERA_PLOTS_EXE = ${HERE}/scripts/vera_plots.py
+#VERA_PLOTS_EXE = ${HERE}/scripts/vera_plots.py
 
 ######## Instructions ########
 #### Install ####

--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,15 @@ version: clean
 	echo "__version__ = '${VERSION}'" > src/mcfacts/__version__.py
 
 install: clean version
-	pip3 install -e .
+	pip install -e .
 
 #### Test one thing at a time ####
 
 mcfacts_sim: clean
-	python3 ${MCFACTS_SIM_EXE} --fname-log out.log
+	python ${MCFACTS_SIM_EXE} --fname-log out.log
 
 plots:  mcfacts_sim
-	python3 ${POPULATION_PLOTS_EXE}
+	python ${POPULATION_PLOTS_EXE}
 
 #### CLEAN ####
 clean:

--- a/Makefile
+++ b/Makefile
@@ -33,20 +33,22 @@ install: clean version
 
 #### Test one thing at a time ####
 
+wd=$(shell pwd)/test_output
+
 mcfacts_sim: clean
-	python ${MCFACTS_SIM_EXE} --fname-log out.log
+	python ${MCFACTS_SIM_EXE} --fname-log out.log --work-directory ${wd}
 
 plots:  mcfacts_sim
-	python ${POPULATION_PLOTS_EXE}
+	python ${POPULATION_PLOTS_EXE} --fname-mergers ${wd}/output_mergers_population.dat --plots-directory ${wd}
 
 #### CLEAN ####
 clean:
-	rm -rf run*
-	rm -rf output_mergers_population.dat
-	rm -rf m1m2.png
-	rm -rf merger_mass_v_radius.png
-	rm -rf q_chi_eff.png
-	rm -rf time_of_merger.png
-	rm -rf merger_remnant_mass.png
-	rm -rf gw_strain.png
-	rm -rf out.log
+	rm -rf ${wd}/run*
+	rm -rf ${wd}/output_mergers_population.dat
+	rm -rf ${wd}/m1m2.png
+	rm -rf ${wd}/merger_mass_v_radius.png
+	rm -rf ${wd}/q_chi_eff.png
+	rm -rf ${wd}/time_of_merger.png
+	rm -rf ${wd}/merger_remnant_mass.png
+	rm -rf ${wd}/gw_strain.png
+	rm -rf ${wd}/out.log

--- a/Makefile
+++ b/Makefile
@@ -31,33 +31,32 @@ version: clean
 	echo "__version__ = '${VERSION}'" > src/mcfacts/__version__.py
 
 install: clean version
-	pip3 install -e .
+	pip install -e .
 
 #### Test one thing at a time ####
 
+wd=$(shell pwd)/test_output
+
 mcfacts_sim: clean
-	python3 ${MCFACTS_SIM_EXE} \
-		--n_iterations 100 \
-		--fname-log out.log
+	python ${MCFACTS_SIM_EXE} \
+		--fname-log out.log --work-directory ${wd}
 
 plots:  mcfacts_sim
-	python3 ${POPULATION_PLOTS_EXE} 
+	python ${POPULATION_PLOTS_EXE} --fname-mergers ${wd}/output_mergers_population.dat --plots-directory ${wd}
 
-vera_plots: mcfacts_sim
-	python3 ${VERA_PLOTS_EXE} \
-		--cdf chi_eff chi_p M gen1 gen2 t_merge \
-		--verbose
+#vera_plots: mcfacts_sim
+#	python3 ${VERA_PLOTS_EXE} \
+#		--cdf chi_eff chi_p M gen1 gen2 t_merge \
+#		--verbose
 
 #### CLEAN ####
 clean:
-	rm -rf run*
-	rm -rf output_mergers_population.dat
-	rm -rf m1m2.png
-	rm -rf merger_mass_v_radius.png
-	rm -rf q_chi_eff.png
-	rm -rf time_of_merger.png
-	rm -rf merger_remnant_mass.png
-	rm -rf gw_strain.png
-	rm -rf out.log
-	rm -rf mergers_cdf*.png
-	rm -rf mergers_nal*.png
+	rm -rf ${wd}/run*
+	rm -rf ${wd}/output_mergers_population.dat
+	rm -rf ${wd}/m1m2.png
+	rm -rf ${wd}/merger_mass_v_radius.png
+	rm -rf ${wd}/q_chi_eff.png
+	rm -rf ${wd}/time_of_merger.png
+	rm -rf ${wd}/merger_remnant_mass.png
+	rm -rf ${wd}/gw_strain.png
+	rm -rf ${wd}/out.log

--- a/objects/agnobject.py
+++ b/objects/agnobject.py
@@ -8,36 +8,132 @@ def dump_array_to_file(fname=None, samples_out=None):
   fname_out_ascii= fname
   dframe.to_csv(fname_out_ascii,sep=' ',header=[f"#{x}" if x == dframe.columns[0] else x for x in dframe.columns],index=False) # # is not pre-appended...just boolean
 
+""" 
+def check_1d_length(arr_list):
+    if(len({arr.shape for arr in arr_list}) > 1):
+        raise ValueError('Arrays are not all 1d.')
+
+    if( len(set(map(len,arr_list))) != 1):
+        raise ValueError('Arrays are not all the same length.')
+ """    
+
+#TODO: method to print values when you just run an AGNOBject class in a jupyter notebook or similar.
+#TODO: similar vein: print method? Same thing maybe?
+#TODO: custom error messages when you don't supply all the fields for init and add methods
+#TODO: custom error messages when input arrays to init and add methods aren't the same length
+#TODO: dump_record_array writes every value as a float. Make dictionary with all attributes and datatypes? Or is a float fine?
+#TODO: init_from_file: you have to initialize an empty AGNObject before you can init_from_file and that seems weird.
+       #check if this is now just an AGNObject because we would want it to be an AGNStar or AGNBlackHole etc
+#TODO: error if you try to pass kwarg that doesnt exist. AttributeError?
+#TODO: issue: right now you can pass AGNStar arrays that are 8-elements long for the star parameters and 10-elements long 
+       #for the AGNObject parameters and it doesn't complain.
+#TODO: dump_array_to_file: can I just import DataFrame and to_csv so it's lower overhead?
 
 class AGNObject(object):
     """
     An array of objects. Should include all objects of this type.
     Argument arrays should be *1d scalar arrays*.
+    Everything here is for the center-of-mass around the SMBH
     """
 
-    def __init__(self, orbit_a = None, mass = None, orbit_inclination= None, orbit_e = None, **kwargs):
-        self.orbit_a = orbit_a #Should be array. Semimajor axis
+    def __init__(self,  mass = None,
+                        spin = None, #internal quantity. total J for a binary
+                        spin_angle = None, #angle between J and orbit around SMBH for binary
+                        orbit_a = None, #location
+                        orbit_inclination= None, #of CoM for binary around SMBH
+                        orb_ang_mom = None,
+                        orbit_e = None,
+                        nsystems = None):
+        
+        #Make sure all inputs are included
+        if mass is None: raise AttributeError("mass is not included in inputs")
+        if spin is None: raise AttributeError('spin is not included in inputs')
+        if spin_angle is None: raise AttributeError('spin_angle is not included in inputs')
+        if orbit_a is None: raise AttributeError('orbit_a is not included in inputs')
+        if orbit_inclination is None: raise AttributeError('orbit_inclination is not included in inputs')
+        if orb_ang_mom is None: raise AttributeError('orb_ang_mom is not included in inputs')
+        if orbit_e is None: raise AttributeError('orbit_e is not included in inputs')
+
+        if nsystems is None: nsystems = mass.size
+
+        assert mass.shape == (nsystems,),"mass: all arrays must be 1d and the same length"
+        assert spin.shape == (nsystems,),"spin: all arrays must be 1d and the same length"
+        assert spin_angle.shape == (nsystems,),"spin_angle: all arrays must be 1d and the same length"
+        assert orbit_a.shape == (nsystems,),"orbit_a: all arrays must be 1d and the same length"
+        assert orbit_inclination.shape == (nsystems,),"orbit_inclination: all arrays must be 1d and the same length"
+        assert orb_ang_mom.shape == (nsystems,),"orb_ang_mom: all arrays must be 1d and the same length"
+        assert orbit_e.shape == (nsystems,),"orbit_e: all arrays must be 1d and the same length"
+        
         self.mass = mass #Should be array. TOTAL masses.
+        self.spin = spin #Should be array
+        self.spin_angle = spin_angle #should be array
+        self.orbit_a = orbit_a #Should be array. Semimajor axis
         self.orbit_inclination = orbit_inclination #Should be array. Allows for misaligned orbits.
+        self.orb_ang_mom = orb_ang_mom #Should be array
         self.orbit_e = orbit_e #Should be array. Allows for eccentricity.
+        self.generations = np.full(len(self.mass),1)
     
-    def __add_objects__(self, new_object_a = None, new_object_mass = None, new_object_inclination = None, new_object_e = None):
+    def __add_objects__(self, new_mass = None,
+                              new_spin = None,
+                              new_spin_angle = None,
+                              new_a = None,
+                              new_inclination = None,
+                              new_orb_ang_mom = None,
+                              new_e = None,
+                              nsystems = None):
         """
         Adds new values to the end of existing arrays
-        TODO: check that all arrays are the same length.
-        TODO: check that all arrays are included
         """
-        self.orbit_a = np.concatenate([self.orbit_a,new_object_a])
-        self.mass = np.concatenate([self.mass,new_object_mass])
-        self.orbit_inclination = np.concatenate([self.orbit_inclination,new_object_inclination])
-        self.orbit_e = np.concatenate([self.orbit_e,new_object_e])
+
+        #Make sure all inputs are included
+        if new_mass is None: raise AttributeError('new_mass is not included in inputs')
+        if new_spin is None: raise AttributeError('new_spin is not included in inputs')
+        if new_spin_angle is None: raise AttributeError('new_spin_angle is not included in inputs')
+        if new_a is None: raise AttributeError('new_a is not included in inputs')
+        if new_inclination is None: raise AttributeError('new_inclination is not included in inputs')
+        if new_orb_ang_mom is None: raise AttributeError('new_orb_ang_mom is not included in inputs')
+        if new_e is None: raise AttributeError('new_e is not included in inputs')
+
+        if nsystems is None: nsystems = new_mass.size
+
+        assert new_mass.shape == (nsystems,),"new mass: all arrays must be 1d and the same length"
+        assert new_spin.shape == (nsystems,),"new_spin: all arrays must be 1d and the same length"
+        assert new_spin_angle.shape == (nsystems,),"new_spin_angle: all arrays must be 1d and the same length"
+        assert new_a.shape == (nsystems,),"new_a: all arrays must be 1d and the same length"
+        assert new_inclination.shape == (nsystems,),"new_inclination: all arrays must be 1d and the same length"
+        assert new_orb_ang_mom.shape == (nsystems,),"new_orb_ang_mom: all arrays must be 1d and the same length"
+        assert new_e.shape == (nsystems,),"new_e: all arrays must be 1d and the same length"
+
+
+        self.mass = np.concatenate([self.mass,new_mass])
+        self.spin = np.concatenate([self.spin,new_spin])
+        self.spin_angle = np.concatenate([self.spin_angle,new_spin_angle])
+        self.orbit_a = np.concatenate([self.orbit_a,new_a])
+        self.orbit_inclination = np.concatenate([self.orbit_inclination,new_inclination])
+        self.orb_ang_mom = np.concatenate([self.orb_ang_mom,new_orb_ang_mom])
+        self.orbit_e = np.concatenate([self.orbit_e,new_e])
+        self.generations = np.concatenate([self.generations,np.full(len(new_mass),1)])
 
     def remove_objects(self, idx_remove = None):
         """
+        Removes objects at specified indices.
+
+        Parameters
+        ----------
+        idx_remove : numpy array
+            Indices to remove
+
+        Returns
+        -------
+        ???
         idx_remove should be a numpy array of indices to change, e.g., [2, 15, 23]
         as written, this loops over all attributes, not just those in the AGNObjects class,
         i.e., we don't need a separate remove_objects method for the subclasses.
         """
+
+        #Check that the index array is a numpy array.
+        assert isinstance(idx_remove,np.ndarray),"idx_remove must be numpy array"
+
         if idx_remove is None:
             return None
         
@@ -46,20 +142,44 @@ class AGNObject(object):
         for attr in vars(self).keys():
             setattr(self,attr,getattr(self,attr)[idx_change])
 
+    def locate(self,idx=None):
+        """
+        Returns objects at specified indices
+        """
+
+        #Check that index array is numpy array
+        assert isinstance(idx,np.ndarray),"idx must be numpy array"
+
+        if idx is None:
+            return None
+        
+        idx_full = np.zeros(len(self.mass),dtype=bool)
+        idx_full[idx] = True
+
+    def return_params(self):
+        """
+        Gets list of parameters present in object.
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        list
+            parameters in object
+        """
+        return(list(vars(self).keys()))
+
+
     def return_record_array(self,**kwargs):
         """
         Right now every dtype is float.
-        TODO: We will probably want to change this later. Dictionary with attribute names and keys?
         Loops over all attributes, don't need to rewrite for subclasses.
         """
-        #dat_out = np.array(len(self.mass), dtype = {attr:float for attr in vars(self).keys()})
         dtype = np.dtype([(attr,'float') for attr in vars(self).keys()])
         dat_out = np.empty(len(self.mass),dtype=dtype)
-        print(dat_out)
         for attr in vars(self).keys():
-            print(attr)
-            print(dat_out[attr])
-            print(getattr(self,attr))
             dat_out[attr] = getattr(self,attr)
         return(dat_out)
     
@@ -67,32 +187,373 @@ class AGNObject(object):
         """
         Read in previously saved data file and create AGNObject from it.
         Odd implementation right now, have to init AGNObject and only then read from file.
-        TODO: Fix so that you can just read from file.
         """
         dat_in = np.genfromtxt(fname,names=True)
         for name in dat_in.dtype.names:
             setattr(self,name,dat_in[name])
 
-#TODO: method to print values when you just run an AGNOBject class in a jupyter notebook or similar.
-#TODO: similar vein: print method? Same thing maybe?
-#TODO: custom error messages when you don't supply all the fields
-#TODO: add spin for stars
-
 
 class AGNStar(AGNObject):
     """
     An array of single stars. Should include all objects of this type. No other objects should contain objects of this type.
+    Takes in initial helium and metals mass fractions, calculates hydrogen mass fraction from that to ensure it adds up to unity.
     """
-    def __init__(self, star_radius = None, star_X = None, star_Y = None, star_Z = None, **kwargs):
-       self.star_radius = star_radius
-       self.star_X = star_X
-       self.star_Y = star_Y
-       self.star_Z = star_Z
-       super(AGNStar,self).__init__(**kwargs) #calls top level functions
+    def __init__(self, star_radius = None, star_Y = None, star_Z = None, nsystems = None, **kwargs):
+        """
+        Array of single star objects.
+        star_radius should be a 1d numpy array
+        star_Y and star_Z can be floats or 1d numpy arrays, but must sum to 1 or less.
+        """
+        #Make sure all inputs are included
+        if star_radius is None: raise AttributeError('star_radius is not included in inputs')
+        if star_Y is None: raise AttributeError('star_Y is not included in inputs')
+        if star_Z is None: raise AttributeError('star_Z is not included in inputs')
 
-    def add_stars(self, new_star_radius = None, new_star_X = None, new_star_Y = None, new_star_Z = None, **kwargs):
-        self.star_radius = np.concatenate([self.star_radius,new_star_radius])
-        self.star_X = np.concatenate([self.star_X,new_star_X])
-        self.star_Y = np.concatenate([self.star_Y,new_star_Y])
-        self.star_Z = np.concatenate([self.star_Z,new_star_Z])
-        super(AGNStar,self).__add_objects__(**kwargs)
+        if nsystems is None: nsystems = star_radius.size
+
+        #Make sure inputs are numpy arrays
+        assert isinstance(star_radius,np.ndarray),"star_radius is not a numpy array"
+
+        self.star_radius = star_radius
+
+        if (np.any(star_Y + star_Z > 1.)):
+            raise ValueError("star_Y and star_Z must sum to 1 or less.")
+
+        if ((isinstance(star_Y,float) and (isinstance(star_Z,float)))):
+            self.star_X = np.ones(len(star_radius)) - np.full(len(star_radius),star_Y) - np.full(len(star_radius),star_Z)
+            self.star_Y = np.full(len(star_radius),star_Y)
+            self.star_Z = np.full(len(star_radius),star_Z)
+        
+        elif ((isinstance(star_Y,np.ndarray) and isinstance(star_Z,np.ndarray))):
+            assert star_radius.shape == (nsystems,),"star_radius != nsystems"
+            assert star_Y.shape == (nsystems,),"star_Y, array: all arrays must be 1d and the same length"
+            assert star_Z.shape == (nsystems,),"star_Z, array: all arrays must be 1d and the same length"
+
+            self.star_X = 1. - star_Y - star_Z
+            self.star_Y = star_Y
+            self.star_Z = star_Z
+
+        else:
+            raise TypeError("star_Y and star_Z must be either both floats or numpy arrays")
+
+
+        super(AGNStar,self).__init__(nsystems = nsystems, **kwargs) #calls top level functions
+    
+    def __repr__(self):
+        return('AGNStar(): {} single stars'.format(len(self.mass)))
+
+    def add_stars(self, new_radius = None, new_Y = None, new_Z = None, nsystems = None, **kwargs):
+        """
+        Add new star values to the end of existing arrays.
+        """
+
+        #Make sure all inputs are included
+        if new_radius is None: raise AttributeError("new_radius is not included in inputs")
+        if new_Y is None: raise AttributeError("new_Y is not included in inputs")
+        if new_Z is None: raise AttributeError("new_Z is not included in inputs")
+
+        if nsystems is None: nsystems = new_radius.size
+
+        assert new_radius.shape == (nsystems,),"new_radius: all arrays must be 1d and the same length"
+        self.star_radius = np.concatenate([self.star_radius,new_radius])
+
+        if(np.any(new_Y + new_Z) > 1.): raise ValueError("new_Y and new_Z must sum to 1 or less")
+
+        if( (isinstance(new_Y, float)) and (isinstance(new_Z, float))):
+            self.star_X = np.concatenate(self.star_X, np.full(nsystems,1.-new_Y-new_Z))
+            self.star_Y = np.concatenate([self.star_Y, np.full(nsystems,new_Y)])
+            self.star_Z = np.concatenate([self.star_Z, np.full(nsystems,new_Z)])
+            
+        if( (isinstance(new_Y, np.ndarray)) and (isinstance(new_Z, np.ndarray))):
+            self.star_X = np.concatenate([self.star_X, np.ones(nsystems) - new_Y - new_Z])
+            self.star_Y = np.concatenate([self.star_Y, new_Y])
+            self.star_Z = np.concatenate([self.star_Z, new_Z])
+        super(AGNStar,self).__add_objects__(nsystems = nsystems, **kwargs)
+
+
+class AGNBlackHole(AGNObject):
+    """
+    An array of single black holes. Should include all objects of this type. No other objects should contain objects of this type.
+    """
+    def __init__(self,**kwargs):
+        super(AGNBlackHole,self).__init__(**kwargs) #Calls top level functions
+    
+    def __repr__(self):
+        return('AGNBlackHole(): {} single black holes'.format(len(self.mass)))
+
+
+    def add_blackholes(self, nsystems = None, **kwargs):
+        super(AGNBlackHole,self).__add_objects__(nsystems = nsystems, **kwargs)
+
+
+class AGNBinaryStar(AGNObject):
+    """
+    An array of binary stars. Should include all objects of this type. No other objects should include objects of this type.
+    """
+
+    def __init__(self, star_mass1 = None,
+                       star_mass2 = None,
+                       star_radius1 = None,
+                       star_radius2 = None,
+                       star_Y1 = None,
+                       star_Y2 = None,
+                       star_Z1 = None,
+                       star_Z2 = None,
+                       star_spin1 = None,
+                       star_spin2 = None,
+                       star_spin_angle1 = None,
+                       star_spin_angle2 = None,
+                       star_orbit_a1 = None,
+                       star_orbit_a2 = None,
+                       star_orbit_inclination1 = None,
+                       star_orbit_inclination2 = None,
+                       star_orb_ang_mom1 = None,
+                       star_orb_ang_mom2 = None,
+                       binary_e = None,
+                       binary_a = None,
+                       nsystems = None,
+                     **kwargs):
+        
+        #Make sure all inputs are included
+        if star_mass1 is None: raise AttributeError("star_mass1 is not included in inputs")
+        if star_mass2 is None: raise AttributeError("star_mass2 is not included in inputs")
+        if star_radius1 is None: raise AttributeError("star_radius1 is not included in inputs")
+        if star_radius2 is None: raise AttributeError("star_radius2 is not included in inputs")
+        if star_Y1 is None: raise AttributeError("star_Y1 is not included in inputs")
+        if star_Y2 is None: raise AttributeError("star_Y2 is not included in inputs")
+        if star_Z1 is None: raise AttributeError("star_Z1 is not included in inputs")
+        if star_Z2 is None: raise AttributeError("star_Z2 is not included in inputs")
+        if star_spin1 is None: raise AttributeError("star_spin1 is not included in inputs")
+        if star_spin2 is None: raise AttributeError("star_spin2 is not included in inputs")
+        if star_spin_angle1 is None: raise AttributeError("star_spin_angle1 is not included in inputs")
+        if star_spin_angle2 is None: raise AttributeError("star_spin_angle2 is not included in inputs")
+        if star_orbit_a1 is None: raise AttributeError("star_orbit_a1 is not included in inputs")
+        if star_orbit_a2 is None: raise AttributeError("star_orbit_a2 is not included in inputs")
+        if star_orbit_inclination1 is None: raise AttributeError("star_orbit_inclination1 is not included in inputs")
+        if star_orbit_inclination2 is None: raise AttributeError("star_orbit_inclination2 is not included in inputs")
+        if star_orb_ang_mom1 is None: raise AttributeError("star_orb_ang_mom1 is not included in inputs")
+        if star_orb_ang_mom2 is None: raise AttributeError("star_orb_ang_mom2 is not included in inputs")
+        if binary_e is None: raise AttributeError("binary_e is not included in inputs")
+        if binary_a is None: raise AttributeError("binary_a is not included in inputs")
+
+        if nsystems is None: nsystems = star_mass1.size
+
+        #Check that all inputs are 1d numpy arrays
+        assert star_mass1.shape == (nsystems,),"star_mass1: all arrays must be 1d and the same length"
+        assert star_mass2.shape == (nsystems,),"star_mass2: all arrays must be 1d and the same length"
+        assert star_radius1.shape == (nsystems,),"star_radius1: all arrays must be 1d and the same length"
+        assert star_radius2.shape == (nsystems,),"star_radius2: all arrays must be 1d and the same length"
+        assert star_spin1.shape == (nsystems,),"star_spin1: all arrays must be 1d and the same length"
+        assert star_spin2.shape == (nsystems,),"star_spin2: all arrays must be 1d and the same length"
+        assert star_spin_angle1.shape == (nsystems,),"star_spin_angle1: all arrays must be 1d and the same length"
+        assert star_spin_angle2.shape == (nsystems,),"star_spin_angle2: all arrays must be 1d and the same length"
+        assert star_orbit_a1.shape == (nsystems,),"star_orbit_a1: all arrays must be 1d and the same length"
+        assert star_orbit_a2.shape == (nsystems,),"star_orbit_a2: all arrays must be 1d and the same length"
+        assert star_orbit_inclination1.shape == (nsystems,),"star_orbit_inclination1: all arrays must be 1d and the same length"
+        assert star_orbit_inclination2.shape == (nsystems,),"star_orbit_inclination2: all arrays must be 1d and the same length"
+        assert star_orb_ang_mom1.shape == (nsystems,),"star_orb_ang_mom1: all arrays must be 1d and the same length"
+        assert star_orb_ang_mom2.shape == (nsystems,),"star_orb_ang_mom2: all arrays must be 1d and the same length"
+        assert binary_e.shape == (nsystems,),"binary_e: all arrays must be 1d and the same length"
+        assert binary_a.shape == (nsystems,),"binary_a: all arrays must be 1d and the same length"
+
+        if (np.any(star_Y1 + star_Z1 > 1.)):
+            raise ValueError("star_Y1 and star_Z1 must sum to 1 or less.")
+        if (np.any(star_Y2 + star_Z2 > 1.)):
+            raise ValueError("star_Y2 and star_Z2 must sum to 1 or less.")
+
+        if((isinstance(star_Y1,float)) and (isinstance(star_Z1,float))):
+            star_X1 = np.full(nsystems,1. - star_Y1 - star_Z1)
+            star_Y1 = np.full(nsystems,star_Y1)
+            star_Z1 = np.full(nsystems,star_Z1)
+        if((isinstance(star_Y2,float)) and (isinstance(star_Z2,float))):
+            star_X2 = np.full(nsystems,1. - star_Y2 - star_Z2)
+            star_Y2 = np.full(nsystems,star_Y2)
+            star_Z2 = np.full(nsystems,star_Z2)
+        if((isinstance(star_Y1,np.ndarray)) and (isinstance(star_Z1,np.ndarray))):
+            assert star_Y1.shape == (nsystems,),"star_Y1: all arrays must be 1d and the same length"
+            assert star_Z1.shape == (nsystems,),"star_Z1: all arrays must be 1d and the same length"
+            star_X1 = np.ones(nsystems) - star_Y1 - star_Z1
+        if((isinstance(star_Y2,np.ndarray)) and (isinstance(star_Z2,np.ndarray))):
+            assert star_Y2.shape == (nsystems,),"star_Y2: all arrays must be the same length"
+            assert star_Z2.shape == (nsystems,),"star_Z2: all arrays must be the same length"
+            star_X2 = np.ones(nsystems) - star_Y2 - star_Z2
+        else: raise TypeError("star_Y1, star_Z1 and star_Y2, star_Z2 must be either both floats or numpy arrays")
+
+
+        #Now assign attributes
+        self.star_mass1 = star_mass1
+        self.star_mass2 = star_mass2
+        self.star_radius1 = star_radius1
+        self.star_radius2 = star_radius2
+        self.star_X1 = star_X1
+        self.star_X2 = star_X2
+        self.star_Y1 = star_Y1
+        self.star_Y2 = star_Y2
+        self.star_Z1 = star_Z1
+        self.star_Z2 = star_Z2
+        self.star_spin1 = star_spin1
+        self.star_spin2 = star_spin2
+        self.star_spin_angle1 = star_spin_angle1
+        self.star_spin_angle2 = star_spin_angle2
+        self.star_orbit_a1 = star_orbit_a1
+        self.star_orbit_a2 = star_orbit_a2
+        self.star_orbit_inclination1 = star_orbit_inclination1
+        self.star_orbit_inclination2 = star_orbit_inclination2
+        self.star_orb_ang_mom1 = star_orb_ang_mom1
+        self.star_orb_ang_mom2 = star_orb_ang_mom2
+        self.binary_e = binary_e
+        self.binary_a = binary_a
+
+        #Now calculate properties for the AGNObject class aka the totals
+        total_mass = star_mass1 + star_mass2
+        total_spin = star_spin1 + star_spin2
+        total_spin_angle = star_spin_angle1 + star_spin_angle2
+        total_orbit_a = star_orbit_a1 + star_orbit_a2
+        total_orbit_inclination = star_orbit_inclination1 + star_orbit_inclination2
+        total_orb_ang_mom = star_orb_ang_mom1 + star_orb_ang_mom2
+
+        super(AGNBinaryStar,self).__init__(mass = total_mass, spin = total_spin, spin_angle = total_spin_angle, orbit_a = total_orbit_a, orbit_inclination = total_orbit_inclination, orb_ang_mom = total_orb_ang_mom, orbit_e = binary_e, nsystems = nsystems)
+        
+
+    def __repr__(self):
+        return('AGNBinaryStar(): {} stellar binaries'.format(len(self.mass)))
+    
+    def add_binaries(self, new_star_mass1 = None,
+                        new_star_radius1 = None,
+                        new_star_mass2 = None,
+                        new_star_radius2 = None,
+                        new_star_Y1 = None,
+                        new_star_Y2 = None,
+                        new_star_Z1 = None,
+                        new_star_Z2 = None,
+                        new_star_spin1 = None,
+                        new_star_spin2 = None,
+                        new_star_spin_angle1 = None,
+                        new_star_spin_angle2 = None,
+                        new_star_orbit_a1 = None,
+                        new_star_orbit_a2 = None,
+                        new_star_orbit_inclination1 = None,
+                        new_star_orbit_inclination2 = None,
+                        new_star_orb_ang_mom1 = None,
+                        new_star_orb_ang_mom2 = None,
+                        new_binary_e = None,
+                        new_binary_a = None,
+                        nsystems = None,
+                    **kwargs):
+        
+
+        #Make sure all inputs are included
+        if new_star_mass1 is None: raise AttributeError("new_star_mass1 is not included in inputs")
+        if new_star_mass2 is None: raise AttributeError("new_star_mass2 is not included in inputs")
+        if new_star_radius1 is None: raise AttributeError("new_star_radius1 is not included in inputs")
+        if new_star_radius2 is None: raise AttributeError("new_star_radius2 is not included in inputs")
+        if new_star_Y1 is None: raise AttributeError("new_star_Y1 is not included in inputs")
+        if new_star_Y2 is None: raise AttributeError("new_star_Y2 is not included in inputs")
+        if new_star_Z1 is None: raise AttributeError("new_star_Z1 is not included in inputs")
+        if new_star_Z2 is None: raise AttributeError("new_star_Z2 is not included in inputs")
+        if new_star_spin1 is None: raise AttributeError("new_star_spin1 is not included in inputs")
+        if new_star_spin2 is None: raise AttributeError("new_star_spin2 is not included in inputs")
+        if new_star_spin_angle1 is None: raise AttributeError("new_star_spin_angle1 is not included in inputs")
+        if new_star_spin_angle2 is None: raise AttributeError("new_star_spin_angle2 is not included in inputs")
+        if new_star_orbit_a1 is None: raise AttributeError("new_star_orbit_a1 is not included in inputs")
+        if new_star_orbit_a2 is None: raise AttributeError("new_star_orbit_a2 is not included in inputs")
+        if new_star_orbit_inclination1 is None: raise AttributeError("new_star_orbit_inclination1 is not included in inputs")
+        if new_star_orbit_inclination2 is None: raise AttributeError("new_star_orbit_inclination2 is not included in inputs")
+        if new_star_orb_ang_mom1 is None: raise AttributeError("new_star_orb_ang_mom1 is not included in inputs")
+        if new_star_orb_ang_mom2 is None: raise AttributeError("new_star_orb_ang_mom2 is not included in inputs")
+        if new_binary_e is None: raise AttributeError("new_binary_e is not included in inputs")
+        if new_binary_a is None: raise AttributeError("new_binary_a is not included in inputs")
+
+        if nsystems is None: nsystems = new_star_mass1.size
+
+        #Check that all inputs are 1d numpy arrays
+        assert new_star_mass1.shape == (nsystems,),"new_star_mass1: all arrays must be 1d and the same length"
+        assert new_star_mass2.shape == (nsystems,),"new_star_mass2: all arrays must be 1d and the same length"
+        assert new_star_radius1.shape == (nsystems,),"new_star_radius1: all arrays must be 1d and the same length"
+        assert new_star_radius2.shape == (nsystems,),"new_star_radius2: all arrays must be 1d and the same length"
+        assert new_star_spin1.shape == (nsystems,),"new_star_spin1: all arrays must be 1d and the same length"
+        assert new_star_spin2.shape == (nsystems,),"new_star_spin2: all arrays must be 1d and the same length"
+        assert new_star_spin_angle1.shape == (nsystems,),"new_star_spin_angle1: all arrays must be 1d and the same length"
+        assert new_star_spin_angle2.shape == (nsystems,),"new_star_spin_angle2: all arrays must be 1d and the same length"
+        assert new_star_orbit_a1.shape == (nsystems,),"new_star_orbit_a1: all arrays must be 1d and the same length"
+        assert new_star_orbit_a2.shape == (nsystems,),"new_star_orbit_a2: all arrays must be 1d and the same length"
+        assert new_star_orbit_inclination1.shape == (nsystems,),"new_star_orbit_inclination1: all arrays must be 1d and the same length"
+        assert new_star_orbit_inclination2.shape == (nsystems,),"new_star_orbit_inclination2: all arrays must be 1d and the same length"
+        assert new_star_orb_ang_mom1.shape == (nsystems,),"new_star_orb_ang_mom1: all arrays must be 1d and the same length"
+        assert new_star_orb_ang_mom2.shape == (nsystems,),"new_star_orb_ang_mom2: all arrays must be 1d and the same length"
+        assert new_binary_e.shape == (nsystems,),"new_binary_e: all arrays must be 1d and the same length"
+        assert new_binary_a.shape == (nsystems,),"new_binary_a: all arrays must be 1d and the same length"
+
+        if (np.any(new_star_Y1 + new_star_Z1 > 1.)):
+            raise ValueError("new_star_Y1 and new_star_Z1 must sum to 1 or less.")
+        if (np.any(new_star_Y2 + new_star_Z2 > 1.)):
+            raise ValueError("new_star_Y2 and new_star_Z2 must sum to 1 or less.")
+
+        if((isinstance(new_star_Y1,float)) and (isinstance(new_star_Z1,float))):
+            new_star_X1 = np.full(nsystems,1. - new_star_Y1 - new_star_Z1)
+            new_star_Y1 = np.full(nsystems,new_star_Y1)
+            new_star_Z1 = np.full(nsystems,new_star_Z1)
+        if((isinstance(new_star_Y2,float)) and (isinstance(new_star_Z2,float))):
+            new_star_X2 = np.full(nsystems,1. - new_star_Y2 - new_star_Z2)
+            new_star_Y2 = np.full(nsystems,new_star_Y2)
+            new_star_Z2 = np.full(nsystems,new_star_Z2)
+        if((isinstance(new_star_Y1,np.ndarray)) and (isinstance(new_star_Z1,np.ndarray))):
+            assert new_star_Y1.shape == (nsystems,),"new_star_Y1: all arrays must be 1d and the same length"
+            assert new_star_Z1.shape == (nsystems,),"new_star_Z1: all arrays must be 1d and the same length"
+            new_star_X1 = np.ones(nsystems) - new_star_Y1 - new_star_Z1
+        if((isinstance(new_star_Y2,np.ndarray)) and (isinstance(new_star_Z2,np.ndarray))):
+            assert new_star_Y2.shape == (nsystems,),"new_star_Y2: all arrays must be the same length"
+            assert new_star_Z2.shape == (nsystems,),"new_star_Z2: all arrays must be the same length"
+            new_star_X2 = np.ones(nsystems) - new_star_Y2 - new_star_Z2
+        else: raise TypeError("new_star_Y1, new_star_Z1 and new_star_Y2, new_star_Z2 must be either both floats or numpy arrays")
+
+
+        #Now add new values
+        self.star_mass1 = np.concatenate([self.star_mass1, new_star_mass1])
+        self.star_mass2 = np.concatenate([self.star_mass2, new_star_mass2])
+        self.star_radius1 = np.concatenate([self.star_radius1, new_star_radius1])
+        self.star_radius2 = np.concatenate([self.star_radius2, new_star_radius2])
+        self.star_X1 = np.concatenate([self.star_X1, new_star_X1])
+        self.star_Y1 = np.concatenate([self.star_Y1, new_star_Y1])
+        self.star_Z1 = np.concatenate([self.star_Z1, new_star_Z1])
+        self.star_X2 = np.concatenate([self.star_X2, new_star_X2])
+        self.star_Y2 = np.concatenate([self.star_Y2, new_star_Y2])
+        self.star_Z2 = np.concatenate([self.star_Z2, new_star_Z2])
+        self.star_spin1 = np.concatenate([self.star_spin1, new_star_spin1])
+        self.star_spin2 = np.concatenate([self.star_spin2, new_star_spin2])
+        self.star_spin_angle1 = np.concatenate([self.star_spin_angle1, new_star_spin_angle1])
+        self.star_spin_angle2 = np.concatenate([self.star_spin_angle2, new_star_spin_angle2])
+        self.star_orbit_a1 = np.concatenate([self.star_orbit_a1, new_star_orbit_a1])
+        self.star_orbit_a2 = np.concatenate([self.star_orbit_a2, new_star_orbit_a2])
+        self.star_orbit_inclination1 = np.concatenate([self.star_orbit_inclination1, new_star_orbit_inclination1])
+        self.star_orbit_inclination2 = np.concatenate([self.star_orbit_inclination2, new_star_orbit_inclination2])
+        self.star_orb_ang_mom1 = np.concatenate([self.star_orb_ang_mom1, new_star_orb_ang_mom1])
+        self.star_orb_ang_mom2 = np.concatenate([self.star_orb_ang_mom2, new_star_orb_ang_mom2])
+        self.binary_e = np.concatenate([self.binary_e, new_binary_e])
+        self.binary_a = np.concatenate([self.binary_a, new_binary_a])
+
+        new_total_mass = new_star_mass1 + new_star_mass2
+        new_total_spin = new_star_spin1 + new_star_spin2
+        new_total_spin_angle = new_star_spin1 + new_star_spin2
+        new_total_orbit_a = new_star_orbit_a1 + new_star_orbit_a2
+        new_total_orbit_inclination = new_star_orbit_inclination1 + new_star_orbit_inclination2
+        new_total_orb_ang_mom = new_star_orb_ang_mom1 + new_star_orb_ang_mom2
+
+        super(AGNBinaryStar,self).__add_objects__(new_mass = new_total_mass,
+                                                   new_spin=new_total_spin,
+                                                   new_spin_angle=new_total_spin_angle,
+                                                   new_a = new_total_orbit_a,
+                                                   new_inclination=new_total_orbit_inclination,
+                                                   new_orb_ang_mom=new_total_orb_ang_mom,
+                                                   new_e=new_binary_e,
+                                                   nsystems=nsystems)
+
+
+        
+        
+
+
+
+
+
+

--- a/objects/agnobject.py
+++ b/objects/agnobject.py
@@ -1,0 +1,98 @@
+import numpy as np
+
+def dump_array_to_file(fname=None, samples_out=None):
+  # Write output (ascii)
+  # Vastly superior data i/o with pandas, but note no # used
+  import pandas
+  dframe = pandas.DataFrame(samples_out)
+  fname_out_ascii= fname
+  dframe.to_csv(fname_out_ascii,sep=' ',header=[f"#{x}" if x == dframe.columns[0] else x for x in dframe.columns],index=False) # # is not pre-appended...just boolean
+
+
+class AGNObject(object):
+    """
+    An array of objects. Should include all objects of this type.
+    Argument arrays should be *1d scalar arrays*.
+    """
+
+    def __init__(self, orbit_a = None, mass = None, orbit_inclination= None, orbit_e = None, **kwargs):
+        self.orbit_a = orbit_a #Should be array. Semimajor axis
+        self.mass = mass #Should be array. TOTAL masses.
+        self.orbit_inclination = orbit_inclination #Should be array. Allows for misaligned orbits.
+        self.orbit_e = orbit_e #Should be array. Allows for eccentricity.
+    
+    def __add_objects__(self, new_object_a = None, new_object_mass = None, new_object_inclination = None, new_object_e = None):
+        """
+        Adds new values to the end of existing arrays
+        TODO: check that all arrays are the same length.
+        TODO: check that all arrays are included
+        """
+        self.orbit_a = np.concatenate([self.orbit_a,new_object_a])
+        self.mass = np.concatenate([self.mass,new_object_mass])
+        self.orbit_inclination = np.concatenate([self.orbit_inclination,new_object_inclination])
+        self.orbit_e = np.concatenate([self.orbit_e,new_object_e])
+
+    def remove_objects(self, idx_remove = None):
+        """
+        idx_remove should be a numpy array of indices to change, e.g., [2, 15, 23]
+        as written, this loops over all attributes, not just those in the AGNObjects class,
+        i.e., we don't need a separate remove_objects method for the subclasses.
+        """
+        if idx_remove is None:
+            return None
+        
+        idx_change = np.ones(len(self.mass),dtype=bool)
+        idx_change[idx_remove] = False
+        for attr in vars(self).keys():
+            setattr(self,attr,getattr(self,attr)[idx_change])
+
+    def return_record_array(self,**kwargs):
+        """
+        Right now every dtype is float.
+        TODO: We will probably want to change this later. Dictionary with attribute names and keys?
+        Loops over all attributes, don't need to rewrite for subclasses.
+        """
+        #dat_out = np.array(len(self.mass), dtype = {attr:float for attr in vars(self).keys()})
+        dtype = np.dtype([(attr,'float') for attr in vars(self).keys()])
+        dat_out = np.empty(len(self.mass),dtype=dtype)
+        print(dat_out)
+        for attr in vars(self).keys():
+            print(attr)
+            print(dat_out[attr])
+            print(getattr(self,attr))
+            dat_out[attr] = getattr(self,attr)
+        return(dat_out)
+    
+    def init_from_file(self,fname=None):
+        """
+        Read in previously saved data file and create AGNObject from it.
+        Odd implementation right now, have to init AGNObject and only then read from file.
+        TODO: Fix so that you can just read from file.
+        """
+        dat_in = np.genfromtxt(fname,names=True)
+        for name in dat_in.dtype.names:
+            setattr(self,name,dat_in[name])
+
+#TODO: method to print values when you just run an AGNOBject class in a jupyter notebook or similar.
+#TODO: similar vein: print method? Same thing maybe?
+#TODO: custom error messages when you don't supply all the fields
+#TODO: add spin for stars
+
+
+class AGNStar(AGNObject):
+    """
+    An array of single stars. Should include all objects of this type. No other objects should contain objects of this type.
+    """
+    def __init__(self, star_radius = None, star_X = None, star_Y = None, star_Z = None, **kwargs):
+       self.star_radius = star_radius
+       self.star_X = star_X
+       self.star_Y = star_Y
+       self.star_Z = star_Z
+       super(AGNStar,self).__init__(**kwargs) #calls top level functions
+
+    def add_stars(self, new_star_radius = None, new_star_X = None, new_star_Y = None, new_star_Z = None, **kwargs):
+        self.star_radius = np.concatenate([self.star_radius,new_star_radius])
+        self.star_X = np.concatenate([self.star_X,new_star_X])
+        self.star_Y = np.concatenate([self.star_Y,new_star_Y])
+        self.star_Z = np.concatenate([self.star_Z,new_star_Z])
+        super(AGNStar,self).__add_objects__(**kwargs)

--- a/objects/agnobject.py
+++ b/objects/agnobject.py
@@ -396,7 +396,7 @@ class AGNBinaryStar(AGNObject):
         total_spin = None # we will pass None for now, until we decide how to treat angular momentum
         total_spin_angle = None  # we will pass None for now, until we decide how to treat angular momentum
 
-        super(AGNBinaryStar,self).__init__(mass = total_mass, spin = None, spin_angle = None, orbit_a = cm_orbit_a, orbit_inclination = cm_orbit_inclination, orbit_e = cm_orbit_e, nsystems = nsystems)
+        super(AGNBinaryStar,self).__init__(mass = total_mass, spin = star_spin_angle2, spin_angle = star_spin_angle2, orbit_a = cm_orbit_a, orbit_inclination = cm_orbit_inclination, orbit_e = cm_orbit_e, nsystems = nsystems)
         
 
     def __repr__(self):

--- a/recipes/model_choice.ini
+++ b/recipes/model_choice.ini
@@ -56,6 +56,21 @@ frac_Eddington_ratio = 1.0
 # Maximum initial eccentricity
 max_initial_eccentricity = 0.3
 #
+#
+#Star stuff
+min_initial_star_mass = 5.
+max_initial_star_mass = 40.
+star_mass_powerlaw_index = 2.35
+mu_star_spin_distribution = 100.
+sigma_star_spin_distribution = 20.
+spin_star_torque_condition = 0.1
+frac_star_Eddington_ratio = 1.0
+max_initial_star_eccentricity = 0.3
+#These values are from Brott+2011
+stars_initial_X = 0.7274
+stars_initial_Y = 0.2638
+stars_initial_Z = 0.0088
+
 # Timing:
 # 
 # timestep in years (float)

--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -1,0 +1,89 @@
+[top]
+# model_choice.txt
+# This file is for making model choices for a single run of McFACTS
+# It is your start up file (or template)! 
+# See IOdocumentation.txt for details.
+#
+# SMBH mass in units of M_sun:
+mass_smbh = 1.e8
+#
+# SMBH accretion disk:
+#
+# Specify prefix to filenames for input disk model
+disk_model_name = 'sirko_goodman'
+# trap radius in r_g
+trap_radius = 700.
+# disk outer radius in r_g
+disk_outer_radius = 50000.
+# disk alpha parameter (viscosity parameter, alpha=0.01 in sirko_goodman)
+alpha = 0.01
+#
+# Nuclear Star Cluster Population:
+#
+#Outer radius of NSC (1-10pc) in units of pc
+r_nsc_out = 5.0
+#Mass of NSC in M_sun. Milky Way NSC is 3x10^7Msun. Typically 10^6-8Msun from obs.
+M_nsc = 3.e7
+#Inner critial NSC radius (where radial number density changes) in units of pc. 0.25pc for SgrA* (Generozov+18).
+r_nsc_crit = 0.25
+#Ratio of number of BH to number of Stars (spans 3x10^-4 to 10^-2 in Generozov+18)
+nbh_nstar_ratio = 1.e-3
+#Typical ratio of mass of BH to mass of star (10Msun:1Msun in Generozov+18)
+mbh_mstar_ratio = 10.0
+#Radial density index for inner NSC, for r<r_nsc_crit. n propto r^-7/4 for Bahcall-Wolf (& Generozov+18)
+nsc_index_inner = 1.75
+#Radial density index for outer NSC, for r>r_nsc_crit. n propto r^-2.5 for Generozov+18, r^-2.25 Peebles)
+nsc_index_outer = 2.5
+#Average aspect ratio of disk (calculate this based on r_disk_outer?). Roughly 3% or so for Sirko&Goodman03.
+h_disk_average = 0.03
+#
+
+# Mode of initial BH mass distribution in M_sun (peak of Pareto fn)
+mode_mbh_init = 10.
+# Pareto (powerlaw) initial BH mass index
+mbh_powerlaw_index = 2.
+# Maximum initial BH mass in distribution in M_sun
+max_initial_bh_mass = 40.
+# Mean of Gaussian initial spin distribution 
+mu_spin_distribution = 0.
+# Sigma of Gaussian initial spin distribution 
+sigma_spin_distribution = 0.1
+# Spin torque condition
+spin_torque_condition = 0.1
+# Accretion rate of fully embedded stellar mass black hole in units of 
+#   Eddington accretion rate
+frac_Eddington_ratio = 1.0
+# Maximum initial eccentricity
+max_initial_eccentricity = 0.3
+#
+# Timing:
+# 
+# timestep in years (float)
+timestep = 1.e4
+# For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
+number_of_timesteps = 100
+
+# number of iterations of code (1 for testing. 30 for a quick run.)
+n_iterations = 1
+#
+# Other physics choices: 
+#
+# retrograde binaries on/off (1/0) switch. Retrograde = 0(1) means retrograde bins are suppressed(allowed)
+retro = 0
+# feedback on/off switch. Feedback = 1(0) means feedback is allowed(off)
+feedback = 0
+# eccentricity damping (1/0) switch. 
+# orb_ecc_damping = 1 means orbital damping is on & orb ecc is drawn from e.g. uniform or thermal distribution
+# orb_ecc_damping = 0 means orbital damping is off and all BH are assumed to be on circularized orbits (=e_crit)
+orb_ecc_damping = 1
+# Disk capture 
+# capture time in years (float). Secunda et al. (2021) assume capture rate 1/0.1Myr
+capture_time = 1.e5
+# Disk capture outer radius (in units of r_g). Secunda et al. (2021) assume <2000r_g from Fabj et al. (2020)
+outer_capture_radius = 1.e3
+#Critical eccentricity (limiting eccentricity, below which assumed circular orbit)
+crit_ecc = 0.01
+#Dynamics on/off switch. Dynamics = 0(1) means dynamical encounters are off (on)
+dynamic_enc = 0
+# Delta Energy per Strong interaction (can be up to 20%,0.2)
+de = 0.1

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -43,7 +43,6 @@ binary_stars_field_names="R1 R2 M1 M2 R1_star R2_star a1 a2 theta1 theta2 sep co
 merger_field_names=' '.join(mergerfile.names_rec)
 merger_stars_field_names=' '.join(mergerfile.names_rec)
 bh_initial_field_names = "disk_location mass spin spin_angle orb_ang_mom orb_ecc orb_incl"
-stars_initial_field_names = "disk_location mass radius X Y Z spin spin_angle orb_ang_mom _orb_ecc orb_incl"
 DEFAULT_INI = Path(__file__).parent.resolve() / ".." / "recipes" / "model_choice.ini"
 assert DEFAULT_INI.is_file()
 
@@ -299,54 +298,6 @@ def main():
                         n_stars = n_stars)
 
 
-        #Generate initial stars arrays
-        """stars_initial_locations = setupdiskstars.setup_disk_stars_location(
-            rng,
-            n_stars,
-            opts.disk_outer_radius
-            )
-        stars_initial_masses = setupdiskstars.setup_disk_stars_masses(
-            rng,
-            n_stars,
-            opts.min_initial_star_mass,
-            opts.max_initial_star_mass,
-            opts.star_mass_powerlaw_index
-            )
-        stars_initial_X, stars_initial_Y, stars_initial_Z = setupdiskstars.setup_disk_stars_comp(
-            n_stars,
-            opts.stars_initial_X, 
-            opts.stars_initial_Y, 
-            opts.stars_initial_Z)
-        stars_initial_radii = setupdiskstars.setup_disk_stars_radii(
-            stars_initial_masses
-            )
-        stars_initial_spins = setupdiskstars.setup_disk_stars_spins(
-            rng,
-            n_stars,
-            opts.mu_star_spin_distribution,
-            opts.sigma_star_spin_distribution
-        )
-        stars_initial_spin_angles = setupdiskstars.setup_disk_stars_spin_angles(
-            rng,
-            n_stars,
-            stars_initial_spins
-        )
-        stars_initial_orb_ang_mom = setupdiskstars.setup_disk_stars_orb_ang_mom(
-            rng,
-            n_stars
-            )
-        if opts.orb_ecc_damping == 1:
-            stars_initial_orb_ecc = setupdiskstars.setup_disk_stars_eccentricity_uniform(rng,n_stars)
-        else:
-            stars_initial_orb_ecc = setupdiskstars.setup_disk_stars_circularized(rng,n_stars,opts.crit_ecc)
-
-        stars_initial_orb_incl = setupdiskstars.setup_disk_stars_inclination(rng,n_stars)
-        #print("orb ecc",bh_initial_orb_ecc)
-        #bh_initial_generations = np.ones((integer_nbh,),dtype=int)  
-
-        stars_initial_generations = np.ones((n_stars,),dtype=int)"""
-
-
         # assign functions to variable names (continuity issue)
         # Disk surface density (in kg/m^2) is a function of radius, where radius is in r_g
         disk_surface_density = surf_dens_func
@@ -406,25 +357,7 @@ def main():
                                  star_Y=stars.star_Y[prograde_stars_orb_ang_mom_indices],
                                  star_Z=stars.star_Z[prograde_stars_orb_ang_mom_indices])
 
-        """ #Find prograde stars. Identify stars with orb. ang mom =+1
-        stars_orb_ang_mom_indices = np.array(stars_initial_orb_ang_mom)
-        prograde_stars_orb_ang_mom_indices = np.where(stars_orb_ang_mom_indices == 1)
-        #retrograde_orb_ang_mom_indices = np.where(stars_orb_ang_mom_indices == -1)
-        prograde_stars_locations = stars_initial_locations[prograde_stars_orb_ang_mom_indices]
-        sorted_prograde_stars_locations = np.sort(prograde_stars_locations)
-        print("Sorted prograde stars locations:",
-        len(sorted_prograde_stars_locations), len(prograde_stars_locations))
-        print(sorted_prograde_stars_locations)
-        print(prograde_stars_locations)
-        #print("Aspect ratio",aspect_ratio_func(prograde_stars_locations))
-        #Use masses of prograde stars only
-        prograde_stars_masses = stars_initial_masses[prograde_stars_orb_ang_mom_indices]
-        print("Prograde stars initial masses", len(prograde_stars_masses))
-        print("Prograde stars initital spins",stars_initial_spins[prograde_stars_orb_ang_mom_indices])
-        print("Prograde stars initial spin angles",stars_initial_spin_angles[prograde_stars_orb_ang_mom_indices])
-        # Orbital eccentricities
-        prograde_stars_orb_ecc = stars_initial_orb_ecc[prograde_stars_orb_ang_mom_indices]
-        print("Prograde orbital eccentricities",prograde_stars_orb_ecc) """
+
 
 
         
@@ -480,22 +413,7 @@ def main():
                       bh_initial_orb_incl.T],
                 header = bh_initial_field_names
         )
-        
-        """ np.savetxt(
-                os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/initial_params_stars.dat"),
-                np.c_[stars.orbit_a.T, 
-                      stars.mass.T, 
-                      stars.star_radius.T, 
-                      stars.star_X.T,
-                      stars.star_Y.T,
-                      stars.star_Z.T,
-                      stars.spin.T, 
-                      stars.spin_angle.T, 
-                      stars.orb_ang_mom.T, 
-                      stars.orbit_e.T, 
-                      stars.orbit_inclination.T],
-                header = stars_initial_field_names
-        ) """
+
         stars.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/initial_params_stars2.dat"))
 
 
@@ -574,20 +492,6 @@ def main():
                 )
 
                 #Save star params
-                """ np.savetxt(
-                    os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_stars_single_{n_timestep_index}.dat"),
-                    np.c_[prograde_stars_locations.T, 
-                          prograde_stars_masses.T, 
-                          prograde_stars_radii.T, 
-                          prograde_stars_X.T, 
-                          prograde_stars_Y.T, 
-                          prograde_stars_Z.T, 
-                          prograde_stars_spins.T, 
-                          prograde_stars_spin_angles.T, 
-                          prograde_stars_orb_ecc.T, 
-                          prograde_stars_generations[:n_stars_out_size].T],
-                    header="disk_location mass radius x y z spin theta ecc gen"
-                ) """
                 prograde_stars.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_stars_single_{n_timestep_index}.dat"))
 
                 # np.savetxt(os.path.join(work_directory, "output_bh_single_{}.dat".format(n_timestep_index)), np.c_[prograde_bh_locations.T, prograde_bh_masses.T, prograde_bh_spins.T, prograde_bh_spin_angles.T, prograde_bh_orb_ecc.T, prograde_bh_generations[:n_bh_out_size].T], header="r_bh m a theta ecc gen")

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -15,7 +15,10 @@ import argparse
 
 from mcfacts.inputs import ReadInputs
 
+from objects.agnobject import AGNStar
+
 from mcfacts.setup import setupdiskblackholes
+from mcfacts.setup import setupdiskstars
 from mcfacts.physics.migration.type1 import type1
 from mcfacts.physics.accretion.eddington import changebhmass
 from mcfacts.physics.accretion.torque import changebh
@@ -238,6 +241,22 @@ def main():
         #bh_initial_generations = np.ones((integer_nbh,),dtype=int)  
 
         bh_initial_generations = np.ones((n_bh,),dtype=int)
+
+        #----------now stars
+        n_stars = 200 #working on making this physical
+
+        #this doesn't work like it should. need some sort of initialization function. radius should call the masses function.
+
+        stars = AGNStar(mass = setupdiskstars.setup_disk_stars_masses(rng, n_stars, min_initial_star_mass,max_initial_star_mass,mstar_powerlaw_index),
+                        spin = setupdiskstars.setup_disk_stars_spins(rng, n_stars, mu_star_spin_distribution, sigma_star_spin_distribution),
+                        spin_angle = setupdiskstars.setup_disk_stars_spin_angles(rng, n_stars, stars_initial_spins),
+                        orbit_a = setupdiskstars.setup_disk_stars_location(rng, n_stars, disk_outer_radius),
+                        orbit_inclination = setupdiskstars.setup_disk_stars_inclination(rng, n_stars),
+                        #orb_ang_mom = orb_ang_mom,
+                        orbit_e = setupdiskstars.setup_disk_stars_eccentricity_uniform(rng, n_stars),
+                        star_radius = setupdiskstars.setup_disk_stars_radii(masses),
+                        star_Y = 0.0088,
+                        star_Z = 0.026)
 
         # assign functions to variable names (continuity issue)
         # Disk surface density (in kg/m^2) is a function of radius, where radius is in r_g

--- a/scripts/population_plots.py
+++ b/scripts/population_plots.py
@@ -22,6 +22,9 @@ def arg():
     parser.add_argument("--fname-mergers",
         default="output_mergers_population.dat",
         type=str, help="output_mergers file")
+    parser.add_argument("--plots-directory",
+        default=".",
+        type=str, help="directory to save plots")
     opts = parser.parse_args()
     assert os.path.isfile(opts.fname_mergers)
     return opts
@@ -56,11 +59,9 @@ def main():
     ax = plt.gca()
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
-    plt.savefig("./merger_remnant_mass.png", format='png')
+    plt.savefig(opts.plots_directory+"/merger_remnant_mass.png", format='png')
     plt.tight_layout()
     plt.close()
-
-
 
 
     trap_radius = 700
@@ -83,7 +84,7 @@ def main():
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
     plt.tight_layout()
-    plt.savefig("./merger_mass_v_radius.png", format='png')
+    plt.savefig(opts.plots_directory+"/merger_mass_v_radius.png", format='png')
     plt.close()
 
 
@@ -113,7 +114,7 @@ def main():
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
     plt.tight_layout()
-    plt.savefig("./q_chi_eff.png", format='png')
+    plt.savefig(opts.plots_directory+"/q_chi_eff.png", format='png')
     plt.close()
 
 
@@ -142,7 +143,7 @@ def main():
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
     plt.tight_layout()
-    plt.savefig('./time_of_merger.png', format='png')
+    plt.savefig(opts.plots_directory+'/time_of_merger.png', format='png')
     plt.close()
 
 
@@ -157,7 +158,7 @@ def main():
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
     plt.tight_layout()
-    plt.savefig('./m1m2.png', format='png')
+    plt.savefig(opts.plots_directory+'/m1m2.png', format='png')
 
     #GW strain figure: 
     #make sure LISA.py and PhenomA.py in /vis directory
@@ -210,7 +211,7 @@ def main():
     #ax.loglog(f_gw,h,color ='black', label='GW150914')
 
     ax.legend()
-    plt.savefig('./gw_strain.png', format='png')
+    plt.savefig(opts.plots_directory+'/gw_strain.png', format='png')
     plt.close()
 
 ######## Execution ########

--- a/scripts/population_plots.py
+++ b/scripts/population_plots.py
@@ -3,6 +3,7 @@
 ######## Globals ########
 COLUMN_NAMES = "iter CM M chi_eff a_tot spin_angle m1 m2 a1 a2 theta1 theta2 gen1 gen2 t_merge"
 
+
 ######## Imports ########
 import matplotlib.pyplot as plt
 import numpy as np
@@ -22,7 +23,11 @@ def arg():
     parser.add_argument("--fname-mergers",
         default="output_mergers_population.dat",
         type=str, help="output_mergers file")
+    parser.add_argument("--plots-directory",
+        default=".",
+        type=str, help="directory to save plots")
     opts = parser.parse_args()
+    print(opts.fname_mergers)
     assert os.path.isfile(opts.fname_mergers)
     return opts
 
@@ -53,7 +58,7 @@ def main():
     ax = plt.gca()
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
-    plt.savefig("./merger_remnant_mass.png", format='png')
+    plt.savefig(opts.plots_directory+"/merger_remnant_mass.png", format='png')
     plt.tight_layout()
     plt.close()
 
@@ -80,7 +85,7 @@ def main():
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
     plt.tight_layout()
-    plt.savefig("./merger_mass_v_radius.png", format='png')
+    plt.savefig(opts.plots_directory+"/merger_mass_v_radius.png", format='png')
     plt.close()
 
 
@@ -110,7 +115,7 @@ def main():
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
     plt.tight_layout()
-    plt.savefig("./q_chi_eff.png", format='png')
+    plt.savefig(opts.plots_directory+"/q_chi_eff.png", format='png')
     plt.close()
 
 
@@ -139,7 +144,7 @@ def main():
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
     plt.tight_layout()
-    plt.savefig('./time_of_merger.png', format='png')
+    plt.savefig(opts.plots_directory+'/time_of_merger.png', format='png')
     plt.close()
 
 
@@ -154,7 +159,7 @@ def main():
     ax.set_axisbelow(True)
     plt.grid(True, color='gray', ls='dashed')
     plt.tight_layout()
-    plt.savefig('./m1m2.png', format='png')
+    plt.savefig(opts.plots_directory+'/m1m2.png', format='png')
 
     #GW strain figure: 
     #make sure LISA.py and PhenomA.py in /vis directory
@@ -207,7 +212,7 @@ def main():
     #ax.loglog(f_gw,h,color ='black', label='GW150914')
 
     ax.legend()
-    plt.savefig('./gw_strain.png', format='png')
+    plt.savefig(opts.plots_directory+'/gw_strain.png', format='png')
     plt.close()
 
 ######## Execution ########

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -46,6 +46,12 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     mbh_powerlaw_index : float
         Initial mass distribution for stellar bh is assumed to be Pareto
         with high mass cutoff--powerlaw index for Pareto dist
+    min_initial_star_mass : float
+        Initial mass distribution for stars is assumed Salpeter
+    max_initial_star_mass : float
+        Initial mass distribution for stars is assumed Salpeter
+    star_mass_powerlaw_index : float
+        Initial mass distribution for stars is assumed Salpeter, alpha = 2.35
     mu_spin_distribution : float
         Initial spin distribution for stellar bh is assumed to be Gaussian
         --mean of spin dist
@@ -62,6 +68,27 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     max_initial_eccentricity : float
         assuming initially flat eccentricity distribution among single orbiters around SMBH
         out to max_initial_eccentricity. Eventually this will become smarter.
+    mu_star_spin_distribution : float
+        Initial spin distribution for stars is assumed to be Gaussian
+    sigma_star_spin_distribution : float
+        Initial spin distribution for stars is assumed to be Gaussian
+        --standard deviation of spin dist
+    spin_star_torque_condition : float
+        fraction of initial mass required to be accreted before star spin is torqued 
+        fully into alignment with the AGN disk. We don't know for sure but 
+        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
+    frac_star_Eddington_ratio : float
+        assumed accretion rate onto stars from disk gas, in units of Eddington
+        accretion rate
+    max_initial_star_eccentricity : float
+        assuming initially flat eccentricity distribution among single orbiters around SMBH
+        out to max_initial_eccentricity. Eventually this will become smarter.
+    stars_initial_X  : float
+        Stellar initial hydrogen mass fraction
+    stars_initial_Y : float
+        Stellar initial helium mass fraction
+    stars_initial_Z : float
+        Stellar initial metallicity mass fraction
     timestep : float
         How long is your timestep in years?
     number_of_timesteps : int
@@ -131,11 +158,22 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
         'mode_mbh_init' : float,
         'max_initial_bh_mass' : float,
         'mbh_powerlaw_index' : float,
+        'min_initial_star_mass' : float,
+        'max_initial_star_mass' : float,
+        'star_mass_powerlaw_index' : float,
         'mu_spin_distribution' : float,
         'sigma_spin_distribution' : float,
         'spin_torque_condition' : float,
         'frac_Eddington_ratio' : float,
         'max_initial_eccentricity' : float,
+        'mu_star_spin_distribution' : float,
+        'sigma_star_spin_distribution' : float,
+        'spin_star_torque_condition' : float,
+        'frac_star_Eddington_ratio' : float,
+        'max_initial_star_eccentricity' : float,
+        'stars_initial_X' : float,
+        'stars_initial_Y' : float,
+        'stars_initial_Z' : float,
         'timestep' : float,
         'number_of_timesteps' : int,
         'retro' : int,

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -143,7 +143,7 @@ class AGNObject(object):
         for attr in vars(self).keys():
             setattr(self,attr,getattr(self,attr)[idx_change])
 
-    def locate(self,idx=None):
+    def locate(self, idx=None):
         """
         Returns objects at specified indices
         """
@@ -157,16 +157,14 @@ class AGNObject(object):
         idx_full = np.zeros(len(self.mass),dtype=bool)
         idx_full[idx] = True
 
-    def sort(self,sort_attr=None):
+    def sort(self, sort_attr=None):
         #Takes in one attribute array and sorts the whole class by that array
         #Sorted array indices
         sort_idx = np.argsort(sort_attr)
 
         #Now apply these to each of the attributes
         for attr in vars(self).keys():
-            setattr(self,attr,getattr(self,attr)[sort_idx])
-
-
+            setattr(self, attr, getattr(self, attr)[sort_idx])
 
     def return_params(self):
         """

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -1,4 +1,5 @@
 import numpy as np
+from mcfacts.setup import setupdiskstars
 
 def dump_array_to_file(fname=None, samples_out=None):
   # Write output (ascii)
@@ -41,7 +42,7 @@ class AGNObject(object):
                         spin_angle = None, #angle between J and orbit around SMBH for binary
                         orbit_a = None, #location
                         orbit_inclination= None, #of CoM for binary around SMBH
-#                        orb_ang_mom = None,  # redundant, should be computed from keplerian orbit formula for L in terms of mass, a, eccentricity
+                        orb_ang_mom = None,  # redundant, should be computed from keplerian orbit formula for L in terms of mass, a, eccentricity
                         orbit_e = None,
                         nsystems = None):
         
@@ -69,9 +70,9 @@ class AGNObject(object):
         self.spin_angle = spin_angle #should be array
         self.orbit_a = orbit_a #Should be array. Semimajor axis
         self.orbit_inclination = orbit_inclination #Should be array. Allows for misaligned orbits.
-#        self.orb_ang_mom = orb_ang_mom #Should be array
+        self.orb_ang_mom = orb_ang_mom #needs to be added in!
         self.orbit_e = orbit_e #Should be array. Allows for eccentricity.
-        self.generations = np.full(len(self.mass),1)
+        self.generations = np.full(nsystems,1)
     
     def __add_objects__(self, new_mass = None,
                               new_spin = None,
@@ -156,6 +157,17 @@ class AGNObject(object):
         idx_full = np.zeros(len(self.mass),dtype=bool)
         idx_full[idx] = True
 
+    def sort(self,sort_attr=None):
+        #Takes in one attribute array and sorts the whole class by that array
+        #Sorted array indices
+        sort_idx = np.argsort(sort_attr)
+
+        #Now apply these to each of the attributes
+        for attr in vars(self).keys():
+            setattr(self,attr,getattr(self,attr)[sort_idx])
+
+
+
     def return_params(self):
         """
         Gets list of parameters present in object.
@@ -183,6 +195,16 @@ class AGNObject(object):
             dat_out[attr] = getattr(self,attr)
         return(dat_out)
     
+    def to_file(self,fname=None):
+        # Write output (ascii)
+        # Vastly superior data i/o with pandas, but note no # used
+        import pandas
+        samples_out = self.return_record_array()
+        dframe = pandas.DataFrame(samples_out)
+        fname_out_ascii= fname
+        dframe.to_csv(fname_out_ascii,sep=' ',header=[f"#{x}" if x == dframe.columns[0] else x for x in dframe.columns],index=False) # # is not pre-appended...just boolean
+
+    
     def init_from_file(self,fname=None):
         """
         Read in previously saved data file and create AGNObject from it.
@@ -198,23 +220,26 @@ class AGNStar(AGNObject):
     An array of single stars. Should include all objects of this type. No other objects should contain objects of this type.
     Takes in initial helium and metals mass fractions, calculates hydrogen mass fraction from that to ensure it adds up to unity.
     """
-    def __init__(self, star_radius = None, star_Y = None, star_Z = None, nsystems = None, **kwargs):
+    def __init__(self, star_radius = None, star_Y = None, star_Z = None, n_stars = None, **kwargs):
         """
         Array of single star objects.
         star_radius should be a 1d numpy array
         star_Y and star_Z can be floats or 1d numpy arrays, but must sum to 1 or less.
         """
         #Make sure all inputs are included
-        if star_radius is None: raise AttributeError('star_radius is not included in inputs')
+        #if star_radius is None: raise AttributeError('star_radius is not included in inputs')
         if star_Y is None: raise AttributeError('star_Y is not included in inputs')
         if star_Z is None: raise AttributeError('star_Z is not included in inputs')
 
-        if nsystems is None: nsystems = star_radius.size
+        if n_stars is None: n_stars = star_radius.size
 
         #Make sure inputs are numpy arrays
-        assert isinstance(star_radius,np.ndarray),"star_radius is not a numpy array"
+        if star_radius is None:
+            self.star_radius = setupdiskstars.setup_disk_stars_radii(masses=mass)
 
-        self.star_radius = star_radius
+        else:
+            assert isinstance(star_radius,np.ndarray),"star_radius is not a numpy array"
+            self.star_radius = star_radius
 
         if (np.any(star_Y + star_Z > 1.)):
             raise ValueError("star_Y and star_Z must sum to 1 or less.")
@@ -225,9 +250,9 @@ class AGNStar(AGNObject):
             self.star_Z = np.full(len(star_radius),star_Z)
         
         elif ((isinstance(star_Y,np.ndarray) and isinstance(star_Z,np.ndarray))):
-            assert star_radius.shape == (nsystems,),"star_radius != nsystems"
-            assert star_Y.shape == (nsystems,),"star_Y, array: all arrays must be 1d and the same length"
-            assert star_Z.shape == (nsystems,),"star_Z, array: all arrays must be 1d and the same length"
+            assert star_radius.shape == (n_stars,),"star_radius: all arrays must be 1d and the same length"
+            assert star_Y.shape == (n_stars,),"star_Y, array: all arrays must be 1d and the same length"
+            assert star_Z.shape == (n_stars,),"star_Z, array: all arrays must be 1d and the same length"
 
             self.star_X = 1. - star_Y - star_Z
             self.star_Y = star_Y
@@ -237,7 +262,7 @@ class AGNStar(AGNObject):
             raise TypeError("star_Y and star_Z must be either both floats or numpy arrays")
 
 
-        super(AGNStar,self).__init__(nsystems = nsystems, **kwargs) #calls top level functions
+        super(AGNStar,self).__init__(nsystems = n_stars, **kwargs) #calls top level functions
     
     def __repr__(self):
         return('AGNStar(): {} single stars'.format(len(self.mass)))

--- a/src/mcfacts/physics/accretion/eddington/changestarsmass.py
+++ b/src/mcfacts/physics/accretion/eddington/changestarsmass.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+
+def change_mass(prograde_stars_masses, frac_Eddington_ratio, mass_growth_Edd_rate, timestep):
+    """Given initial black hole masses at start of timestep, add mass according to
+        chosen stellar mass accretion prescription
+
+    Parameters
+    ----------
+    prograde_stars_masses : float array
+        initial masses of stars in prograde orbits around SMBH, units of solar masses
+    frac_Eddington_ratio : float
+        user chosen input set by input file; Accretion rate of fully embedded stars
+          in units of Eddington accretion rate. 1.0=embedded star accreting at Eddington.
+        Super-Eddington accretion rates are permitted.
+    mass_growth_Edd_rate : float
+        fractional rate of mass growth AT Eddington accretion rate per year (2.3e-8)
+    timestep : float
+        length of timestep in units of years
+
+    Returns
+    -------
+    bh_new_masses : float array
+        masses of black holes after accreting at prescribed rate for one timestep
+    """
+    # Mass grows exponentially for length of timestep:
+    stars_new_masses = prograde_stars_masses*np.exp(mass_growth_Edd_rate*frac_Eddington_ratio*timestep)
+
+    return stars_new_masses

--- a/src/mcfacts/physics/accretion/torque/changestars.py
+++ b/src/mcfacts/physics/accretion/torque/changestars.py
@@ -1,0 +1,139 @@
+import numpy as np
+
+def change_spin_magnitudes(prograde_bh_spins, frac_Eddington_ratio, spin_torque_condition, timestep, prograde_bh_orb_ecc, e_crit):
+    """Update the spin magnitude of the embedded black holes based on their accreted mass
+        in this timestep.
+
+    Parameters
+    ----------
+    prograde_bh_spins : float array
+        initial spins of black holes in prograde orbits around SMBH
+    frac_Eddington_ratio : float
+        user chosen input set by input file; Accretion rate of fully embedded stellar mass 
+        black hole in units of Eddington accretion rate. 1.0=embedded BH accreting at Eddington.
+        Super-Eddington accretion rates are permitted.
+    spin_torque_condition : float
+        user chosen input set by input file; fraction of initial mass required to be 
+        accreted before BH spin is torqued fully into alignment with the AGN disk. 
+        We don't know for sure but Bogdanovic et al. says between 0.01=1% and 0.1=10% 
+        is what is required
+    timestep : float
+        length of timestep in units of years
+    prograde_bh_orb_ecc : float array
+        orbital eccentricity of BH in prograde orbits around SMBH
+    e_crit : float
+        critical value of orbital eccentricity below which prograde accretion (& migration & binary formation) occurs
+    Returns
+    -------
+    bh_new_spins : float array
+        spin magnitudes of black holes after accreting at prescribed rate for one timestep
+    """
+    #A retrograde BH a=-1 will spin down to a=0 when it accretes a factor sqrt(3/2)=1.22 in mass (Bardeen 1970).
+    # Since M_edd/t = 2.3 e-8 M0/yr or 2.3e-4M0/10kyr then M(t)=M0*exp((M_edd/t)*f_edd*time)
+    # so M(t)~1.2=M0*exp(0.2) so in 10^7yr, spin should go a=-1 to a=0. Or delta a ~ 10^-3 every 10^4yr.
+
+    #def change_spin_magnitudes(bh_spins,prograde_orb_ang_mom_indices,frac_Eddington_ratio,spin_torque_condition,mass_growth_Edd_rate,timestep):
+    #bh_new_spins=bh_spins
+    normalized_Eddington_ratio = frac_Eddington_ratio/1.0
+    normalized_timestep = timestep/1.e4
+    normalized_spin_torque_condition = spin_torque_condition/0.1
+   
+    #I think this should be 1.e-3! See argument above.
+    spin_iteration = (1.e-3*normalized_Eddington_ratio*normalized_spin_torque_condition*normalized_timestep)
+    #print("Spin Iteration", spin_iteration)
+    #spin_iteration = (4.4e-3*normalized_Eddington_ratio*normalized_spin_torque_condition*normalized_timestep)
+
+    bh_new_spins = prograde_bh_spins
+    #Singleton BH with orb ecc > e_crit will spin down b/c accrete retrograde
+    prograde_bh_spin_down = np.ma.masked_where(prograde_bh_orb_ecc <= e_crit, prograde_bh_orb_ecc)
+    #Singleton BH with orb ecc < e_crit will spin up b/c accrete prograde
+    prograde_bh_spin_up = np.ma.masked_where(prograde_bh_orb_ecc >e_crit, prograde_bh_orb_ecc)
+    #Indices of singleton BH with orb ecc > e_crit
+    indices_bh_spin_down = np.ma.nonzero(prograde_bh_spin_down) 
+    #print(indices_bh_spin_down)
+    #Indices of singleton BH with orb ecc < e_crit
+    indices_bh_spin_up = np.ma.nonzero(prograde_bh_spin_up)
+    #bh_new_spins[prograde_orb_ang_mom_indices]=bh_new_spins[prograde_orb_ang_mom_indices]+(4.4e-3*normalized_Eddington_ratio*normalized_spin_torque_condition*normalized_timestep)
+    bh_new_spins[indices_bh_spin_up] = prograde_bh_spins[indices_bh_spin_up] + spin_iteration
+    #print('BH spin up', bh_new_spins[indices_bh_spin_up])
+    #Spin down BH with orb ecc > e_crit
+    bh_new_spins[indices_bh_spin_down] = prograde_bh_spins[indices_bh_spin_down] - spin_iteration
+    #print('BH spin down', bh_new_spins[indices_bh_spin_down])
+    # TO DO: Include a condition to keep a maximal (a=+0.98) spin BH at that value once it reaches it
+    #Housekeeping:
+    bh_max_spin = 0.98
+    bh_min_spin = -0.98
+    #print("OLD/NEW SPINs",prograde_bh_spins,bh_new_spins)
+    #for i in range(len(prograde_bh_spins)):
+    #    if bh_new_spins[i] < bh_min_spin:
+    #        bh_new_spins[i] = bh_min_spin
+
+    #    if bh_new_spins[i] > bh_max_spin:
+    #        bh_new_spins[i] = bh_max_spin      
+    #bh_new_spins = np.where(bh_new_spins < bh_min_spin, bh_new_spins, bh_min_spin)
+    #bh_new_spins = np.where(bh_new_spins > bh_max_spin, bh_new_spins, bh_max_spin)
+    #Return updated new spins    
+    return bh_new_spins
+
+
+def change_spin_angles(prograde_bh_spin_angles, frac_Eddington_ratio, spin_torque_condition, spin_minimum_resolution, timestep, prograde_bh_orb_ecc, e_crit):
+    """_summary_
+
+    Parameters
+    ----------
+    prograde_bh_spin_angles : float array
+        _description_
+    frac_Eddington_ratio : float
+        _description_
+    spin_torque_condition : _type_
+        _description_
+    spin_minimum_resolution : _type_
+        _description_
+    timestep : float
+        _description_
+    prograde_bh_orb ecc : float array
+        orbital eccentricity of BH around SMBH
+    e_crit : float
+        critical eccentricity of BH below which prograde accretion & spin torque into disk alignment else retrograde accretion
+    Returns
+    -------
+    bh_new_spin_angles : float array
+        Iterated BH spin angles w.r.t disk orbital angular momentum. 0= complete alignment.
+    """
+    #Calculate change in spin angle due to accretion during timestep
+    normalized_Eddington_ratio = frac_Eddington_ratio/1.0
+    normalized_timestep = timestep/1.e4
+    normalized_spin_torque_condition = spin_torque_condition/0.1
+
+    spin_torque_iteration = (6.98e-3*normalized_Eddington_ratio*normalized_spin_torque_condition*normalized_timestep)
+    
+    #print("Initital spin angles",prograde_bh_spin_angles)
+    #Assume same angles as before to start
+    bh_new_spin_angles = prograde_bh_spin_angles
+    #Singleton BH with orb ecc > e_crit will spin down b/c accrete retrograde
+    prograde_bh_spin_down = np.ma.masked_where(prograde_bh_orb_ecc <= e_crit, prograde_bh_orb_ecc)
+    #Singleton BH with orb ecc < e_crit will spin up b/c accrete prograde
+    prograde_bh_spin_up = np.ma.masked_where(prograde_bh_orb_ecc >e_crit, prograde_bh_orb_ecc)
+    #Indices of singleton BH with orb ecc > e_crit
+    indices_bh_spin_down = np.ma.nonzero(prograde_bh_spin_down) 
+    #print(indices_bh_spin_down)
+    #Indices of singleton BH with orb ecc < e_crit
+    indices_bh_spin_up = np.ma.nonzero(prograde_bh_spin_up)
+
+    # Spin up BH are torqued towards zero (ie alignment with disk, so decrease mag of spin angle)
+    bh_new_spin_angles[indices_bh_spin_up] = prograde_bh_spin_angles[indices_bh_spin_up] - spin_torque_iteration
+    #Spin down BH with orb ecc > e_crit are torqued toward anti-alignment with disk, incr mag of spin angle.
+    bh_new_spin_angles[indices_bh_spin_down] = prograde_bh_spin_angles[indices_bh_spin_down] + spin_torque_iteration
+    #print(bh_new_spin_angles[indices_bh_spin_down])
+    
+    #TO DO: Include a condition to keep spin angle at or close to zero once it gets there
+    #Return new spin angles
+    #Housekeeping
+    # Max bh spin angle in rads (pi rads = anti-alignment)
+    bh_max_spin_angle = 3.10
+    bh_new_spin_angles[bh_new_spin_angles<spin_minimum_resolution] = 0.0
+    bh_new_spin_angles[bh_new_spin_angles > bh_max_spin_angle] = bh_max_spin_angle
+    #print("Final spin angles",bh_new_spin_angles)
+    return bh_new_spin_angles
+
+

--- a/src/mcfacts/setup/setupdiskstars.py
+++ b/src/mcfacts/setup/setupdiskstars.py
@@ -126,19 +126,19 @@ def setup_disk_stars_circularized(rng, n_stars,crit_ecc):
     stars_initial_orb_ecc = crit_ecc*np.zeros((integer_nstars,),dtype = float)
     return stars_initial_orb_ecc
 
-def setup_disk_nbh(M_nsc,nbh_nstar_ratio,mbh_mstar_ratio,r_nsc_out,nsc_index_outer,mass_smbh,disk_outer_radius,h_disk_average,r_nsc_crit,nsc_index_inner):
-    # Return the integer number of BH in the AGN disk as calculated from NSC inputs assuming isotropic distribution of NSC orbits
+def setup_disk_nstars(M_nsc,nbh_nstar_ratio,mbh_mstar_ratio,r_nsc_out,nsc_index_outer,mass_smbh,disk_outer_radius,h_disk_average,r_nsc_crit,nsc_index_inner):
+    # Return the integer number of stars in the AGN disk as calculated from NSC inputs assuming isotropic distribution of NSC orbits
     # To do: Calculate when R_disk_outer is not equal to the r_nsc_crit
     # To do: Calculate when disky NSC population of BH in plane/out of plane.
     # Housekeeping:
     # Convert outer disk radius in r_g to units of pc. 1r_g =1AU (M_smbh/10^8Msun) and 1pc =2e5AU =2e5 r_g(M/10^8Msun)^-1
     pc_dist = 2.e5*((mass_smbh/1.e8)**(-1.0))
     critical_disk_radius_pc = disk_outer_radius/pc_dist
-    #Total average mass of BH in NSC
-    M_bh_nsc = M_nsc * nbh_nstar_ratio * mbh_mstar_ratio
+    #Total average mass of stars in NSC
+    M_stars_nsc = M_nsc * (1./nbh_nstar_ratio) * (1./mbh_mstar_ratio)
     #print("M_bh_nsc",M_bh_nsc)
-    #Total number of BH in NSC
-    N_bh_nsc = M_bh_nsc / mbh_mstar_ratio
+    #Total number of stars in NSC
+    N_stars_nsc = M_stars_nsc * mbh_mstar_ratio
     #print("N_bh_nsc",N_bh_nsc)
     #Relative volumes:
     #   of central 1 pc^3 to size of NSC
@@ -146,24 +146,24 @@ def setup_disk_nbh(M_nsc,nbh_nstar_ratio,mbh_mstar_ratio,r_nsc_out,nsc_index_out
     #   of r_nsc_crit^3 to size of NSC
     relative_volumes_at_r_nsc_crit = (r_nsc_crit/r_nsc_out)**(3.0)
     #print(relative_volumes_at1pc)
-    #Total number of BH 
+    #Total number of stars 
     #   at R<1pc (should be about 10^4 for Milky Way parameters; 3x10^7Msun, 5pc, r^-5/2 in outskirts)
-    N_bh_nsc_pc = N_bh_nsc * relative_volumes_at1pc * (1.0/r_nsc_out)**(-nsc_index_outer)
+    N_stars_nsc_pc = N_stars_nsc * relative_volumes_at1pc * (1.0/r_nsc_out)**(-nsc_index_outer)
     #   at r_nsc_crit
-    N_bh_nsc_crit = N_bh_nsc * relative_volumes_at_r_nsc_crit * (r_nsc_crit/r_nsc_out)**(-nsc_index_outer)
+    N_stars_nsc_crit = N_stars_nsc * relative_volumes_at_r_nsc_crit * (r_nsc_crit/r_nsc_out)**(-nsc_index_outer)
     #print("Normalized N_bh at 1pc",N_bh_nsc_pc)
     
-    #Calculate Total number of BH in volume R < disk_outer_radius, assuming disk_outer_radius<=1pc.
+    #Calculate Total number of stars in volume R < disk_outer_radius, assuming disk_outer_radius<=1pc.
     
     if critical_disk_radius_pc >= r_nsc_crit:
         relative_volumes_at_disk_outer_radius = (critical_disk_radius_pc/1.0)**(3.0)
-        Nbh_disk_volume = N_bh_nsc_pc * relative_volumes_at_disk_outer_radius * ((critical_disk_radius_pc/1.0)**(-nsc_index_outer))          
+        Nstars_disk_volume = N_stars_nsc_pc * relative_volumes_at_disk_outer_radius * ((critical_disk_radius_pc/1.0)**(-nsc_index_outer))          
     else:
         relative_volumes_at_disk_outer_radius = (critical_disk_radius_pc/r_nsc_crit)**(3.0)
-        Nbh_disk_volume = N_bh_nsc_crit * relative_volumes_at_disk_outer_radius * ((critical_disk_radius_pc/r_nsc_crit)**(-nsc_index_inner))
+        Nstars_disk_volume = N_stars_nsc_crit * relative_volumes_at_disk_outer_radius * ((critical_disk_radius_pc/r_nsc_crit)**(-nsc_index_inner))
      
     # Total number of BH in disk
-    Nbh_disk_total = np.rint(Nbh_disk_volume * h_disk_average)
+    Nstars_disk_total = np.rint(Nstars_disk_volume * h_disk_average)
     #print("Nbh_disk_total",Nbh_disk_total)  
-    return np.int64(Nbh_disk_total)
+    return np.int64(Nstars_disk_total)
 

--- a/src/mcfacts/setup/setupdiskstars.py
+++ b/src/mcfacts/setup/setupdiskstars.py
@@ -13,8 +13,8 @@ def setup_disk_stars_masses(rng,n_star,min_initial_star_mass,max_initial_star_ma
     #Taken from here: https://python4mpia.github.io/fitting_data/MC-sampling-from-Salpeter.html
 
     #Convert limits from M to logM
-    log_M_min = np.log10(min_initial_star_mass)
-    log_M_max = np.log10(max_initial_star_mass)
+    log_M_min = np.log(min_initial_star_mass)
+    log_M_max = np.log(max_initial_star_mass)
 
     #Max likelihood is at M_min
     maxlik = np.power(min_initial_star_mass, 1.0 - mstar_powerlaw_index)

--- a/src/mcfacts/setup/setupdiskstars.py
+++ b/src/mcfacts/setup/setupdiskstars.py
@@ -1,0 +1,169 @@
+import numpy as np
+
+
+def setup_disk_stars_location(rng, n_stars, disk_outer_radius):
+    #Return an array of BH locations distributed randomly uniformly in disk
+    integer_nstars = int(n_stars)
+    stars_initial_locations = disk_outer_radius*rng.random(integer_nstars)
+    return stars_initial_locations
+
+
+def setup_disk_stars_masses(rng,n_star,min_initial_star_mass,max_initial_star_mass,mstar_powerlaw_index):
+    #Return an array of star initial masses for a given alpha and min/max mass with the Salpeter IMF.
+    #Taken from here: https://python4mpia.github.io/fitting_data/MC-sampling-from-Salpeter.html
+
+    #Convert limits from M to logM
+    log_M_min = np.log10(min_initial_star_mass)
+    log_M_max = np.log10(max_initial_star_mass)
+
+    #Max likelihood is at M_min
+    maxlik = np.power(min_initial_star_mass, 1.0 - mstar_powerlaw_index)
+
+    #Make array for output
+    masses = []
+    while(len(masses) < n_star):
+        #draw candidate from logM interval
+        logM = rng.uniform(low=log_M_min, high=log_M_max)
+        M = np.exp(logM)
+        #Compute likelihood of candidate from Salpeter SMF
+        likelihood = np.power(M,1.0-mstar_powerlaw_index)
+        #Accept randomly
+        u = rng.uniform(low=0.0, high=maxlik)
+        if(u < likelihood):
+            masses.append(M)
+    masses = np.array(masses)
+    return(masses)
+
+def setup_disk_stars_radii(masses):
+    #For now the radius is just set to the ZAMS radius via the mass-radius relation and does not change
+    radii = np.power(masses,0.8)
+    return(radii)
+
+def setup_disk_stars_comp(n_star,star_ZAMS_metallicity, star_ZAMS_hydrogen, star_ZAMS_helium):
+    #For now the numbers are set in the input file. Maybe we want to just set 2 of them (X and Y?) and calculate the final so it adds to 1?
+    star_Z = np.full(n_star,star_ZAMS_metallicity)
+    star_X = np.full(n_star,star_ZAMS_hydrogen)
+    star_Y = np.full(n_star,star_ZAMS_helium)
+    return(star_X, star_Y, star_Z)
+
+
+def setup_disk_stars_spins(rng, n_stars, mu_star_spin_distribution, sigma_star_spin_distribution):
+    #Return an array of BH initial spin magnitudes for a given mode and sigma of a distribution
+    integer_nstars = int(n_stars)
+    stars_initial_spins = rng.normal(mu_star_spin_distribution, sigma_star_spin_distribution, integer_nstars)
+    return stars_initial_spins
+
+
+def setup_disk_stars_spin_angles(rng, n_stars, stars_initial_spins):
+    #Return an array of BH initial spin angles (in radians).
+    #Positive (negative) spin magnitudes have spin angles [0,1.57]([1.5701,3.14])rads
+    #All BH spin angles drawn from [0,1.57]rads and +1.57rads to negative spin indices
+    integer_nstars = int(n_stars)
+    stars_initial_spin_indices = np.array(stars_initial_spins)
+    negative_spin_indices = np.where(stars_initial_spin_indices < 0.)
+    stars_initial_spin_angles = rng.uniform(0.,1.57,integer_nstars)
+    stars_initial_spin_angles[negative_spin_indices] = stars_initial_spin_angles[negative_spin_indices] + 1.57
+    return stars_initial_spin_angles
+
+
+def setup_disk_stars_orb_ang_mom(rng, n_stars):
+    #Return an array of BH initial orbital angular momentum.
+    #Assume either fully prograde (+1) or retrograde (-1)
+    integer_nstars = int(n_stars)
+    random_uniform_number = rng.random((integer_nstars,))
+    stars_initial_orb_ang_mom = (2.0*np.around(random_uniform_number)) - 1.0
+    return stars_initial_orb_ang_mom
+
+def setup_disk_stars_eccentricity_thermal(rng, n_stars):
+    # Return an array of BH orbital eccentricities
+    # For a thermal initial distribution of eccentricities, select from a uniform distribution in e^2.
+    # Thus (e=0.7)^2 is 0.49 (half the eccentricities are <0.7). 
+    # And (e=0.9)^2=0.81 (about 1/5th eccentricities are >0.9)
+    # So rnd= draw from a uniform [0,1] distribution, allows ecc=sqrt(rnd) for thermal distribution.
+    # Thermal distribution in limit of equipartition of energy after multiple dynamical encounters
+    integer_nstars = int(n_stars)
+    random_uniform_number = rng.random((integer_nstars,))
+    stars_initial_orb_ecc = np.sqrt(random_uniform_number)
+    return stars_initial_orb_ecc
+
+def setup_disk_stars_eccentricity_uniform(rng, n_stars):
+    # Return an array of BH orbital eccentricities
+    # For a uniform initial distribution of eccentricities, select from a uniform distribution in e.
+    # Thus half the eccentricities are <0.5
+    # And about 1/10th eccentricities are >0.9
+    # So rnd = draw from a uniform [0,1] distribution, allows ecc = rnd for uniform distribution
+    # Most real clusters/binaries lie between thermal & uniform (e.g. Geller et al. 2019, ApJ, 872, 165)
+    integer_nstars = int(n_stars)
+    random_uniform_number = rng.random((integer_nstars,))
+    stars_initial_orb_ecc = random_uniform_number
+    return stars_initial_orb_ecc
+
+def setup_disk_stars_inclination(rng, n_stars):
+    # Return an array of BH orbital inclinations
+    # Return an initial distribution of inclination angles that are 0.0
+    #
+    # To do: initialize inclinations so random draw with i <h (so will need to input bh_locations and disk_aspect_ratio)
+    # and then damp inclination.
+    # To do: calculate v_kick for each merger and then the (i,e) orbital elements for the newly merged BH. 
+    # Then damp (i,e) as appropriate
+    integer_nstars = int(n_stars)
+    # For now, inclinations are zeros
+    stars_initial_orb_incl = np.zeros((integer_nstars,),dtype = float)
+    return stars_initial_orb_incl
+
+def setup_disk_stars_circularized(rng, n_stars,crit_ecc):
+    # Return an array of BH orbital inclinations
+    # Return an initial distribution of inclination angles that are 0.0
+    #
+    # To do: initialize inclinations so random draw with i <h (so will need to input bh_locations and disk_aspect_ratio)
+    # and then damp inclination.
+    # To do: calculate v_kick for each merger and then the (i,e) orbital elements for the newly merged BH. 
+    # Then damp (i,e) as appropriate
+    integer_nstars = int(n_stars)
+    # For now, inclinations are zeros
+    #bh_initial_orb_ecc = crit_ecc*np.ones((integer_nbh,),dtype = float)
+    #Try zero eccentricities
+    stars_initial_orb_ecc = crit_ecc*np.zeros((integer_nstars,),dtype = float)
+    return stars_initial_orb_ecc
+
+def setup_disk_nbh(M_nsc,nbh_nstar_ratio,mbh_mstar_ratio,r_nsc_out,nsc_index_outer,mass_smbh,disk_outer_radius,h_disk_average,r_nsc_crit,nsc_index_inner):
+    # Return the integer number of BH in the AGN disk as calculated from NSC inputs assuming isotropic distribution of NSC orbits
+    # To do: Calculate when R_disk_outer is not equal to the r_nsc_crit
+    # To do: Calculate when disky NSC population of BH in plane/out of plane.
+    # Housekeeping:
+    # Convert outer disk radius in r_g to units of pc. 1r_g =1AU (M_smbh/10^8Msun) and 1pc =2e5AU =2e5 r_g(M/10^8Msun)^-1
+    pc_dist = 2.e5*((mass_smbh/1.e8)**(-1.0))
+    critical_disk_radius_pc = disk_outer_radius/pc_dist
+    #Total average mass of BH in NSC
+    M_bh_nsc = M_nsc * nbh_nstar_ratio * mbh_mstar_ratio
+    #print("M_bh_nsc",M_bh_nsc)
+    #Total number of BH in NSC
+    N_bh_nsc = M_bh_nsc / mbh_mstar_ratio
+    #print("N_bh_nsc",N_bh_nsc)
+    #Relative volumes:
+    #   of central 1 pc^3 to size of NSC
+    relative_volumes_at1pc = (1.0/r_nsc_out)**(3.0)
+    #   of r_nsc_crit^3 to size of NSC
+    relative_volumes_at_r_nsc_crit = (r_nsc_crit/r_nsc_out)**(3.0)
+    #print(relative_volumes_at1pc)
+    #Total number of BH 
+    #   at R<1pc (should be about 10^4 for Milky Way parameters; 3x10^7Msun, 5pc, r^-5/2 in outskirts)
+    N_bh_nsc_pc = N_bh_nsc * relative_volumes_at1pc * (1.0/r_nsc_out)**(-nsc_index_outer)
+    #   at r_nsc_crit
+    N_bh_nsc_crit = N_bh_nsc * relative_volumes_at_r_nsc_crit * (r_nsc_crit/r_nsc_out)**(-nsc_index_outer)
+    #print("Normalized N_bh at 1pc",N_bh_nsc_pc)
+    
+    #Calculate Total number of BH in volume R < disk_outer_radius, assuming disk_outer_radius<=1pc.
+    
+    if critical_disk_radius_pc >= r_nsc_crit:
+        relative_volumes_at_disk_outer_radius = (critical_disk_radius_pc/1.0)**(3.0)
+        Nbh_disk_volume = N_bh_nsc_pc * relative_volumes_at_disk_outer_radius * ((critical_disk_radius_pc/1.0)**(-nsc_index_outer))          
+    else:
+        relative_volumes_at_disk_outer_radius = (critical_disk_radius_pc/r_nsc_crit)**(3.0)
+        Nbh_disk_volume = N_bh_nsc_crit * relative_volumes_at_disk_outer_radius * ((critical_disk_radius_pc/r_nsc_crit)**(-nsc_index_inner))
+     
+    # Total number of BH in disk
+    Nbh_disk_total = np.rint(Nbh_disk_volume * h_disk_average)
+    #print("Nbh_disk_total",Nbh_disk_total)  
+    return np.int64(Nbh_disk_total)
+

--- a/src/mcfacts/setup/setupdiskstars.py
+++ b/src/mcfacts/setup/setupdiskstars.py
@@ -1,0 +1,169 @@
+import numpy as np
+
+
+def setup_disk_stars_location(rng, n_stars, disk_outer_radius):
+    #Return an array of BH locations distributed randomly uniformly in disk
+    integer_nstars = int(n_stars)
+    stars_initial_locations = disk_outer_radius*rng.random(integer_nstars)
+    return stars_initial_locations
+
+
+def setup_disk_stars_masses(rng,n_star,min_initial_star_mass,max_initial_star_mass,mstar_powerlaw_index):
+    #Return an array of star initial masses for a given alpha and min/max mass with the Salpeter IMF.
+    #Taken from here: https://python4mpia.github.io/fitting_data/MC-sampling-from-Salpeter.html
+
+    #Convert limits from M to logM
+    log_M_min = np.log10(min_initial_star_mass)
+    log_M_max = np.log10(max_initial_star_mass)
+
+    #Max likelihood is at M_min
+    maxlik = np.power(min_initial_star_mass, 1.0 - mstar_powerlaw_index)
+
+    #Make array for output
+    masses = []
+    while(len(masses) < n_star):
+        #draw candidate from logM interval
+        logM = rng.uniform(low=log_M_min, high=log_M_max)
+        M = np.exp(logM)
+        #Compute likelihood of candidate from Salpeter SMF
+        likelihood = np.power(M,1.0-mstar_powerlaw_index)
+        #Accept randomly
+        u = rng.uniform(low=0.0, high=maxlik)
+        if(u < likelihood):
+            masses.append(M)
+    masses = np.array(masses)
+    return(masses)
+
+def setup_disk_stars_radii(masses):
+    #For now the radius is just set to the ZAMS radius via the mass-radius relation and does not change
+    radii = np.power(masses,0.8)
+    return(radii)
+
+def setup_disk_stars_comp(n_star,star_ZAMS_metallicity, star_ZAMS_hydrogen, star_ZAMS_helium):
+    #For now the numbers are set in the input file. Maybe we want to just set 2 of them (X and Y?) and calculate the final so it adds to 1?
+    star_Z = np.full(n_star,star_ZAMS_metallicity)
+    star_X = np.full(n_star,star_ZAMS_hydrogen)
+    star_Y = np.full(n_star,star_ZAMS_helium)
+    return(star_X, star_Y, star_Z)
+
+
+def setup_disk_stars_spins(rng, n_stars, mu_star_spin_distribution, sigma_star_spin_distribution):
+    #Return an array of BH initial spin magnitudes for a given mode and sigma of a distribution
+    integer_nstars = int(n_stars)
+    stars_initial_spins = rng.normal(mu_star_spin_distribution, sigma_star_spin_distribution, integer_nstars)
+    return stars_initial_spins
+
+
+def setup_disk_stars_spin_angles(rng, n_stars, stars_initial_spins):
+    #Return an array of BH initial spin angles (in radians).
+    #Positive (negative) spin magnitudes have spin angles [0,1.57]([1.5701,3.14])rads
+    #All BH spin angles drawn from [0,1.57]rads and +1.57rads to negative spin indices
+    integer_nstars = int(n_stars)
+    stars_initial_spin_indices = np.array(stars_initial_spins)
+    negative_spin_indices = np.where(stars_initial_spin_indices < 0.)
+    stars_initial_spin_angles = rng.uniform(0.,1.57,integer_nstars)
+    stars_initial_spin_angles[negative_spin_indices] = stars_initial_spin_angles[negative_spin_indices] + 1.57
+    return stars_initial_spin_angles
+
+
+def setup_disk_stars_orb_ang_mom(rng, n_stars):
+    #Return an array of BH initial orbital angular momentum.
+    #Assume either fully prograde (+1) or retrograde (-1)
+    integer_nstars = int(n_stars)
+    random_uniform_number = rng.random((integer_nstars,))
+    stars_initial_orb_ang_mom = (2.0*np.around(random_uniform_number)) - 1.0
+    return stars_initial_orb_ang_mom
+
+def setup_disk_stars_eccentricity_thermal(rng, n_stars):
+    # Return an array of BH orbital eccentricities
+    # For a thermal initial distribution of eccentricities, select from a uniform distribution in e^2.
+    # Thus (e=0.7)^2 is 0.49 (half the eccentricities are <0.7). 
+    # And (e=0.9)^2=0.81 (about 1/5th eccentricities are >0.9)
+    # So rnd= draw from a uniform [0,1] distribution, allows ecc=sqrt(rnd) for thermal distribution.
+    # Thermal distribution in limit of equipartition of energy after multiple dynamical encounters
+    integer_nstars = int(n_stars)
+    random_uniform_number = rng.random((integer_nstars,))
+    stars_initial_orb_ecc = np.sqrt(random_uniform_number)
+    return stars_initial_orb_ecc
+
+def setup_disk_stars_eccentricity_uniform(rng, n_stars):
+    # Return an array of BH orbital eccentricities
+    # For a uniform initial distribution of eccentricities, select from a uniform distribution in e.
+    # Thus half the eccentricities are <0.5
+    # And about 1/10th eccentricities are >0.9
+    # So rnd = draw from a uniform [0,1] distribution, allows ecc = rnd for uniform distribution
+    # Most real clusters/binaries lie between thermal & uniform (e.g. Geller et al. 2019, ApJ, 872, 165)
+    integer_nstars = int(n_stars)
+    random_uniform_number = rng.random((integer_nstars,))
+    stars_initial_orb_ecc = random_uniform_number
+    return stars_initial_orb_ecc
+
+def setup_disk_stars_inclination(rng, n_stars):
+    # Return an array of BH orbital inclinations
+    # Return an initial distribution of inclination angles that are 0.0
+    #
+    # To do: initialize inclinations so random draw with i <h (so will need to input bh_locations and disk_aspect_ratio)
+    # and then damp inclination.
+    # To do: calculate v_kick for each merger and then the (i,e) orbital elements for the newly merged BH. 
+    # Then damp (i,e) as appropriate
+    integer_nstars = int(n_stars)
+    # For now, inclinations are zeros
+    stars_initial_orb_incl = np.zeros((integer_nstars,),dtype = float)
+    return stars_initial_orb_incl
+
+def setup_disk_stars_circularized(rng, n_stars,crit_ecc):
+    # Return an array of BH orbital inclinations
+    # Return an initial distribution of inclination angles that are 0.0
+    #
+    # To do: initialize inclinations so random draw with i <h (so will need to input bh_locations and disk_aspect_ratio)
+    # and then damp inclination.
+    # To do: calculate v_kick for each merger and then the (i,e) orbital elements for the newly merged BH. 
+    # Then damp (i,e) as appropriate
+    integer_nstars = int(n_stars)
+    # For now, inclinations are zeros
+    #bh_initial_orb_ecc = crit_ecc*np.ones((integer_nbh,),dtype = float)
+    #Try zero eccentricities
+    stars_initial_orb_ecc = crit_ecc*np.zeros((integer_nstars,),dtype = float)
+    return stars_initial_orb_ecc
+
+def setup_disk_nstars(M_nsc,nbh_nstar_ratio,mbh_mstar_ratio,r_nsc_out,nsc_index_outer,mass_smbh,disk_outer_radius,h_disk_average,r_nsc_crit,nsc_index_inner):
+    # Return the integer number of stars in the AGN disk as calculated from NSC inputs assuming isotropic distribution of NSC orbits
+    # To do: Calculate when R_disk_outer is not equal to the r_nsc_crit
+    # To do: Calculate when disky NSC population of BH in plane/out of plane.
+    # Housekeeping:
+    # Convert outer disk radius in r_g to units of pc. 1r_g =1AU (M_smbh/10^8Msun) and 1pc =2e5AU =2e5 r_g(M/10^8Msun)^-1
+    pc_dist = 2.e5*((mass_smbh/1.e8)**(-1.0))
+    critical_disk_radius_pc = disk_outer_radius/pc_dist
+    #Total average mass of stars in NSC
+    M_stars_nsc = M_nsc * (1./nbh_nstar_ratio) * (1./mbh_mstar_ratio)
+    #print("M_bh_nsc",M_bh_nsc)
+    #Total number of stars in NSC
+    N_stars_nsc = M_stars_nsc * mbh_mstar_ratio
+    #print("N_bh_nsc",N_bh_nsc)
+    #Relative volumes:
+    #   of central 1 pc^3 to size of NSC
+    relative_volumes_at1pc = (1.0/r_nsc_out)**(3.0)
+    #   of r_nsc_crit^3 to size of NSC
+    relative_volumes_at_r_nsc_crit = (r_nsc_crit/r_nsc_out)**(3.0)
+    #print(relative_volumes_at1pc)
+    #Total number of stars 
+    #   at R<1pc (should be about 10^4 for Milky Way parameters; 3x10^7Msun, 5pc, r^-5/2 in outskirts)
+    N_stars_nsc_pc = N_stars_nsc * relative_volumes_at1pc * (1.0/r_nsc_out)**(-nsc_index_outer)
+    #   at r_nsc_crit
+    N_stars_nsc_crit = N_stars_nsc * relative_volumes_at_r_nsc_crit * (r_nsc_crit/r_nsc_out)**(-nsc_index_outer)
+    #print("Normalized N_bh at 1pc",N_bh_nsc_pc)
+    
+    #Calculate Total number of stars in volume R < disk_outer_radius, assuming disk_outer_radius<=1pc.
+    
+    if critical_disk_radius_pc >= r_nsc_crit:
+        relative_volumes_at_disk_outer_radius = (critical_disk_radius_pc/1.0)**(3.0)
+        Nstars_disk_volume = N_stars_nsc_pc * relative_volumes_at_disk_outer_radius * ((critical_disk_radius_pc/1.0)**(-nsc_index_outer))          
+    else:
+        relative_volumes_at_disk_outer_radius = (critical_disk_radius_pc/r_nsc_crit)**(3.0)
+        Nstars_disk_volume = N_stars_nsc_crit * relative_volumes_at_disk_outer_radius * ((critical_disk_radius_pc/r_nsc_crit)**(-nsc_index_inner))
+     
+    # Total number of BH in disk
+    Nstars_disk_total = np.rint(Nstars_disk_volume * h_disk_average)
+    #print("Nbh_disk_total",Nbh_disk_total)  
+    return np.int64(Nstars_disk_total)
+


### PR DESCRIPTION
The beginnings of stars in McFacts!

**File changes**
- new folder at src/mcfacts/objects
    - contains` __init__.py` for python reasons
    - agnobject.py with the classes for stars, BH, binary stars, and binary BHs (very preliminary for all)
    - src/mcfacts/physics/accretion/eddington/changestarsmass.py is a copy of the changebhmass.py for now
    - src/mcfacts/physics/accretion/torque/changestars.py is a copy of the changebh.py for now
    - src/mcfacts/setup/setupdiskstars.py has setup functions for stars

The only (semi) functional class right now is AGNStar, which is single stars. It functions as a container of arrays with attributes
- mass
- spin
- spin_angle
- orbit_a
- orbit_inclination
- orb_ang_mom
- orbit_e
- star_radius
- star_Y
- star_Z

**Makefile changes**
I added lines in the makefile so that all the McFacts outputs can be in an output folder of your choosing (default is test_outputs). It just makes it easier to keep things clean.