### PR TITLE
Changing variable names and cleaning up mcfacts_sim, initializediskstars, agnobject, and setupdiskstars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ install: $(CLEAN_CMD) version
 # do not put linebreaks between any of these lines. Your run will call a different .ini file
 mcfacts_sim: $(CLEAN_CMD)
 	python ${MCFACTS_SIM_EXE} \
-		--n_iterations 100 \
+		--n_iterations 3 \
 		--fname-ini ${FNAME_INI} \
 		--fname-log out.log \
 		--seed ${SEED}
@@ -87,7 +87,7 @@ mstar_runs:
 		--fname-ini ${FNAME_INI} \
 		--number_of_timesteps 1000 \
         --n_bins_max 10000 \
-		--n_iterations 100 \
+		--n_iterations 3 \
 		--dynamics \
 		--feedback \
 		--mstar-min 1e9 \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ install: $(CLEAN_CMD) version
 # do not put linebreaks between any of these lines. Your run will call a different .ini file
 mcfacts_sim: $(CLEAN_CMD)
 	python ${MCFACTS_SIM_EXE} \
-		--n_iterations 3 \
+		--iteration_num 3 \
 		--fname-ini ${FNAME_INI} \
 		--fname-log out.log \
 		--seed ${SEED}
@@ -87,7 +87,7 @@ mstar_runs:
 		--fname-ini ${FNAME_INI} \
 		--number_of_timesteps 1000 \
         --n_bins_max 10000 \
-		--n_iterations 3 \
+		--iteration_num 3 \
 		--dynamics \
 		--feedback \
 		--mstar-min 1e9 \

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ MSTAR_PLOT_EXE = ${HERE}/src/mcfacts/outputs/plot_mcfacts_handler_quantities.py
 
 #### Setup ####
 SEED=3456789012
-FNAME_INI= ${HERE}/recipes/p1_thompson.ini
-#FNAME_INI= ${HERE}/recipes/model_choice_old.ini
+#FNAME_INI= ${HERE}/recipes/p1_thompson.ini
+FNAME_INI= ${HERE}/recipes/model_choice_old.ini
 MSTAR_RUNS_WKDIR = ${HERE}/runs_mstar_bins
 # NAL files might not exist unless you download them from
 # https://gitlab.com/xevra/nal-data

--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -5,85 +5,109 @@
 # See IOdocumentation.txt for details.
 #
 # SMBH mass in units of M_sun:
-mass_smbh = 1.e8
+smbh_mass = 1.e8
 #
 # SMBH accretion disk:
 #
 # Specify prefix to filenames for input disk model
 disk_model_name = 'sirko_goodman'
+# pAGN flag (0/1) boolean
+flag_use_pagn = 0
 # trap radius in r_g
-trap_radius = 700.
+disk_radius_trap = 700.
 # disk outer radius in r_g
-disk_outer_radius = 50000.
+disk_radius_outer = 50000.
+# Maximum disk outer radius (pc) (0. turns this off)
+disk_radius_max_pc = 0.
 # disk alpha parameter (viscosity parameter, alpha=0.01 in sirko_goodman)
-alpha = 0.01
+disk_alpha_viscosity = 0.01
 #
 # Nuclear Star Cluster Population:
 #
 #Outer radius of NSC (1-10pc) in units of pc
-r_nsc_out = 5.0
-#Mass of NSC in M_sun. Milky Way NSC is 3x10^7Msun. Typically 10^6-8Msun from obs.
-M_nsc = 3.e7
+nsc_radius_outer = 5.0
+#Mass of NSC in M_sun. Milky Way NSC is 3x10^7Msun. Typically 10^6-8Msun from obs
+nsc_mass = 3.e7
 #Inner critial NSC radius (where radial number density changes) in units of pc. 0.25pc for SgrA* (Generozov+18).
-r_nsc_crit = 0.25
+nsc_radius_crit = 0.25
 #Ratio of number of BH to number of Stars (spans 3x10^-4 to 10^-2 in Generozov+18)
-nbh_nstar_ratio = 1.e-3
+nsc_ratio_bh_num_star_num = 1.e-3
 #Typical ratio of mass of BH to mass of star (10Msun:1Msun in Generozov+18)
-mbh_mstar_ratio = 10.0
+nsc_ratio_bh_mass_star_mass = 10.0
 #Radial density index for inner NSC, for r<r_nsc_crit. n propto r^-7/4 for Bahcall-Wolf (& Generozov+18)
-nsc_index_inner = 1.75
-#Radial density index for outer NSC, for r>r_nsc_crit. n propto r^-2.5 for Generozov+18, r^-2.25 Peebles)
-nsc_index_outer = 2.5
+nsc_density_index_inner = 1.75
+#Radial density index for outer NSC, for r>r_nsc_crit. n propto r^-2.5 for Generozov+18, r^-2.25 Peebles
+nsc_density_index_outer = 2.5
 #Average aspect ratio of disk (calculate this based on r_disk_outer?). Roughly 3% or so for Sirko&Goodman03.
-h_disk_average = 0.03
-#
+disk_aspect_ratio_avg = 0.03
+#Normalize spheroid component rate of interactions (default = 1.0)
+nsc_spheroid_normalization = 1.0
 
 # Mode of initial BH mass distribution in M_sun (peak of Pareto fn)
-mode_mbh_init = 10.
+nsc_bh_imf_mode = 10.
 # Pareto (powerlaw) initial BH mass index
-mbh_powerlaw_index = 2.
+nsc_bh_imf_powerlaw_index = 2.
 # Maximum initial BH mass in distribution in M_sun
-max_initial_bh_mass = 40.
+nsc_bh_imf_mass_max = 40.
 # Mean of Gaussian initial spin distribution 
-mu_spin_distribution = 0.
+nsc_bh_spin_dist_mu = 0.
 # Sigma of Gaussian initial spin distribution 
-sigma_spin_distribution = 0.1
+nsc_bh_spin_dist_sigma = 0.1
 # Spin torque condition
-spin_torque_condition = 0.1
+disk_bh_torque_condition = 0.1
 # Accretion rate of fully embedded stellar mass black hole in units of 
 #   Eddington accretion rate
-frac_Eddington_ratio = 1.0
+disk_bh_eddington_ratio = 1.0
 # Maximum initial eccentricity
-max_initial_eccentricity = 0.3
+disk_bh_orb_ecc_max_init = 0.3
 #
+#
+#Star stuff
+disk_star_mass_min_init = 5.
+disk_star_mass_max_init = 40.
+nsc_imf_star_powerlaw_index = 2.35
+nsc_star_spin_dist_mu = 100.
+nsc_star_spin_dist_sigma = 20.
+disk_star_torque_condition = 0.1
+disk_star_eddington_ratio = 1.0
+disk_star_orb_ecc_max_init = 0.3
+#These values are from Brott+2011
+nsc_star_metallicity_x_init = 0.7274
+nsc_star_metallicity_y_init = 0.2638
+nsc_star_metallicity_z_init = 0.0088
+
 # Timing:
 # 
 # timestep in years (float)
-timestep = 1.e4
+timestep_duration_yr = 1.e4
 # For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
-number_of_timesteps = 100
+timestep_num = 100
 
 # number of iterations of code (1 for testing. 30 for a quick run.)
-n_iterations = 1
+iteration_num = 1
 #
 # Other physics choices: 
 #
 # retrograde binaries on/off (1/0) switch. Retrograde = 0(1) means retrograde bins are suppressed(allowed)
-retro = 0
+fraction_retro = 0.5
+# New retrograde binary switch
+fraction_bin_retro = 0.0
 # feedback on/off switch. Feedback = 1(0) means feedback is allowed(off)
-feedback = 0
+flag_thermal_feedback = 1
 # eccentricity damping (1/0) switch. 
 # orb_ecc_damping = 1 means orbital damping is on & orb ecc is drawn from e.g. uniform or thermal distribution
 # orb_ecc_damping = 0 means orbital damping is off and all BH are assumed to be on circularized orbits (=e_crit)
-orb_ecc_damping = 1
+flag_orb_ecc_damping = 1
 # Disk capture 
 # capture time in years (float). Secunda et al. (2021) assume capture rate 1/0.1Myr
-capture_time = 1.e5
+capture_time_yr = 1.e5
 # Disk capture outer radius (in units of r_g). Secunda et al. (2021) assume <2000r_g from Fabj et al. (2020)
-outer_capture_radius = 1.e3
+disk_radius_capture_outer = 1.e3
 #Critical eccentricity (limiting eccentricity, below which assumed circular orbit)
-crit_ecc = 0.01
+disk_bh_pro_orb_ecc_crit = 0.01
 #Dynamics on/off switch. Dynamics = 0(1) means dynamical encounters are off (on)
-dynamic_enc = 0
+flag_dynamic_enc = 1
 # Delta Energy per Strong interaction (can be up to 20%,0.2)
-de = 0.1
+delta_energy_strong = 0.1
+# Prior AGN sims BH output (output_mergers_survivors.dat) used as input ( renamed & located as /recipes/postagn_bh_pop1.dat)
+flag_prior_agn = 0

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -260,9 +260,9 @@ def main():
                                   spin_angle=bh_initial_spin_angles,
                                   orb_a=bh_initial_locations,
                                   orb_inc=bh_initial_orb_incl,
-                                  orbit_ecc=bh_initial_orb_ecc,
+                                  orb_ecc=bh_initial_orb_ecc,
                                   orb_arg_periapse=bh_initial_orb_arg_periapse,
-                                  mass_smbh=opts.smbh_mass,
+                                  smbh_mass=opts.smbh_mass,
                                   obj_num=disk_bh_num)
 
         # Initialize stars
@@ -280,7 +280,7 @@ def main():
                                    new_orb_a=stars.orb_a,
                                    new_orb_inc=stars.orb_inc,
                                    new_orb_ang_mom=stars.orb_ang_mom,
-                                   new_orb_ecc=stars.orbit_ecc,
+                                   new_orb_ecc=stars.orb_ecc,
                                    new_orb_arg_periapse=stars.orb_arg_periapse,
                                    new_gen=stars.gen)
 
@@ -397,8 +397,8 @@ def main():
             print("prior locations", blackholes_pro.orb_a)
             print("prior gens", blackholes_pro.gen)
             prior_ecc_factor = 0.3
-            blackholes_pro.orbit_ecc = setupdiskblackholes.setup_disk_blackholes_eccentricity_uniform_modified(prior_ecc_factor, bh_pro_num)
-            print("prior ecc", blackholes_pro.orbit_ecc)
+            blackholes_pro.orb_ecc = setupdiskblackholes.setup_disk_blackholes_eccentricity_uniform_modified(prior_ecc_factor, bh_pro_num)
+            print("prior ecc", blackholes_pro.orb_ecc)
 
         # Start Loop of Timesteps
         print("Start Loop!")
@@ -457,7 +457,7 @@ def main():
                 opts.timestep_duration_yr,
                 ratio_heat_mig_torques_agnobj,
                 opts.disk_radius_trap,
-                blackholes_pro.orbit_ecc,
+                blackholes_pro.orb_ecc,
                 opts.disk_bh_pro_orb_ecc_crit
             )
 
@@ -475,7 +475,7 @@ def main():
                 opts.disk_bh_eddington_ratio,
                 opts.disk_bh_torque_condition,
                 opts.timestep_duration_yr,
-                blackholes_pro.orbit_ecc,
+                blackholes_pro.orb_ecc,
                 opts.disk_bh_pro_orb_ecc_crit,
             )
 
@@ -486,18 +486,18 @@ def main():
                 opts.disk_bh_torque_condition,
                 disk_bh_spin_resolution_min,
                 opts.timestep_duration_yr,
-                blackholes_pro.orbit_ecc,
+                blackholes_pro.orb_ecc,
                 opts.disk_bh_pro_orb_ecc_crit
             )
 
             # Damp BH orbital eccentricity
-            blackholes_pro.orbit_ecc = orbital_ecc.orbital_ecc_damping(
+            blackholes_pro.orb_ecc = orbital_ecc.orbital_ecc_damping(
                 opts.smbh_mass,
                 blackholes_pro.orb_a,
                 blackholes_pro.mass,
                 disk_surface_density,
                 disk_aspect_ratio,
-                blackholes_pro.orbit_ecc,
+                blackholes_pro.orb_ecc,
                 opts.timestep_duration_yr,
                 opts.disk_bh_pro_orb_ecc_crit,
             )
@@ -506,11 +506,11 @@ def main():
             #   note this is dyn friction only, not true 'migration'
             # change retrograde eccentricity (some damping, some pumping)
             # damp orbital inclination
-            blackholes_retro.orbit_ecc, blackholes_retro.orb_a, blackholes_retro.orb_inc = crude_retro_evol.crude_retro_bh(
+            blackholes_retro.orb_ecc, blackholes_retro.orb_a, blackholes_retro.orb_inc = crude_retro_evol.crude_retro_bh(
                 opts.smbh_mass,
                 blackholes_retro.mass,
                 blackholes_retro.orb_a,
-                blackholes_retro.orbit_ecc,
+                blackholes_retro.orb_ecc,
                 blackholes_retro.orb_inc,
                 blackholes_retro.orb_arg_periapse,
                 disk_surface_density,
@@ -529,7 +529,7 @@ def main():
                 opts.timestep_duration_yr,
                 ratio_heat_mig_stars_torques,
                 opts.disk_radius_trap,
-                stars_pro.orbit_ecc,
+                stars_pro.orb_ecc,
                 opts.disk_bh_pro_orb_ecc_crit
             )
             
@@ -546,7 +546,7 @@ def main():
                 opts.disk_star_eddington_ratio,
                 opts.disk_bh_torque_condition,
                 opts.timestep_duration_yr,
-                stars_pro.orbit_ecc,
+                stars_pro.orb_ecc,
                 opts.disk_bh_pro_orb_ecc_crit,
             )
 
@@ -557,18 +557,18 @@ def main():
                 opts.disk_bh_torque_condition,
                 disk_bh_spin_resolution_min,
                 opts.timestep_duration_yr,
-                stars_pro.orbit_ecc,
+                stars_pro.orb_ecc,
                 opts.disk_bh_pro_orb_ecc_crit
             )
 
             # Damp stars orbital eccentricity
-            stars_pro.orbit_ecc = orbital_ecc.orbital_ecc_damping(
+            stars_pro.orb_ecc = orbital_ecc.orbital_ecc_damping(
                 opts.smbh_mass,
                 stars_pro.orb_a,
                 stars_pro.mass,
                 disk_surface_density,
                 disk_aspect_ratio,
-                stars_pro.orbit_ecc,
+                stars_pro.orb_ecc,
                 opts.timestep_duration_yr,
                 opts.disk_bh_pro_orb_ecc_crit,
             )
@@ -579,11 +579,11 @@ def main():
             # damp orbital inclination
             
             # This is not working for retrograde stars, just says parameters are unreliable
-            # stars_retro.orbit_ecc, stars_retro.orb_a, stars_retro.orb_inc = crude_retro_evol.crude_retro_bh(
+            # stars_retro.orb_ecc, stars_retro.orb_a, stars_retro.orb_inc = crude_retro_evol.crude_retro_bh(
             #     opts.smbh_mass,
             #     stars_retro.mass,
             #     stars_retro.orb_a,
-            #     stars_retro.orbit_ecc,
+            #     stars_retro.orb_ecc,
             #     stars_retro.orb_inc,
             #     stars_retro.orb_arg_periapse,
             #     disk_surface_density,
@@ -599,13 +599,13 @@ def main():
                     blackholes_pro.mass,
                     disk_surface_density,
                     disk_aspect_ratio,
-                    blackholes_pro.orbit_ecc,
+                    blackholes_pro.orb_ecc,
                     opts.timestep_duration_yr,
                     opts.disk_bh_pro_orb_ecc_crit,
                     opts.delta_energy_strong,
                 )
                 blackholes_pro.orb_a = prograde_bh_locn_orb_ecc[0][0]
-                blackholes_pro.orbit_ecc = prograde_bh_locn_orb_ecc[1][0]
+                blackholes_pro.orb_ecc = prograde_bh_locn_orb_ecc[1][0]
                 
                 stars_pro_locn_orb_ecc = dynamics.circular_singles_encounters_prograde(
                     rng,
@@ -614,13 +614,13 @@ def main():
                     stars_pro.mass,
                     disk_surface_density,
                     disk_aspect_ratio,
-                    stars_pro.orbit_ecc,
+                    stars_pro.orb_ecc,
                     opts.timestep_duration_yr,
                     opts.disk_bh_pro_orb_ecc_crit,
                     opts.delta_energy_strong,
                 )
                 stars_pro.orb_a = stars_pro_locn_orb_ecc[0][0]
-                stars_pro.orbit_ecc = stars_pro_locn_orb_ecc[1][0]
+                stars_pro.orb_ecc = stars_pro_locn_orb_ecc[1][0]
             
             # Do things to the binaries--first check if there are any:
             if bin_index > 0:
@@ -653,7 +653,7 @@ def main():
                             opts.smbh_mass,
                             blackholes_pro.orb_a,
                             blackholes_pro.mass,
-                            blackholes_pro.orbit_ecc,
+                            blackholes_pro.orb_ecc,
                             opts.timestep_duration_yr,
                             opts.disk_bh_pro_orb_ecc_crit,
                             opts.delta_energy_strong,
@@ -667,7 +667,7 @@ def main():
                             opts.smbh_mass,
                             blackholes_pro.orb_a,
                             blackholes_pro.mass,
-                            blackholes_pro.orbit_ecc,
+                            blackholes_pro.orb_ecc,
                             opts.timestep_duration_yr,
                             opts.disk_bh_pro_orb_ecc_crit,
                             opts.delta_energy_strong,
@@ -989,7 +989,7 @@ def main():
 
                 # check which binaries should get made
             close_encounters_indices = hillsphere.binary_check2(
-                blackholes_pro.orb_a, blackholes_pro.mass, opts.smbh_mass, blackholes_pro.orbit_ecc, opts.disk_bh_pro_orb_ecc_crit
+                blackholes_pro.orb_a, blackholes_pro.mass, opts.smbh_mass, blackholes_pro.orb_ecc, opts.disk_bh_pro_orb_ecc_crit
             )
 
             if np.size(close_encounters_indices) > 0:
@@ -1063,7 +1063,7 @@ def main():
                 inner_disk_masses = np.append(inner_disk_masses, blackholes_pro.mass[inner_disk_indices])
                 inner_disk_spins = np.append(inner_disk_spins, blackholes_pro.spin[inner_disk_indices])
                 inner_disk_spin_angles = np.append(inner_disk_spin_angles, blackholes_pro.spin_angle[inner_disk_indices])
-                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc, blackholes_pro.orbit_ecc[inner_disk_indices])
+                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc, blackholes_pro.orb_ecc[inner_disk_indices])
                 inner_disk_orb_inc = np.append(inner_disk_orb_inc, blackholes_pro.orb_inc[inner_disk_indices])
                 inner_disk_gens = np.append(inner_disk_gens, blackholes_pro.gen[inner_disk_indices])
                 # Remove BH from prograde_disk_arrays
@@ -1078,7 +1078,7 @@ def main():
                 inner_disk_masses = np.append(inner_disk_masses, blackholes_retro.mass[inner_disk_retro_indices])
                 inner_disk_spins = np.append(inner_disk_spins, blackholes_retro.spin[inner_disk_retro_indices])
                 inner_disk_spin_angles = np.append(inner_disk_spin_angles, blackholes_retro.spin_angle[inner_disk_retro_indices])
-                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc, blackholes_retro.orbit_ecc[inner_disk_retro_indices])
+                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc, blackholes_retro.orb_ecc[inner_disk_retro_indices])
                 inner_disk_orb_inc = np.append(inner_disk_orb_inc, blackholes_retro.orb_inc[inner_disk_retro_indices])
                 inner_disk_gens = np.append(inner_disk_gens, blackholes_retro.gen[inner_disk_retro_indices])
                 
@@ -1145,7 +1145,7 @@ def main():
             # stop treating them with crude retro evolution--it will be sad
             # SF: fix the inc threshhold later!!!
             inc_threshhold = 5.0 * np.pi/180.0
-            flip_to_prograde_indices = np.where((np.abs(blackholes_retro.orb_inc) <= inc_threshhold) | (blackholes_retro.orbit_ecc == 0.0))
+            flip_to_prograde_indices = np.where((np.abs(blackholes_retro.orb_inc) <= inc_threshhold) | (blackholes_retro.orb_ecc == 0.0))
             if np.size(flip_to_prograde_indices) > 0:
                 # add to prograde arrays
                 blackholes_pro.add_blackholes(new_mass=blackholes_retro.mass[flip_to_prograde_indices],
@@ -1154,7 +1154,7 @@ def main():
                                               new_spin_angle=blackholes_retro.spin_angle[flip_to_prograde_indices],
                                               new_orb_inc=blackholes_retro.orb_inc[flip_to_prograde_indices],
                                               new_orb_ang_mom=np.ones(blackholes_retro.mass[flip_to_prograde_indices].size),
-                                              new_orb_ecc=blackholes_retro.orbit_ecc[flip_to_prograde_indices],
+                                              new_orb_ecc=blackholes_retro.orb_ecc[flip_to_prograde_indices],
                                               new_orb_arg_periapse=blackholes_retro.orb_arg_periapse[flip_to_prograde_indices],
                                               new_gen=blackholes_retro.gen[flip_to_prograde_indices],
                                               new_id_num=blackholes_retro.id_num[flip_to_prograde_indices])

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1042,7 +1042,7 @@ def main():
             # To do: What eccentricity do we want the captured BH to have? Right now ecc=0.0? Should it be ecc<h at a?             
             # Assume 1st gen BH captured and orb ecc =0.0
             # To do: Bias disk capture to more massive BH!
-            capture = time_passed % opts.capture_time_myr
+            capture = time_passed % opts.capture_time_yr
             if capture == 0:
                 bh_capture_location = setupdiskblackholes.setup_disk_blackholes_location(
                     1, opts.disk_radius_capture_outer)

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -3,71 +3,46 @@ import os
 from os.path import isfile, isdir
 from pathlib import Path
 
-from cgi import print_arguments
 import numpy as np
-import math
-import matplotlib.pyplot as plt
-import itertools
 import scipy.interpolate
-
-import sys
-import argparse
 
 from mcfacts.inputs import ReadInputs
 from importlib import resources as impresources
 from mcfacts.inputs import data as input_data
 from mcfacts.mcfacts_random_state import reset_random, rng
-from mcfacts.objects.agnobject import AGNStar
-from mcfacts.objects.agnobject import AGNBlackHole
-from mcfacts.objects.agnobject import AGNBinaryBlackHole
-from mcfacts.objects.agnobject import AGNFilingCabinet
+from mcfacts.objects.agnobject import AGNBlackHole, AGNFilingCabinet
 
-from mcfacts.setup import setupdiskblackholes
-from mcfacts.setup import setupdiskstars
+from mcfacts.setup import setupdiskblackholes, initializediskstars
 from mcfacts.physics.migration.type1 import type1
-from mcfacts.physics.accretion.eddington import changebhmass
-from mcfacts.physics.accretion.eddington import changestarsmass
-from mcfacts.physics.accretion.torque import changebh
-from mcfacts.physics.accretion.torque import changestars
-from mcfacts.physics.feedback.hankla21 import feedback_hankla21
-from mcfacts.physics.feedback.hankla21 import feedback_hankla21_stars
+from mcfacts.physics.accretion.eddington import changebhmass, changestarsmass
+from mcfacts.physics.accretion.torque import changebh, changestars
+from mcfacts.physics.feedback.hankla21 import feedback_hankla21, feedback_hankla21_stars
 from mcfacts.physics.dynamics import dynamics
 from mcfacts.physics.eccentricity import orbital_ecc
-from mcfacts.physics.binary.formation import hillsphere
-from mcfacts.physics.binary.formation import add_new_binary
+from mcfacts.physics.binary.formation import hillsphere, add_new_binary
 from mcfacts.physics.binary.evolve import evolve
 from mcfacts.physics.binary.harden import baruteau11
-from mcfacts.physics.binary.merge import tichy08
-from mcfacts.physics.binary.merge import chieff
-from mcfacts.physics.binary.merge import tgw
-
+from mcfacts.physics.binary.merge import tichy08, chieff, tgw
 from mcfacts.physics.disk_capture import crude_retro_evol
-
 from mcfacts.outputs import mergerfile
-#testing
-from mcfacts.setup import initializediskstars
 
-binary_field_names="R1 R2 M1 M2 a1 a2 theta1 theta2 sep com t_gw merger_flag t_mgr  gen_1 gen_2  bin_ang_mom bin_ecc bin_incl bin_orb_ecc nu_gw h_bin"
-binary_stars_field_names="R1 R2 M1 M2 R1_star R2_star a1 a2 theta1 theta2 sep com t_gw merger_flag t_mgr  gen_1 gen_2  bin_ang_mom bin_ecc bin_incl bin_orb_ecc nu_gw h_bin"
-merger_field_names=' '.join(mergerfile.names_rec)
-
-
+binary_field_names = "R1 R2 M1 M2 a1 a2 theta1 theta2 sep com t_gw merger_flag t_mgr  gen_1 gen_2  bin_ang_mom bin_ecc bin_incl bin_orb_ecc nu_gw h_bin"
+binary_stars_field_names = "R1 R2 M1 M2 R1_star R2_star a1 a2 theta1 theta2 sep com t_gw merger_flag t_mgr  gen_1 gen_2  bin_ang_mom bin_ecc bin_incl bin_orb_ecc nu_gw h_bin"
+merger_field_names = ' '.join(mergerfile.names_rec)
 
 # Do not change this line EVER
 DEFAULT_INI = impresources.files(input_data) / "model_choice.ini"
 bh_initial_field_names = "disk_location mass spin spin_angle orb_ang_mom orb_ecc orb_incl"
 # Feature in testing do not use unless you know what you're doing.
 
-#DEFAULT_PRIOR_POP = Path(__file__).parent.resolve() / ".." / "recipes" / "prior_mergers_population.dat"
-
 assert DEFAULT_INI.is_file()
-#assert DEFAULT_PRIOR_POP.is_file()
 
 FORBIDDEN_ARGS = [
     "disk_outer_radius",
     "max_disk_radius_pc",
     "disk_inner_radius",
     ]
+
 
 def arg():
     import argparse
@@ -76,45 +51,44 @@ def arg():
     # General
     parser.add_argument("--n_bins_max", default=1000, type=int)
     parser.add_argument("--n_bins_max_out", default=100, type=int)
-    parser.add_argument("--fname-ini",help="Filename of configuration file",
-        default=DEFAULT_INI,type=str)
-    parser.add_argument("--fname-output-mergers",default="output_mergers.dat",
-        help="output merger file (if any)",type=str)
+    parser.add_argument("--fname-ini", help="Filename of configuration file",
+                        default=DEFAULT_INI, type=str)
+    parser.add_argument("--fname-output-mergers", default="output_mergers.dat",
+                        help="output merger file (if any)", type=str)
     parser.add_argument("--fname-snapshots-bh",
-        default="output_bh_[single|binary]_$(index).dat",
-        help="output of BH index file ")
+                        default="output_bh_[single|binary]_$(index).dat",
+                        help="output of BH index file ")
     parser.add_argument("--no-snapshots", action='store_true')
-    parser.add_argument("--verbose",action='store_true')
+    parser.add_argument("--verbose", action='store_true')
     parser.add_argument("-w", "--work-directory",
-        default=Path().parent.resolve(),
-        help="Set the working directory for saving output. Default: current working directory",
-        type=str
-    )
+                        default=Path().parent.resolve(),
+                        help="Set the working directory for saving output. Default: current working directory",
+                        type=str
+                        )
     parser.add_argument("--seed", type=int, default=None,
-        help="Set the random seed. Randomly sets one if not passed. Default: None")
+                        help="Set the random seed. Randomly sets one if not passed. Default: None")
     parser.add_argument("--fname-log", default="mcfacts_sim.log", type=str,
-        help="Specify a file to save the arguments for mcfacts")
+                        help="Specify a file to save the arguments for mcfacts")
     
     ## Add inifile arguments
     # Read default inifile
-    _variable_inputs = ReadInputs.ReadInputs_ini(DEFAULT_INI,False)
+    _variable_inputs = ReadInputs.ReadInputs_ini(DEFAULT_INI, False)
     # Loop the arguments
     for name in _variable_inputs:
         # Skip CL read of forbidden arguments
         if name in FORBIDDEN_ARGS:
             continue
-        _metavar    = name
-        _opt        = "--%s"%(name)
-        _default    = _variable_inputs[name]
-        _dtype      = type(_variable_inputs[name])
-        parser.add_argument(
-            _opt,
-            default=_default,
-            type=_dtype,
-            metavar=_metavar,
-           )
+        _metavar = name
+        _opt = "--%s" % (name)
+        _default = _variable_inputs[name]
+        _dtype = type(_variable_inputs[name])
+        parser.add_argument(_opt,
+                            default=_default,
+                            type=_dtype,
+                            metavar=_metavar,
+                            )
 
-    ## Parse arguments
+    # Parse arguments
     opts = parser.parse_args()
     # Check that the inifile exists
     assert isfile(opts.fname_ini)
@@ -124,14 +98,14 @@ def arg():
     opts.fname_snapshots_bh = Path(opts.fname_snapshots_bh)
     opts.fname_output_mergers = Path(opts.fname_output_mergers)
 
-    ## Parse inifile
-    print("opts.fname_ini",opts.fname_ini)
+    # Parse inifile
+    print("opts.fname_ini", opts.fname_ini)
     # Read inifile
     variable_inputs = ReadInputs.ReadInputs_ini(opts.fname_ini, opts.verbose)
-    print("variable_inputs",variable_inputs)
-    #Hidden variable inputs
-    print("_variable_inputs",_variable_inputs)
-    #raise Exception
+    print("variable_inputs", variable_inputs)
+    # Hidden variable inputs
+    print("_variable_inputs", _variable_inputs)
+    # raise Exception
     # Okay, this is important. The priority of input arguments is:
     # command line > specified inifile > default inifile
     for name in variable_inputs:
@@ -156,14 +130,14 @@ def arg():
     if opts.verbose:
         for item in opts.__dict__:
             print(item, getattr(opts, item))
-    print("variable_inputs",variable_inputs)
-    #raise Exception
+    print("variable_inputs", variable_inputs)
+    # raise Exception
     # Get the user-defined or default working directory / output location
     opts.work_directory = Path(opts.work_directory).resolve()
     if not isdir(opts.work_directory):
         os.mkdir(opts.work_directory)
     assert opts.work_directory.is_dir()
-    try: # check if working directory for output exists
+    try:  # check if working directory for output exists
         os.stat(opts.work_directory)
     except FileNotFoundError as e:
         raise e
@@ -175,15 +149,14 @@ def arg():
     os.chdir(opts.runtime_directory)
 
     # set the seed for random number generation and reproducibility if not user-defined
-    if opts.seed == None:
+    if opts.seed is None:
         opts.seed = np.random.randint(low=0, high=int(1e18), dtype=np.int_)
         print(f'Random number generator seed set to: {opts.seed}')
-
 
     # Write parameters to log file
     with open(opts.work_directory / opts.fname_log, 'w') as F:
         for item in opts.__dict__:
-            line = "%s = %s\n"%(item, str(opts.__dict__[item]))
+            line = "%s = %s\n" % (item, str(opts.__dict__[item]))
             F.write(line)
     return opts
 
@@ -194,47 +167,37 @@ def main():
     # Setting up automated input parameters
     # see IOdocumentation.txt for documentation of variable names/types/etc.
     opts = arg()
-    surf_dens_func, aspect_ratio_func = \
-        ReadInputs.construct_disk_interp(
-        opts.mass_smbh,
-        opts.disk_outer_radius,
-        opts.disk_model_name,
-        opts.alpha,
-        opts.frac_Eddington_ratio,
-        max_disk_radius_pc      = opts.max_disk_radius_pc,
-        disk_model_use_pagn     = opts.disk_model_use_pagn,
-        verbose                 = opts.verbose
-        )
+    # Disk surface density (in kg/m^2) is a function of radius, where radius is in r_g
+    # Disk aspect ratio is also a function of radius, where radius is in r_g
+    disk_surface_density, disk_aspect_ratio = \
+        ReadInputs.construct_disk_interp(opts.mass_smbh,
+                                         opts.disk_outer_radius,
+                                         opts.disk_model_name,
+                                         opts.alpha,
+                                         opts.frac_Eddington_ratio,
+                                         max_disk_radius_pc=opts.max_disk_radius_pc,
+                                         disk_model_use_pagn=opts.disk_model_use_pagn,
+                                         verbose=opts.verbose
+                                         )
         
     merged_bh_array_pop = []
-
     surviving_bh_array_pop = []
-    
     emris_array_pop = []
 
     gw_array_pop = []
-    print("opts.__dict__",opts.__dict__)
-    print("opts.mass_smbh",opts.mass_smbh)
-    print("opts.frac_bin_retro",opts.frac_bin_retro)
-    #temp_emri_array = np.zeros(7)
-
-    #emri_array = np.zeros(7)
-
-    #temp_bbh_gw_array = np.zeros(7)
-
-    #bbh_gw_array = np.zeros(7)
+    print("opts.__dict__", opts.__dict__)
+    print("opts.mass_smbh", opts.mass_smbh)
+    print("opts.frac_bin_retro", opts.frac_bin_retro)
 
     for iteration in range(opts.n_iterations):
         print("Iteration", iteration)
         # Set random number generator for this run with incremented seed
-        # ALERT: ONLY this random number generator can be used throughout the code to ensure reproducibility.
-        #rng = np.random.default_rng(opts.seed + iteration)
         reset_random(opts.seed+iteration)
 
         # Make subdirectories for each iteration
         # Fills run number with leading zeros to stay sequential
         iteration_zfilled_str = f"{iteration:>0{int(np.log10(opts.n_iterations))+1}}"
-        try: # Make subdir, exit if it exists to avoid clobbering.
+        try:  # Make subdir, exit if it exists to avoid clobbering.
             os.makedirs(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}"), exist_ok=False)
         except FileExistsError:
             raise FileExistsError(f"Directory \'run{iteration_zfilled_str}\' exists. Exiting so I don't delete your data.")
@@ -243,17 +206,22 @@ def main():
         # galaxy_type = galaxy_models[iteration] # e.g. star forming/spiral vs. elliptical
         # NSC mass
         # SMBH mass
-        #Housekeeping for array initialization
+        # Housekeeping for array initialization
         temp_emri_array = np.zeros(7)
-
         emri_array = np.zeros(7)
-
         temp_bbh_gw_array = np.zeros(7)
+        bbh_gw_array = np.zeros(7)
 
-        bbh_gw_array = np.zeros(7)    
+        # Fractional rate of mass growth per year set to 
+        # the Eddington rate(2.3e-8/yr)
+        disk_bh_eddington_mass_growth_rate = 2.3e-8
+        # minimum spin angle resolution 
+        # (ie less than this value gets fixed to zero) 
+        # e.g 0.02 rad=1deg
+        disk_bh_spin_resolution_min = 0.02
 
-        #Set up number of BH in disk
-        n_bh = setupdiskblackholes.setup_disk_nbh(
+        # Set up number of BH in disk
+        disk_bh_num = setupdiskblackholes.setup_disk_nbh(
             opts.M_nsc,
             opts.nbh_nstar_ratio,
             opts.mbh_mstar_ratio,
@@ -265,90 +233,69 @@ def main():
             opts.r_nsc_crit,
             opts.nsc_index_inner,
         )
-
-        #This generates 10^6 more stars than BH so for right now I have artificially limited it to 5000 stars.
-        """ n_stars = setupdiskstars.setup_disk_nstars(
-            opts.M_nsc,
-            opts.nbh_nstar_ratio,
-            opts.mbh_mstar_ratio,
-            opts.r_nsc_out,
-            opts.nsc_index_outer,
-            opts.mass_smbh,
-            opts.disk_outer_radius,
-            opts.h_disk_average,
-            opts.r_nsc_crit,
-            opts.nsc_index_inner,
-        )
-        n_stars = np.int64(5000) """
 
         # generate initial BH parameter arrays
         print("Generate initial BH parameter arrays")
         bh_initial_locations = setupdiskblackholes.setup_disk_blackholes_location(
-            n_bh,
+            disk_bh_num,
             opts.disk_outer_radius,
         )
         bh_initial_masses = setupdiskblackholes.setup_disk_blackholes_masses(
-            n_bh,
+            disk_bh_num,
             opts.mode_mbh_init,
             opts.max_initial_bh_mass,
             opts.mbh_powerlaw_index,
         )
         bh_initial_spins = setupdiskblackholes.setup_disk_blackholes_spins(
-            n_bh,
+            disk_bh_num,
             opts.mu_spin_distribution,
             opts.sigma_spin_distribution
         )
         bh_initial_spin_angles = setupdiskblackholes.setup_disk_blackholes_spin_angles(
-            n_bh,
+            disk_bh_num,
             bh_initial_spins
         )
         bh_initial_orb_ang_mom = setupdiskblackholes.setup_disk_blackholes_orb_ang_mom(
-            n_bh
+            disk_bh_num
         )
         if opts.orb_ecc_damping == 1:
-            bh_initial_orb_ecc = setupdiskblackholes.setup_disk_blackholes_eccentricity_uniform(n_bh,opts.max_initial_eccentricity)
+            bh_initial_orb_ecc = setupdiskblackholes.setup_disk_blackholes_eccentricity_uniform(disk_bh_num, opts.max_initial_eccentricity)
         else:
-            bh_initial_orb_ecc = setupdiskblackholes.setup_disk_blackholes_circularized(n_bh,opts.crit_ecc)
+            bh_initial_orb_ecc = setupdiskblackholes.setup_disk_blackholes_circularized(disk_bh_num, opts.crit_ecc)
 
-        #bh_initial_orb_incl = setupdiskblackholes.setup_disk_blackholes_inclination(rng,n_bh)
-        bh_initial_orb_incl = setupdiskblackholes.setup_disk_blackholes_incl(n_bh, bh_initial_locations, bh_initial_orb_ang_mom, aspect_ratio_func)
-
-        bh_initial_orb_arg_periapse = setupdiskblackholes.setup_disk_blackholes_arg_periapse(n_bh)
-         
-        bh_initial_generations = np.ones((n_bh,),dtype=int)
-
-        blackholes = AGNBlackHole(mass = bh_initial_masses,
-                                  spin = bh_initial_spins,
-                                  spin_angle = bh_initial_spin_angles,
-                                  orbit_a = bh_initial_locations,
-                                  orbit_inclination = bh_initial_orb_incl,
-                                  orbit_e = bh_initial_orb_ecc,
-                                  orbit_arg_periapse = bh_initial_orb_arg_periapse,
-                                  mass_smbh = opts.mass_smbh,
-                                  nsystems = n_bh)
+        # KN: should the inclination function be called in AGNBlackhole init since it takes other parameters of the BHs?
+        bh_initial_orb_incl = setupdiskblackholes.setup_disk_blackholes_incl(disk_bh_num, bh_initial_locations, bh_initial_orb_ang_mom, disk_aspect_ratio)
+        bh_initial_orb_arg_periapse = setupdiskblackholes.setup_disk_blackholes_arg_periapse(disk_bh_num)
         
-        bh_initial_orb_ang_mom = blackholes.orb_ang_mom.copy()
+        # Initialize black holes
+        blackholes = AGNBlackHole(mass=bh_initial_masses,
+                                  spin=bh_initial_spins,
+                                  spin_angle=bh_initial_spin_angles,
+                                  orbit_a=bh_initial_locations,
+                                  orbit_inclination=bh_initial_orb_incl,
+                                  orbit_e=bh_initial_orb_ecc,
+                                  orbit_arg_periapse=bh_initial_orb_arg_periapse,
+                                  mass_smbh=opts.mass_smbh,
+                                  nsystems=disk_bh_num)
+        
+        # Initialize stars
+        stars, disk_star_num = initializediskstars.init_single_stars(opts, id_start_val=blackholes.id_num.max()+1)
+        print('disk_bh_num = {}, disk_star_num = {}'.format(disk_bh_num, disk_star_num))
 
-        #----------now stars
-        stars, n_stars = initializediskstars.init_single_stars(opts,id_start_val=blackholes.id_num.max()+1)
-        print('n_bh = {}, n_stars = {}'.format(n_bh,n_stars))
-
-        filing_cabinet = AGNFilingCabinet(category=np.full(blackholes.mass.shape,0),
+        filing_cabinet = AGNFilingCabinet(category=np.full(blackholes.mass.shape, 0),
                                           agnobj=blackholes
                                           )
-        print(len(filing_cabinet.category),len(filing_cabinet.id_num))
-        filing_cabinet.add_objects(create_id=False,new_id_num=stars.id_num,new_category=np.full(stars.mass.shape,2),
-                                   new_direction=np.full(stars.mass.shape,0),
-                                  new_mass=stars.mass, 
-                                  new_spin=stars.spin, 
-                                  new_spin_angle=stars.spin_angle, 
-                                  new_orb_a=stars.orbit_a, 
-                                  new_orb_inclination=stars.orbit_inclination, 
-                                  new_orb_ang_mom=stars.orb_ang_mom, 
-                                  new_orb_e=stars.orbit_e,
-                                  new_orb_arg_periapse=stars.orbit_arg_periapse,
-                                  new_generation=stars.generations)
-
+        filing_cabinet.add_objects(create_id=False, new_id_num=stars.id_num, new_category=np.full(stars.mass.shape, 2),
+                                   new_direction=np.full(stars.mass.shape, 0),
+                                   new_mass=stars.mass, 
+                                   new_spin=stars.spin, 
+                                   new_spin_angle=stars.spin_angle, 
+                                   new_orb_a=stars.orbit_a, 
+                                   new_orb_inclination=stars.orbit_inclination, 
+                                   new_orb_ang_mom=stars.orb_ang_mom, 
+                                   new_orb_e=stars.orbit_e,
+                                   new_orb_arg_periapse=stars.orbit_arg_periapse,
+                                   new_generation=stars.generations)
 
         # Generate initial inner disk arrays for objects that end up in the inner disk. 
         # This is to track possible EMRIs--we're tossing things in these arrays
@@ -364,172 +311,65 @@ def main():
         inner_disk_orb_inc = []
         inner_disk_gens = []
 
-        # assign functions to variable names (continuity issue)
-        # Disk surface density (in kg/m^2) is a function of radius, where radius is in r_g
-        disk_surface_density = surf_dens_func
-        # and disk aspect ratio is also a function of radius, where radius is in r_g
-        disk_aspect_ratio = aspect_ratio_func
         # Housekeeping: Set up time
         initial_time = 0.0
         final_time = opts.timestep*opts.number_of_timesteps
 
-        # Find prograde BH orbiters. Identify BH with orb. ang mom =+1
-        #bh_orb_ang_mom_indices = np.array(bh_initial_orb_ang_mom)
-        #prograde_orb_ang_mom_indices = np.where(bh_orb_ang_mom_indices == 1)
-        #retrograde_orb_ang_mom_indices = np.where(bh_orb_ang_mom_indices == -1)
-        #prograde_bh_locations = bh_initial_locations[prograde_orb_ang_mom_indices]
-        #sorted_prograde_bh_locations = np.sort(prograde_bh_locations)
-        #Use masses of prograde BH only
-        #prograde_bh_masses = bh_initial_masses[prograde_orb_ang_mom_indices]
-        # Orbital eccentricities
-        #prograde_bh_orb_ecc = bh_initial_orb_ecc[prograde_orb_ang_mom_indices]
-
-        # Get prograde black holes
+        # Find prograde BH orbiters. Identify BH with orb. ang mom > 0 (orb_ang_mom is only ever +1 or -1)
         prograde_bh_indices = np.where(blackholes.orb_ang_mom > 0)
-        prograde_bh_id_nums = np.take(blackholes.id_num,prograde_bh_indices)
+        prograde_bh_id_num = np.take(blackholes.id_num, prograde_bh_indices)
         prograde_blackholes = blackholes.copy()
         prograde_blackholes.keep_objects(prograde_bh_indices)
 
-        filing_cabinet.change_direction(prograde_bh_id_nums,np.ones(prograde_blackholes.mass.shape))
+        # Update filing cabinet
+        filing_cabinet.change_direction(prograde_bh_id_num, np.ones(prograde_blackholes.mass.shape))
 
-        # Find which orbital eccentricities are <=h the disk aspect ratio and set up a mask
-        #prograde_bh_crit_ecc = np.ma.masked_where(prograde_bh_orb_ecc >= aspect_ratio_func(prograde_bh_locations),prograde_bh_orb_ecc)
-        # Orb eccentricities <2h (simple exponential damping): mask entries > 2*aspect_ratio
-        #prograde_bh_modest_ecc = np.ma.masked_where(prograde_bh_orb_ecc > 2.0*aspect_ratio_func(prograde_bh_locations),prograde_bh_orb_ecc)
-        #Orb eccentricities >2h (modified exponential damping): mask entries < 2*aspect_ratio
-        #prograde_bh_large_ecc = np.ma.masked_where(prograde_bh_orb_ecc < 2.0*aspect_ratio_func(prograde_bh_locations),prograde_bh_orb_ecc)
-        # Apply ecc damping to this masked array (where true)
-        #prograde_bh_orb_ecc_damp = orbital_ecc.orbital_ecc_damping(opts.mass_smbh, prograde_bh_locations, prograde_bh_masses, surf_dens_func, aspect_ratio_func, prograde_bh_orb_ecc, opts.timestep, opts.crit_ecc)
-
-        #print('modest ecc ',prograde_bh_modest_ecc)
-        #print('damped ecc',prograde_bh_orb_ecc_damp)
-
-        # Test dynamics
-        #post_dynamics_orb_ecc = dynamics.circular_singles_encounters_prograde(rng,opts.mass_smbh, prograde_bh_locations, prograde_bh_masses, surf_dens_func, aspect_ratio_func, prograde_bh_orb_ecc, opts.timestep, opts.crit_ecc, de)
-
-        #First sort all stars by location
-        #stars.sort(stars.orbit_a)
-
-        #prograde stars stuff
-        #prograde_stars_orb_ang_mom_indices = np.where(stars.orb_ang_mom >= 1)
-        prograde_stars_indices = np.where(stars.orb_ang_mom > 0)
-        prograde_stars_id_nums = np.take(stars.id_num,prograde_stars_indices)
-
+        # Find prograde star orbiters.
+        prograde_star_indices = np.where(stars.orb_ang_mom > 0)
+        prograde_star_id_nums = np.take(stars.id_num, prograde_star_indices)
         prograde_stars = stars.copy()
-        prograde_stars.keep_objects(prograde_stars_indices)
-        filing_cabinet.change_direction(prograde_stars_id_nums,np.ones(prograde_stars.mass.shape))
+        prograde_stars.keep_objects(prograde_star_indices)
+        
+        # Update filing cabinet
+        filing_cabinet.change_direction(prograde_star_id_nums, np.ones(prograde_stars.mass.shape))
 
-        # Migrate
-        # First if feedback present, find ratio of feedback heating torque to migration torque
-        #if feedback > 0:
-        #        ratio_heat_mig_torques = feedback_hankla21.feedback_hankla(prograde_bh_locations, surf_dens_func, opts.frac_Eddington_ratio, opts.alpha)
-        #else:
-        #        ratio_heat_mig_torques = np.ones(len(prograde_bh_locations))
-        # then migrate as usual
-        #prograde_bh_locations_new = type1.type1_migration(opts.mass_smbh , prograde_bh_locations, prograde_bh_masses, disk_surface_density, disk_aspect_ratio, opts.timestep, ratio_heat_mig_torques, opts.trap_radius, prograde_bh_orb_ecc,opts.crit_ecc)
-
-
-        #Orbital inclinations
-        #prograde_bh_orb_incl = bh_initial_orb_incl[prograde_orb_ang_mom_indices]
-        #prograde_stars_orb_incl = stars_initial_orb_incl[prograde_stars_orb_ang_mom_indices]
-        #print("Prograde orbital inclinations")
-
-        # adding arg of periapse for prograde BH
-        #prograde_bh_orb_arg_periapse = bh_initial_orb_arg_periapse[prograde_orb_ang_mom_indices]
-
-        # Now do retrograde BH orbiters setup
-        #retrograde_orb_ang_mom_indices = np.where(bh_orb_ang_mom_indices == -1)
-        #retrograde_bh_locations = bh_initial_locations[retrograde_orb_ang_mom_indices]
-        #retrograde_bh_masses = bh_initial_masses[retrograde_orb_ang_mom_indices]
-        #retrograde_bh_orb_ecc = bh_initial_orb_ecc[retrograde_orb_ang_mom_indices]
-        #retrograde_bh_orb_incl = bh_initial_orb_incl[retrograde_orb_ang_mom_indices]
-        #retrograde_bh_orb_arg_periapse = bh_initial_orb_arg_periapse[retrograde_orb_ang_mom_indices]
-
-
-        # Get retrograde black holes
+        # Find retrograde black holes
         retrograde_bh_indices = np.where(blackholes.orb_ang_mom < 0)
         retrograde_blackholes = blackholes.copy()
         retrograde_blackholes.keep_objects(retrograde_bh_indices)
-        retrograde_bh_id_nums = np.take(blackholes.id_num,retrograde_bh_indices)
+        retrograde_bh_id_num = np.take(blackholes.id_num, retrograde_bh_indices)
 
-        filing_cabinet.change_direction(retrograde_bh_id_nums,np.full(retrograde_blackholes.mass.shape,-1))
+        # Update filing cabinet
+        filing_cabinet.change_direction(retrograde_bh_id_num, np.full(retrograde_blackholes.mass.shape, -1))
 
-        retrograde_stars_indices = np.where(stars.orb_ang_mom < 0)
+        # Find retrograde stars
+        retrograde_star_indices = np.where(stars.orb_ang_mom < 0)
         retrograde_stars = stars.copy()
-        retrograde_stars.keep_objects(retrograde_stars_indices)
-        retrograde_stars_id_nums = np.take(stars.id_num,retrograde_stars_indices)
+        retrograde_stars.keep_objects(retrograde_star_indices)
+        retrograde_star_id_num = np.take(stars.id_num, retrograde_star_indices)
 
-        filing_cabinet.change_direction(retrograde_stars_id_nums,np.full(retrograde_stars.mass.shape,-1))
-
-        # Housekeeping: Fractional rate of mass growth per year at 
-        # the Eddington rate(2.3e-8/yr)
-        mass_growth_Edd_rate = 2.3e-8
-    
-        # Housekeeping: minimum spin angle resolution 
-        # (ie less than this value gets fixed to zero) 
-        # e.g 0.02 rad=1deg
-        spin_minimum_resolution = 0.02
-        # Torque prograde orbiting BH only
-        #prograde_bh_spins = bh_initial_spins[prograde_orb_ang_mom_indices]
-        #prograde_bh_spin_angles = bh_initial_spin_angles[prograde_orb_ang_mom_indices]
-        #prograde_bh_generations = bh_initial_generations[prograde_orb_ang_mom_indices]
-        # but set up retrogrades--think about physics later:
-        #retrograde_bh_spins = bh_initial_spins[retrograde_orb_ang_mom_indices]
-        #retrograde_bh_spin_angles = bh_initial_spin_angles[retrograde_orb_ang_mom_indices]
-        #retrograde_bh_generations = bh_initial_generations[retrograde_orb_ang_mom_indices]
-
-        #Torque prograde orbiting stars only
-        """prograde_stars_spins = stars_initial_spins[prograde_stars_orb_ang_mom_indices]
-        prograde_stars_spin_angles = stars_initial_spin_angles[prograde_stars_orb_ang_mom_indices]
-        prograde_stars_generations = stars_initial_generations[prograde_stars_orb_ang_mom_indices]
-        prograde_stars_radii = stars_initial_radii[prograde_stars_orb_ang_mom_indices]
-        prograde_stars_X = stars_initial_X[prograde_stars_orb_ang_mom_indices]
-        prograde_stars_Y = stars_initial_Y[prograde_stars_orb_ang_mom_indices]
-        prograde_stars_Z = stars_initial_Z[prograde_stars_orb_ang_mom_indices] """
-
-
+        # Update filing cabinet
+        filing_cabinet.change_direction(retrograde_star_id_num, np.full(retrograde_stars.mass.shape, -1))
 
         # Writing initial parameters to file
-        """ np.savetxt(
-                os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/initial_params_bh.dat"),
-                np.c_[bh_initial_locations.T,
-                      bh_initial_masses.T,
-                      bh_initial_spins.T,
-                      bh_initial_spin_angles.T,
-                      bh_initial_orb_ang_mom.T,
-                      bh_initial_orb_ecc.T,
-                      bh_initial_orb_incl.T],
-                header = bh_initial_field_names
-        ) """
-
-        stars.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/initial_params_stars.dat"))
-        blackholes.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/initial_params_bh_agnobject.dat"))
+        stars.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/initial_params_star.dat"))
+        blackholes.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/initial_params_bh.dat"))
 
         # Housekeeping:
         # Number of binary properties that we want to record (e.g. R1,R2,M1,M2,a1,a2,theta1,theta2,sep,com,t_gw,merger_flag,time of merger, gen_1,gen_2, bin_ang_mom, bin_ecc, bin_incl,bin_orb_ecc, nu_gw, h_bin)
-        number_of_bin_properties = len(binary_field_names.split())+1
-        integer_nbinprop = int(number_of_bin_properties)
+        bin_properties_num = len(binary_field_names.split())+1
         bin_index = 0
-        nbin_ever_made_index = 0
-        test_bin_number = opts.n_bins_max
-        integer_test_bin_number = int(test_bin_number)
+        bin_num_total = 0
         number_of_mergers = 0
         int_n_timesteps = int(opts.number_of_timesteps)
         frac_bin_retro = opts.frac_bin_retro
-        number_of_stars_bin_properties = len(binary_stars_field_names.split())+1
-        integer_stars_nbinprop = int(number_of_stars_bin_properties)
-        bin_stars_index = 0
-        nbin_stars_ever_made_index = 0
-        test_bin_stars_number = opts.n_bins_max
-        integer_test_bin_stars_number = int(test_bin_stars_number)
-        number_of_stars_mergers = 0
-        # Set up EMRI output array with properties we want to record (iteration, time, R,M,e,h_char,f_gw)
         
+        # Set up EMRI output array with properties we want to record (iteration, time, R,M,e,h_char,f_gw)
         num_of_emri_properties = 7
         nemri = 0
 
-        #Set up BBH gw array with properties we want to record (iteration, time, sep, Mb, eb(around c.o.m.),h_char,f_gw)
-        #Set up empty list of indices of BBH to track
+        # Set up BBH gw array with properties we want to record (iteration, time, sep, Mb, eb(around c.o.m.),h_char,f_gw)
+        # Set up empty list of indices of BBH to track
         bbh_gw_indices = []
         num_of_bbh_gw_properties = 7
         nbbhgw = 0
@@ -537,29 +377,19 @@ def main():
 
         # Set up empty initial Binary array
         # Initially all zeros, then add binaries plus details as appropriate
-        binary_bh_array = np.zeros((integer_nbinprop,integer_test_bin_number))
-        #binary_blackholes = AGNBinaryBlackHole()
-        #print(binary_blackholes.return_params())
-        #print(ff)
-        binary_stars_array = np.zeros((integer_stars_nbinprop,integer_test_bin_stars_number))
-        # Set up empty initial Binary gw array. Initially all zeros, but records gw freq and strain for all binaries ever made at each timestep, including ones that don't merge or are ionized
-        gw_data_array =np.zeros((int_n_timesteps,integer_test_bin_number))
+        binary_bh_array = np.zeros((bin_properties_num, opts.n_bins_max))
+
         # Set up normalization for t_gw (SF: I do not like this way of handling, flag for update)
         norm_t_gw = tgw.normalize_tgw(opts.mass_smbh)
         print("Scale of t_gw (yrs)=", norm_t_gw)
-    
+
         # Set up merger array (identical to binary array)
-        merger_array = np.zeros((integer_nbinprop,integer_test_bin_number))
-        merger_stars_array = np.zeros((integer_stars_nbinprop,integer_test_bin_stars_number))
+        merger_array = np.zeros((bin_properties_num, opts.n_bins_max))
 
         # Set up output array (mergerfile)
-        nprop_mergers=len(mergerfile.names_rec)
-        integer_nprop_merge=int(nprop_mergers)
-        merged_bh_array = np.zeros((integer_nprop_merge,integer_test_bin_number))
-
-        nprop_stars_mergers=len(mergerfile.names_rec)
-        integer_nprop_stars_merge=int(nprop_stars_mergers)
-        merged_stars_array = np.zeros((integer_nprop_stars_merge,integer_test_bin_stars_number))
+        nprop_mergers = len(mergerfile.names_rec)
+        integer_nprop_merge = int(nprop_mergers)
+        merged_bh_array = np.zeros((integer_nprop_merge, opts.n_bins_max))
 
         # Multiple AGN episodes:
         # If you want to use the output of a previous AGN simulation as an input to another AGN phase
@@ -568,103 +398,51 @@ def main():
         # Initial orb ecc is prior_ecc_factor*uniform[0,0.99]=[0,0.33] for prior_ecc_factor=0.3 (default)
         # SF: No promises this handles retrograde orbiters correctly yet
         if opts.prior_agn == 1.0:
-            
+
             prior_radii, prior_masses, prior_spins, prior_spin_angles, prior_gens \
                 = ReadInputs.ReadInputs_prior_mergers()
-            
-            #num_of_progrades = prograde_bh_locations.size
+
             num_of_progrades = prograde_blackholes.orbit_a.size
 
-            prior_indices = setupdiskblackholes.setup_prior_blackholes_indices(num_of_progrades,prior_radii)
+            prior_indices = setupdiskblackholes.setup_prior_blackholes_indices(num_of_progrades, prior_radii)
             prior_indices = prior_indices.astype('int32')
-
-            #prograde_bh_locations = prior_radii[prior_indices]
-            #prograde_bh_masses = prior_masses[prior_indices]
-            #prograde_bh_spins = prior_spins[prior_indices]
-            #prograde_bh_spin_angles = prior_spin_angles[prior_indices]
-            #prograde_bh_generations = prior_gens[prior_indices]
-
             prograde_blackholes.keep_objects(prior_indices)
 
-            """ print("prior indices",prior_indices)
-            print("prior locations",prograde_bh_locations) 
-            print("prior gens",prograde_bh_generations)
+            print("prior indices", prior_indices)
+            print("prior locations", prograde_blackholes.orbit_a) 
+            print("prior gens", prograde_blackholes.generations)
             prior_ecc_factor = 0.3
-            prograde_bh_orb_ecc = setupdiskblackholes.setup_disk_blackholes_eccentricity_uniform_modified(prior_ecc_factor,num_of_progrades)
-            print("prior ecc",prograde_bh_orb_ecc) """
-
-            print("prior indices",prior_indices)
-            print("prior locations",prograde_blackholes.orbit_a) 
-            print("prior gens",prograde_blackholes.generations)
-            prior_ecc_factor = 0.3
-            prograde_blackholes.orbit_e = setupdiskblackholes.setup_disk_blackholes_eccentricity_uniform_modified(prior_ecc_factor,num_of_progrades)
-            print("prior ecc",prograde_blackholes.orbit_e)
-
-            
+            prograde_blackholes.orbit_e = setupdiskblackholes.setup_disk_blackholes_eccentricity_uniform_modified(prior_ecc_factor, num_of_progrades)
+            print("prior ecc", prograde_blackholes.orbit_e)
+  
         # Start Loop of Timesteps
         print("Start Loop!")
         time_passed = initial_time
-        print("Initial Time(yrs) = ",time_passed)
+        print("Initial Time(yrs) = ", time_passed)
 
         n_its = 0
         n_mergers_so_far = 0
-        n_stars_mergers_so_far = 0
         n_timestep_index = 0
-        n_merger_limit = 1e4
 
         while time_passed < final_time:
-            # Record 
-            if not(opts.no_snapshots):
-                #n_bh_out_size = len(prograde_bh_locations)
-                n_bh_out_size_agnobj = len(prograde_blackholes.orbit_a)
-                #print('aaa')
-                #print(len(prograde_bh_locations),len(prograde_blackholes.orbit_a))
-
-                n_stars_out_size = len(prograde_stars.orbit_a)
-
-                #n_bh_r_out_size = len(retrograde_bh_locations)
-                n_bh_r_out_size_agnobj = len(retrograde_blackholes.orbit_a)
-
-
-                #svals = list(map( lambda x: x.shape,[prograde_bh_locations, prograde_bh_masses, prograde_bh_spins, prograde_bh_spin_angles, prograde_bh_orb_ecc, prograde_bh_generations[:n_bh_out_size]]))
-                # Single output prograde:  does work
-                #np.savetxt(
-                #    os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_bh_single_{n_timestep_index}.dat"),
-                #    np.c_[prograde_bh_locations.T, prograde_bh_masses.T, prograde_bh_spins.T, prograde_bh_spin_angles.T, prograde_bh_orb_ecc.T, prograde_bh_orb_incl.T, prograde_bh_generations[:n_bh_out_size].T],
-                #    header="r_bh m a theta ecc inc gen"
-                #)
-                # Single output retrograde:
-                #np.savetxt(
-                #    os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_bh_single_retro_{n_timestep_index}.dat"),
-                #    np.c_[retrograde_bh_locations.T, retrograde_bh_masses.T, retrograde_bh_spins.T, retrograde_bh_spin_angles.T, retrograde_bh_orb_ecc.T, retrograde_bh_orb_incl.T, retrograde_bh_generations[:n_bh_r_out_size].T],
-                #    header="r_bh m a theta ecc inc gen"
-                #)
+            # Record
+            if not (opts.no_snapshots):
 
                 prograde_blackholes.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_bh_single_{n_timestep_index}_agnobject.dat"))
                 retrograde_blackholes.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_bh_single_retro_{n_timestep_index}_agnobject.dat"))
                 prograde_stars.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_stars_single_{n_timestep_index}_agnobject.dat"))
                 retrograde_stars.to_file(os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_stars_single_retro_{n_timestep_index}_agnobject.dat"))
                 
-                # np.savetxt(os.path.join(work_directory, "output_bh_single_{}.dat".format(n_timestep_index)), np.c_[prograde_bh_locations.T, prograde_bh_masses.T, prograde_bh_spins.T, prograde_bh_spin_angles.T, prograde_bh_orb_ecc.T, prograde_bh_generations[:n_bh_out_size].T], header="r_bh m a theta ecc gen")
                 # Binary output: does not work
                 np.savetxt(
                     os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_bh_binary_{n_timestep_index}.dat"),
-                    binary_bh_array[:,:n_mergers_so_far+1].T,
+                    binary_bh_array[:, :n_mergers_so_far+1].T,
                     header=binary_field_names
                 )
 
+                n_timestep_index += 1
 
-                # np.savetxt(os.path.join(work_directory, "output_bh_single_{}.dat".format(n_timestep_index)), np.c_[prograde_bh_locations.T, prograde_bh_masses.T, prograde_bh_spins.T, prograde_bh_spin_angles.T, prograde_bh_orb_ecc.T, prograde_bh_generations[:n_bh_out_size].T], header="r_bh m a theta ecc gen")
-                # Binary output: does not work
-                np.savetxt(
-                    os.path.join(opts.work_directory, f"run{iteration_zfilled_str}/output_stars_binary_{n_timestep_index}.dat"),
-                    binary_stars_array[:,:n_stars_mergers_so_far+1].T,
-                    header=binary_stars_field_names
-                )
-                # np.savetxt(os.path.join(work_directory, "output_bh_binary_{}.dat".format(n_timestep_index)), binary_bh_array[:,:n_mergers_so_far+1].T, header=binary_field_names)
-                n_timestep_index +=1
-
-            #Order of operations:        
+            # Order of operations:        
             # No migration until orbital eccentricity damped to e_crit 
             # 1. check orb. eccentricity to see if any prograde_bh_location BH have orb. ecc. <e_crit.
             #    Create array prograde_bh_location_ecrit for those (mask prograde_bh_locations?)
@@ -675,37 +453,17 @@ def main():
             # Migrate
             # First if feedback present, find ratio of feedback heating torque to migration torque
             if opts.feedback > 0:
-                #ratio_heat_mig_torques = feedback_hankla21.feedback_hankla(
-                #    prograde_bh_locations, surf_dens_func, opts.frac_Eddington_ratio, opts.alpha)
                 ratio_heat_mig_torques_agnobj = feedback_hankla21.feedback_hankla(
-                    prograde_blackholes.orbit_a, surf_dens_func, opts.frac_Eddington_ratio, opts.alpha)
+                    prograde_blackholes.orbit_a, disk_surface_density, opts.frac_Eddington_ratio, opts.alpha)
             else:
-                #ratio_heat_mig_torques = np.ones(len(prograde_bh_locations))
                 ratio_heat_mig_torques_agnobj = np.ones(len(prograde_blackholes.orbit_a))
 
-            #print(ratio_heat_mig_torques == ratio_heat_mig_torques_agnobj)
-            #now for stars
-            #if opts.feedback > 0:
-            #    ratio_heat_mig_stars_torques = feedback_hankla21.feedback_hankla(
-            #        prograde_stars.orbit_a, surf_dens_func, opts.frac_star_Eddington_ratio, opts.alpha)
-            #else:
-            #    ratio_heat_mig_stars_torques = np.ones(len(prograde_stars.orbit_a))
+            # now for stars
             ratio_heat_mig_stars_torques = feedback_hankla21_stars.feedback_hankla_stars(
-                prograde_stars.orbit_a, surf_dens_func, opts.frac_star_Eddington_ratio, opts.alpha
+                prograde_stars.orbit_a, disk_surface_density, opts.frac_star_Eddington_ratio, opts.alpha
             )
+
             # then migrate as usual
-            """ prograde_bh_locations = type1.type1_migration(
-                opts.mass_smbh,
-                prograde_bh_locations,
-                prograde_bh_masses,
-                disk_surface_density,
-                disk_aspect_ratio,
-                opts.timestep,
-                ratio_heat_mig_torques,
-                opts.trap_radius,
-                prograde_bh_orb_ecc,
-                opts.crit_ecc
-            ) """
 
             prograde_blackholes.orbit_a = type1.type1_migration(
                 opts.mass_smbh,
@@ -719,30 +477,16 @@ def main():
                 prograde_blackholes.orbit_e,
                 opts.crit_ecc
             )
-            
-            # Accrete
-            """ prograde_bh_masses = changebhmass.change_mass(
-                prograde_bh_masses,
-                opts.frac_Eddington_ratio,
-                mass_growth_Edd_rate,
-                opts.timestep
-            ) """
 
+            # Accrete
             prograde_blackholes.mass = changebhmass.change_mass(
                 prograde_blackholes.mass,
                 opts.frac_Eddington_ratio,
-                mass_growth_Edd_rate,
+                disk_bh_eddington_mass_growth_rate,
                 opts.timestep
             )
+
             # Spin up
-            """ prograde_bh_spins = changebh.change_spin_magnitudes(
-                prograde_bh_spins,
-                opts.frac_Eddington_ratio,
-                opts.spin_torque_condition,
-                opts.timestep,
-                prograde_bh_orb_ecc,
-                opts.crit_ecc,
-            ) """
             prograde_blackholes.spin = changebh.change_spin_magnitudes(
                 prograde_blackholes.spin,
                 opts.frac_Eddington_ratio,
@@ -751,44 +495,25 @@ def main():
                 prograde_blackholes.orbit_e,
                 opts.crit_ecc,
             )
-            
+
             # Torque spin angle
-            """ prograde_bh_spin_angles = changebh.change_spin_angles(
-                prograde_bh_spin_angles,
-                opts.frac_Eddington_ratio,
-                opts.spin_torque_condition,
-                spin_minimum_resolution,
-                opts.timestep,
-                prograde_bh_orb_ecc,
-                opts.crit_ecc
-            ) """
             prograde_blackholes.spin_angle = changebh.change_spin_angles(
                 prograde_blackholes.spin_angle,
                 opts.frac_Eddington_ratio,
                 opts.spin_torque_condition,
-                spin_minimum_resolution,
+                disk_bh_spin_resolution_min,
                 opts.timestep,
                 prograde_blackholes.orbit_e,
                 opts.crit_ecc
             )
 
             # Damp BH orbital eccentricity
-            """ prograde_bh_orb_ecc = orbital_ecc.orbital_ecc_damping(
-                opts.mass_smbh,
-                prograde_bh_locations,
-                prograde_bh_masses,
-                surf_dens_func,
-                aspect_ratio_func,
-                prograde_bh_orb_ecc,
-                opts.timestep,
-                opts.crit_ecc,
-            ) """
             prograde_blackholes.orbit_e = orbital_ecc.orbital_ecc_damping(
                 opts.mass_smbh,
                 prograde_blackholes.orbit_a,
                 prograde_blackholes.mass,
-                surf_dens_func,
-                aspect_ratio_func,
+                disk_surface_density,
+                disk_aspect_ratio,
                 prograde_blackholes.orbit_e,
                 opts.timestep,
                 opts.crit_ecc,
@@ -798,16 +523,6 @@ def main():
             #   note this is dyn friction only, not true 'migration'
             # change retrograde eccentricity (some damping, some pumping)
             # damp orbital inclination
-            """ retrograde_bh_orb_ecc, retrograde_bh_locations, retrograde_bh_orb_incl = crude_retro_evol.crude_retro_bh(
-                opts.mass_smbh,
-                retrograde_bh_masses,
-                retrograde_bh_locations,
-                retrograde_bh_orb_ecc,
-                retrograde_bh_orb_incl,
-                retrograde_bh_orb_arg_periapse,
-                surf_dens_func,
-                opts.timestep
-            ) """
             retrograde_blackholes.orbit_e, retrograde_blackholes.orbit_a, retrograde_blackholes.orbit_inclination = crude_retro_evol.crude_retro_bh(
                 opts.mass_smbh,
                 retrograde_blackholes.mass,
@@ -815,10 +530,9 @@ def main():
                 retrograde_blackholes.orbit_e,
                 retrograde_blackholes.orbit_inclination,
                 retrograde_blackholes.orbit_arg_periapse,
-                surf_dens_func,
+                disk_surface_density,
                 opts.timestep
             )
-
 
             # and now stars
 
@@ -840,7 +554,7 @@ def main():
             prograde_stars.mass = changestarsmass.change_mass(
                 prograde_stars.mass,
                 opts.frac_star_Eddington_ratio,
-                mass_growth_Edd_rate, #do we need to alter this for stars?
+                disk_bh_eddington_mass_growth_rate, #do we need to alter this for stars?
                 opts.timestep
             )
             # Spin up
@@ -852,14 +566,13 @@ def main():
                 prograde_stars.orbit_e,
                 opts.crit_ecc,
             )
-            
-            
+
             # Torque spin angle
             prograde_stars.spin_angle = changestars.change_spin_angles(
                 prograde_stars.spin_angle,
                 opts.frac_star_Eddington_ratio,
                 opts.spin_torque_condition,
-                spin_minimum_resolution,
+                disk_bh_spin_resolution_min,
                 opts.timestep,
                 prograde_stars.orbit_e,
                 opts.crit_ecc
@@ -870,8 +583,8 @@ def main():
                 opts.mass_smbh,
                 prograde_stars.orbit_a,
                 prograde_stars.mass,
-                surf_dens_func,
-                aspect_ratio_func,
+                disk_surface_density,
+                disk_aspect_ratio,
                 prograde_stars.orbit_e,
                 opts.timestep,
                 opts.crit_ecc,
@@ -882,42 +595,27 @@ def main():
             # change retrograde eccentricity (some damping, some pumping)
             # damp orbital inclination
             
-            """ retrograde_stars.orbit_e, retrograde_stars.orbit_a, retrograde_stars.orbit_inclination = crude_retro_evol.crude_retro_bh(
-                opts.mass_smbh,
-                retrograde_stars.mass,
-                retrograde_stars.orbit_a,
-                retrograde_stars.orbit_e,
-                retrograde_stars.orbit_inclination,
-                retrograde_stars.orbit_arg_periapse,
-                surf_dens_func,
-                opts.timestep
-            ) """
-
+            # This is not working for retrograde stars
+            # retrograde_stars.orbit_e, retrograde_stars.orbit_a, retrograde_stars.orbit_inclination = crude_retro_evol.crude_retro_bh(
+            #     opts.mass_smbh,
+            #     retrograde_stars.mass,
+            #     retrograde_stars.orbit_a,
+            #     retrograde_stars.orbit_e,
+            #     retrograde_stars.orbit_inclination,
+            #     retrograde_stars.orbit_arg_periapse,
+            #     disk_surface_density,
+            #     opts.timestep
+            # )
 
             # Perturb eccentricity via dynamical encounters
             if opts.dynamic_enc > 0:
-                """ prograde_bh_locn_orb_ecc = dynamics.circular_singles_encounters_prograde(
-                    rng,
-                    opts.mass_smbh,
-                    prograde_bh_locations,
-                    prograde_bh_masses,
-                    surf_dens_func,
-                    aspect_ratio_func,
-                    prograde_bh_orb_ecc,
-                    opts.timestep,
-                    opts.crit_ecc,
-                    opts.de,
-                )
-                prograde_bh_locations = prograde_bh_locn_orb_ecc[0][0]
-                prograde_bh_orb_ecc = prograde_bh_locn_orb_ecc[1][0] """
-                
                 prograde_bh_locn_orb_ecc_agnobj = dynamics.circular_singles_encounters_prograde(
                     rng,
                     opts.mass_smbh,
                     prograde_blackholes.orbit_a,
                     prograde_blackholes.mass,
-                    surf_dens_func,
-                    aspect_ratio_func,
+                    disk_surface_density,
+                    disk_aspect_ratio,
                     prograde_blackholes.orbit_e,
                     opts.timestep,
                     opts.crit_ecc,
@@ -931,8 +629,8 @@ def main():
                     opts.mass_smbh,
                     prograde_stars.orbit_a,
                     prograde_stars.mass,
-                    surf_dens_func,
-                    aspect_ratio_func,
+                    disk_surface_density,
+                    disk_aspect_ratio,
                     prograde_stars.orbit_e,
                     opts.timestep,
                     opts.crit_ecc,
@@ -943,20 +641,19 @@ def main():
             
             # Do things to the binaries--first check if there are any:
             if bin_index > 0:
-                #First check that binaries are real. Discard any columns where the location or the mass is 0.
+                # First check that binaries are real. Discard any columns where the location or the mass is 0.
                 # SF: I believe this step is handling an error checking thing that may have been
                 #     set up in the previous timeloop if e.g. a binary either merged or was ionized?
                 #     Please explain what this is and how it works right here?
-                reality_flag = evolve.reality_check(binary_bh_array, bin_index,integer_nbinprop)
+                reality_flag = evolve.reality_check(binary_bh_array, bin_index, bin_properties_num)
                 if reality_flag >= 0:
                    #One of the key parameter (mass or location is zero). Not real. Delete binary. Remove column at index = ionization_flag
-                    binary_bh_array = np.delete(binary_bh_array,reality_flag,1) 
+                    binary_bh_array = np.delete(binary_bh_array, reality_flag, 1)
                     bin_index = bin_index - 1
                 else:
-                #If there are still binaries after this, evolve them.
-                #if bin_index > 0:
+                    # If there are still binaries after this, evolve them.
                     # If there are binaries, evolve them
-                    #Damp binary orbital eccentricity
+                    # Damp binary orbital eccentricity
                     binary_bh_array = orbital_ecc.orbital_bin_ecc_damping(
                         opts.mass_smbh,
                         binary_bh_array,
@@ -966,14 +663,14 @@ def main():
                         opts.crit_ecc
                     )
                     if (opts.dynamic_enc > 0):
-                    # Harden/soften binaries via dynamical encounters
-                    #Harden binaries due to encounters with circular singletons (e.g. Leigh et al. 2018)
+                        # Harden/soften binaries via dynamical encounters
+                        # Harden binaries due to encounters with circular singletons (e.g. Leigh et al. 2018)
                         binary_bh_array = dynamics.circular_binaries_encounters_circ_prograde(
                             rng,
                             opts.mass_smbh,
-                            prograde_blackholes.orbit_a, #prograde_bh_locations,
-                            prograde_blackholes.mass, #prograde_bh_masses,
-                            prograde_blackholes.orbit_e, #prograde_bh_orb_ecc ,
+                            prograde_blackholes.orbit_a,
+                            prograde_blackholes.mass,
+                            prograde_blackholes.orbit_e,
                             opts.timestep,
                             opts.crit_ecc,
                             opts.de,
@@ -981,41 +678,39 @@ def main():
                             bin_index
                         )
 
-                        #Soften/ ionize binaries due to encounters with eccentric singletons
+                        # Soften/ ionize binaries due to encounters with eccentric singletons
                         binary_bh_array = dynamics.circular_binaries_encounters_ecc_prograde(
                             rng,
                             opts.mass_smbh,
-                            prograde_blackholes.orbit_a, #prograde_bh_locations,
-                            prograde_blackholes.mass, #prograde_bh_masses,
-                            prograde_blackholes.orbit_e, #prograde_bh_orb_ecc ,
+                            prograde_blackholes.orbit_a,
+                            prograde_blackholes.mass,
+                            prograde_blackholes.orbit_e,
                             opts.timestep,
                             opts.crit_ecc,
                             opts.de,
                             binary_bh_array,
                             bin_index
-                        ) 
+                        )
                     # Harden binaries via gas
-                    #Choose between Baruteau et al. 2011 gas hardening, or gas hardening from LANL simulations. To do: include dynamical hardening/softening from encounters
+                    # Choose between Baruteau et al. 2011 gas hardening, or gas hardening from LANL simulations. To do: include dynamical hardening/softening from encounters
                     binary_bh_array = baruteau11.bin_harden_baruteau(
                         binary_bh_array,
-                        integer_nbinprop,
+                        bin_properties_num,
                         opts.mass_smbh,
                         opts.timestep,
                         norm_t_gw,
                         bin_index,
                         time_passed,
                     )
-                    #print("Harden binary")
                     #Check closeness of binary. Are black holes at merger condition separation
                     binary_bh_array = evolve.contact_check(binary_bh_array, bin_index, opts.mass_smbh)
-                    #print("Time passed = ", time_passed)
                     # Accrete gas onto binary components
                     binary_bh_array = evolve.change_bin_mass(
                         binary_bh_array,
                         opts.frac_Eddington_ratio,
-                        mass_growth_Edd_rate,
+                        disk_bh_eddington_mass_growth_rate,
                         opts.timestep,
-                        integer_nbinprop,
+                        bin_properties_num,
                         bin_index
                     )
                     # Spin up binary components
@@ -1024,7 +719,7 @@ def main():
                         opts.frac_Eddington_ratio,
                         opts.spin_torque_condition,
                         opts.timestep,
-                        integer_nbinprop,
+                        bin_properties_num,
                         bin_index
                     )
                     # Torque angle of binary spin components
@@ -1032,9 +727,9 @@ def main():
                         binary_bh_array,
                         opts.frac_Eddington_ratio,
                         opts.spin_torque_condition,
-                        spin_minimum_resolution,
+                        disk_bh_spin_resolution_min,
                         opts.timestep,
-                        integer_nbinprop,
+                        bin_properties_num,
                         bin_index
                     )
 
@@ -1060,23 +755,13 @@ def main():
                             binary_bh_array,
                             opts.timestep
                         )
-                        #binary_bh_array = disk_capture.orb_inc_damping.orb_inc_damping(
-                        #    opts.mass_smbh,
-                        #    retrograde_bh_locations,
-                        #    retrograde_bh_masses,
-                        #    retrograde_bh_orb_ecc,
-                        #    retrograde_bh_orb_inc,
-                        #    retro_arg_periapse,
-                        #    timestep,disk_surf_model
-                        #)    
-                    
-                    #Migrate binaries
+
+                    # Migrate binaries
                     # First if feedback present, find ratio of feedback heating torque to migration torque
-                    #print("feedback",feedback)
                     if opts.feedback > 0:
                         ratio_heat_mig_torques_bin_com = evolve.com_feedback_hankla(
                             binary_bh_array,
-                            surf_dens_func,
+                            disk_surface_density,
                             opts.frac_Eddington_ratio,
                             opts.alpha
                         )
@@ -1097,27 +782,26 @@ def main():
 
                     # Test to see if any binaries separation is O(1r_g)
                     # If so, track them for GW freq, strain.
-                    #Minimum BBH separation (in units of r_g)
+                    # Minimum BBH separation (in units of r_g)
                     min_bbh_gw_separation = 2.0
                     # If there are binaries AND if any separations are < min_bbh_gw_separation
-                    bbh_gw_indices = np.where( (binary_bh_array[8,:] < min_bbh_gw_separation) & (binary_bh_array[8,:]>0))
+                    bbh_gw_indices = np.where((binary_bh_array[8,:] < min_bbh_gw_separation) & (binary_bh_array[8,:]>0))
                     
                     # If bbh_indices exists (ie is not empty)
                     if bbh_gw_indices:
                         #1st time around.
                         if num_bbh_gw_tracked == 0:
-                            old_bbh_gw_freq = 9.e-7*np.ones(np.size(bbh_gw_indices,1))        
+                            old_bbh_gw_freq = 9.e-7*np.ones(np.size(bbh_gw_indices, 1))    
                         if num_bbh_gw_tracked > 0:
                             old_bbh_gw_freq = bbh_gw_freq
 
-                        num_bbh_gw_tracked = np.size(bbh_gw_indices,1)
-                        #print("N_tracked",num_bbh_gw_tracked)
+                        num_bbh_gw_tracked = np.size(bbh_gw_indices, 1)
                         nbbhgw = nbbhgw + num_bbh_gw_tracked
                         
-                        #Now update BBH & generate NEW frequency & evolve  
+                        # Now update BBH & generate NEW frequency & evolve  
                         
-                        bbh_gw_strain,bbh_gw_freq = evolve.bbh_gw_params(
-                            binary_bh_array, 
+                        bbh_gw_strain, bbh_gw_freq = evolve.bbh_gw_params(
+                            binary_bh_array,
                             bbh_gw_indices,
                             opts.mass_smbh,
                             opts.timestep,
@@ -1126,11 +810,6 @@ def main():
                         
                         if num_bbh_gw_tracked == 1:        
                             index = bbh_gw_indices[0]
-                            #print("index",index)
-                            # If index is empty (=[]) then assume we're tracking 1 BBH only, i.e. the 0th element.
-                            #if not index:
-                            #   index = 0
-                               #print("actual index used",index)
 
                             temp_bbh_gw_array[0] = iteration
                             temp_bbh_gw_array[1] = time_passed
@@ -1139,16 +818,16 @@ def main():
                             temp_bbh_gw_array[4] = binary_bh_array[13,index]
                             temp_bbh_gw_array[5] = bbh_gw_strain
                             temp_bbh_gw_array[6] = bbh_gw_freq
-                            
-                            bbh_gw_array = np.vstack((bbh_gw_array,temp_bbh_gw_array))
-                            
+
+                            bbh_gw_array = np.vstack((bbh_gw_array, temp_bbh_gw_array))
+
                         if num_bbh_gw_tracked > 1:
                             index = 0
                             for i in range(0,num_bbh_gw_tracked-1):
-                                
+
                                 index = bbh_gw_indices[0][i]
-                            
-                                #Record: iteration, time_passed, bin sep, bin_mass, bin_ecc(around c.o.m.),bin strain, bin freq       
+
+                                # Record: iteration, time_passed, bin sep, bin_mass, bin_ecc(around c.o.m.),bin strain, bin freq       
                                 temp_bbh_gw_array[0] = iteration
                                 temp_bbh_gw_array[1] = time_passed
                                 temp_bbh_gw_array[2] = binary_bh_array[8,index]
@@ -1157,10 +836,9 @@ def main():
                                 temp_bbh_gw_array[5] = bbh_gw_strain[i]
                                 temp_bbh_gw_array[6] = bbh_gw_freq[i]
                                 #print("temp_bbh_gw_array",temp_bbh_gw_array)
-                                bbh_gw_array = np.vstack((bbh_gw_array,temp_bbh_gw_array))
+                                bbh_gw_array = np.vstack((bbh_gw_array, temp_bbh_gw_array))
                                 #print("bbh_gw_array",bbh_gw_array)
-                            
-                    
+
                     #Evolve GW frequency and strain
                     binary_bh_array = evolve.evolve_gw(
                         binary_bh_array,
@@ -1177,12 +855,6 @@ def main():
                     # Default is ionization flag = -1
                     # If ionization flag >=0 then ionize bin_array[ionization_flag,;]
                     if ionization_flag >= 0:
-                        #Comment out for now
-                        #print("Ionize binary here!")
-                        #print("Number of binaries before ionizing",bin_index)
-                        #print("Index of binary to be ionized=",ionization_flag )
-                        #print("Bin sep.,Bin a_com",binary_bh_array[8,ionization_flag],binary_bh_array[9,ionization_flag])
-
                         # Append 2 new BH to arrays of single BH locations, masses, spins, spin angles & gens
                         # For now add 2 new orb ecc term of 0.01. TO DO: calculate v_kick and resulting perturbation to orb ecc.
                         new_location_1 = binary_bh_array[0,ionization_flag]
@@ -1200,67 +872,38 @@ def main():
                         new_orb_inc_1 = 0.0
                         new_orb_inc_2 = 0.0
 
-
-                        """ prograde_bh_locations = np.append(prograde_bh_locations,new_location_1)
-                        prograde_bh_locations = np.append(prograde_bh_locations,new_location_2)
-                        prograde_bh_masses = np.append(prograde_bh_masses,new_mass_1)
-                        prograde_bh_masses = np.append(prograde_bh_masses,new_mass_2)
-                        prograde_bh_spins = np.append(prograde_bh_spins,new_spin_1)
-                        prograde_bh_spins = np.append(prograde_bh_spins,new_spin_2)
-                        prograde_bh_spin_angles = np.append(prograde_bh_spin_angles,new_spin_angle_1)
-                        prograde_bh_spin_angles = np.append(prograde_bh_spin_angles,new_spin_angle_2)
-                        prograde_bh_generations = np.append(prograde_bh_generations,new_gen_1)
-                        prograde_bh_generations = np.append(prograde_bh_generations,new_gen_2)
-                        prograde_bh_orb_ecc = np.append(prograde_bh_orb_ecc,new_orb_ecc_1)
-                        prograde_bh_orb_ecc = np.append(prograde_bh_orb_ecc,new_orb_ecc_2)
-                        prograde_bh_orb_incl = np.append(prograde_bh_orb_incl,new_orb_inc_1)
-                        prograde_bh_orb_incl = np.append(prograde_bh_orb_incl,new_orb_inc_2)
-                        #Sort new prograde bh_locations
-                        sorted_prograde_bh_locations=np.sort(prograde_bh_locations) """
-
                         # does not have orb_arg_periapse or orb_ang_mom??
                         # orb_ang_mom is only used to separate the pro and retrograde BH so this makes sense for now
-                        prograde_blackholes.add_blackholes(new_mass = ([new_mass_1, new_mass_2]),
-                                                           new_spin = ([new_spin_1, new_spin_2]),
-                                                           new_spin_angle = ([new_spin_angle_1, new_spin_angle_2]),
-                                                           new_orb_a = ([new_location_1, new_location_2]),
-                                                           new_generation = ([new_gen_1, new_gen_2]),
-                                                           new_orb_e = ([new_orb_ecc_1, new_orb_ecc_2]),
-                                                           new_orb_inclination = ([new_orb_inc_1, new_orb_inc_2]),
-                                                           new_orb_ang_mom  = [1,1],
-                                                           new_orb_arg_periapse = [1.0,1.0],
-                                                           new_id_num = [prograde_blackholes.id_num.max()+1, prograde_blackholes.id_num.max()+2]
+                        prograde_blackholes.add_blackholes(new_mass=([new_mass_1, new_mass_2]),
+                                                           new_spin=([new_spin_1, new_spin_2]),
+                                                           new_spin_angle=([new_spin_angle_1, new_spin_angle_2]),
+                                                           new_orb_a=([new_location_1, new_location_2]),
+                                                           new_generation=([new_gen_1, new_gen_2]),
+                                                           new_orb_e=([new_orb_ecc_1, new_orb_ecc_2]),
+                                                           new_orb_inclination=([new_orb_inc_1, new_orb_inc_2]),
+                                                           new_orb_ang_mom=[1, 1],
+                                                           new_orb_arg_periapse=[1.0, 1.0],
+                                                           new_id_num=[prograde_blackholes.id_num.max()+1, prograde_blackholes.id_num.max()+2]
                                                            )
-                        #prograde_blackholes.sort(prograde_blackholes.orbit_a)
-                        #Delete binary. Remove column at index = ionization_flag
-                        binary_bh_array = np.delete(binary_bh_array, ionization_flag, 1)
-                        #Reduce number of binaries
-                        bin_index = bin_index - 1
-                        #Comment out for now
-                        #print("Number of binaries remaining", bin_index)
 
-                    #Test dynamics of encounters between binaries and eccentric singleton orbiters
-                    #dynamics_binary_array = dynamics.circular_binaries_encounters_prograde(rng,opts.mass_smbh, prograde_bh_locations, prograde_bh_masses, disk_surf_model, disk_aspect_ratio_model, bh_orb_ecc, timestep, opts.crit_ecc, opts.de,norm_tgw,bin_array,bindex,integer_nbinprop)         
-                
+                        # Delete binary. Remove column at index = ionization_flag
+                        binary_bh_array = np.delete(binary_bh_array, ionization_flag, 1)
+                        # Reduce number of binaries
+                        bin_index = bin_index - 1
+
+                    # Test dynamics of encounters between binaries and eccentric singleton orbiters
+                    # dynamics_binary_array = dynamics.circular_binaries_encounters_prograde(rng,opts.mass_smbh, prograde_bh_locations, prograde_bh_masses, disk_surf_model, disk_aspect_ratio_model, bh_orb_ecc, timestep, opts.crit_ecc, opts.de,norm_tgw,bin_array,bindex,bin_properties_num)         
+
                     if opts.verbose:
                         print(merger_flags)
                     merger_indices = np.where(merger_flags < 0.0)
-                    if isinstance(merger_indices,tuple):
+                    if isinstance(merger_indices, tuple):
                         merger_indices = merger_indices[0]
                     if opts.verbose:
                         print(merger_indices)
                     #print(binary_bh_array[:,merger_indices])
                     if any_merger > 0:
                         for i in range(any_merger):
-                            #print("Merger!")
-                            # send properties of merging objects to static variable names
-                            #mass_1[i] = binary_bh_array[2,merger_indices[i]]
-                            #mass_2[i] = binary_bh_array[3,merger_indices[i]]
-                            #spin_1[i] = binary_bh_array[4,merger_indices[i]]
-                            #spin_2[i] = binary_bh_array[5,merger_indices[i]]
-                            #angle_1[i] = binary_bh_array[6,merger_indices[i]]
-                            #angle_2[i] = binary_bh_array[7,merger_indices[i]]
-                            #bin_ang_mom[i] = binary_bh_array[16,merger_indices]
                             if time_passed <= opts.timestep:
                                 print("time_passed,loc1,loc2",time_passed,binary_bh_array[0,merger_indices[i]],binary_bh_array[1,merger_indices[i]])
 
@@ -1310,23 +953,17 @@ def main():
                                 merged_chi_p,
                                 time_passed
                             )
-                        #    print("Merger properties (M_f,a_f,Chi_eff,Chi_p,theta1,theta2", merged_mass, merged_spin, merged_chi_eff, merged_chi_p,binary_bh_array[6,merger_indices[i]], binary_bh_array[7,merger_indices[i]],)
                         # do another thing
                         merger_array[:,merger_indices] = binary_bh_array[:,merger_indices]
                         #Reset merger marker to zero
-                        #n_mergers_so_far=int(number_of_mergers)
                         #Remove merged binary from binary array. Delete column where merger_indices is the label.
-                        #print("!Merger properties!",binary_bh_array[:,merger_indices],merger_array[:,merger_indices],merged_bh_array)
                         binary_bh_array=np.delete(binary_bh_array,merger_indices,1)
                 
                         #Reduce number of binaries by number of mergers
                         bin_index = bin_index - len(merger_indices)
-                        #print("bin index",bin_index)
                         #Find relevant properties of merged BH to add to single BH arrays
                         num_mergers_this_timestep = len(merger_indices)
                 
-                        #print("num mergers this timestep",num_mergers_this_timestep)
-                        #print("n_mergers_so_far",n_mergers_so_far)    
                         for i in range (0, num_mergers_this_timestep):
                             merged_bh_com = merged_bh_array[0,n_mergers_so_far + i]
                             merged_mass = merged_bh_array[1,n_mergers_so_far + i]
@@ -1334,39 +971,25 @@ def main():
                             merged_spin_angle = merged_bh_array[4,n_mergers_so_far + i]
                         #New bh generation is max of generations involved in merger plus 1
                             merged_bh_gen = np.maximum(merged_bh_array[11,n_mergers_so_far + i],merged_bh_array[12,n_mergers_so_far + i]) + 1.0 
-                        #print("Merger at=",merged_bh_com,merged_mass,merged_spin,merged_spin_angle,merged_bh_gen)
                         # Add to number of mergers
                         n_mergers_so_far += len(merger_indices)
                         number_of_mergers += len(merger_indices)
 
                         # Append new merged BH to arrays of single BH locations, masses, spins, spin angles & gens
                         # For now add 1 new orb ecc term of 0.01. TO DO: calculate v_kick and resulting perturbation to orb ecc.
-                        """ prograde_bh_locations = np.append(prograde_bh_locations,merged_bh_com)
-                        prograde_bh_masses = np.append(prograde_bh_masses,merged_mass)
-                        prograde_bh_spins = np.append(prograde_bh_spins,merged_spin)
-                        prograde_bh_spin_angles = np.append(prograde_bh_spin_angles,merged_spin_angle)
-                        prograde_bh_generations = np.append(prograde_bh_generations,merged_bh_gen)
-                        prograde_bh_orb_ecc = np.append(prograde_bh_orb_ecc,0.01)
-                        prograde_bh_orb_incl = np.append(prograde_bh_orb_incl,0.0)
-                        sorted_prograde_bh_locations=np.sort(prograde_bh_locations) """
-
-                        #no periapse
-                        prograde_blackholes.add_blackholes(new_mass = [merged_mass],
-                                                           new_orb_a = [merged_bh_com],
-                                                           new_spin = [merged_spin],
-                                                           new_spin_angle = [merged_spin_angle],
-                                                           new_orb_inclination = [0.0],
-                                                           new_orb_ang_mom = [1.0],
-                                                           new_orb_e = [0.01],
-                                                           new_generation = [merged_bh_gen],
-                                                           new_orb_arg_periapse = [1.],
-                                                           new_id_num = [prograde_blackholes.id_num.max()+1])
+                        # no periapse
+                        prograde_blackholes.add_blackholes(new_mass=[merged_mass],
+                                                           new_orb_a=[merged_bh_com],
+                                                           new_spin=[merged_spin],
+                                                           new_spin_angle=[merged_spin_angle],
+                                                           new_orb_inclination=[0.0],
+                                                           new_orb_ang_mom=[1.0],
+                                                           new_orb_e=[0.01],
+                                                           new_generation=[merged_bh_gen],
+                                                           new_orb_arg_periapse=[1.],
+                                                           new_id_num=[prograde_blackholes.id_num.max()+1])
                         if opts.verbose:
-                            #print("New BH locations", sorted_prograde_bh_locations)
                             print("New BH locations", prograde_blackholes.orbit_a)
-                        #print("Merger Flag!")
-                        #print(number_of_mergers)
-                        #print("Time ", time_passed)
                         if opts.verbose:
                             print(merger_array)
                     else:                
@@ -1374,7 +997,6 @@ def main():
                         # do nothing! hardening should happen FIRST (and now it does!)
                         if opts.verbose:
                             if bin_index>0: # verbose:
-                                #print(" BH binaries ", bin_index,  binary_bh_array[:,:int(bin_index)].shape)
                                 print(binary_bh_array[:,:int(bin_index)].T)  # this makes printing work as expected
             else:            
                     if opts.verbose:
@@ -1385,78 +1007,36 @@ def main():
                 #If a close encounter within mutual Hill sphere add a new Binary
 
                 # check which binaries should get made
-            #close_encounters2 = hillsphere.binary_check2(
-            #    prograde_bh_locations, prograde_bh_masses, opts.mass_smbh, prograde_bh_orb_ecc, opts.crit_ecc
-            #)
             close_encounters2 = hillsphere.binary_check2(
                 prograde_blackholes.orbit_a, prograde_blackholes.mass, opts.mass_smbh, prograde_blackholes.orbit_e, opts.crit_ecc
             )
-            close_encounters_agnobj = hillsphere.binary_check2(
-                filing_cabinet.orbit_a[filing_cabinet.direction == 1],
-                filing_cabinet.mass[filing_cabinet.direction == 1],
-                opts.mass_smbh,
-                filing_cabinet.orbit_e[filing_cabinet.direction == 1],
-                opts.crit_ecc
-            )
-            close_encounters_agnobj = hillsphere.binary_check2(
-                prograde_blackholes.orbit_a,
-                prograde_blackholes.mass,
-                opts.mass_smbh,
-                prograde_blackholes.orbit_e,
-                opts.crit_ecc
-            )
-            #print(prograde_bh_locations == prograde_blackholes.orbit_a)
-            #print(close_encounters2)
-            #print(close_encounters_agnobj)
-            #if(len(close_encounters2)>1):
-            #    print(ff)
 
-                #print("Output of close encounters", close_encounters2)
-                # print(close_encounters)
             if np.size(close_encounters2) > 0:
-                    #print("Make binary at time ", time_passed)
-                    #print("shape1",np.shape(close_encounters2)[1])
-                    #print("shape0",np.shape(close_encounters2)[0])
-                    # number of new binaries is length of 2nd dimension of close_encounters2
-                    #number_of_new_bins = np.shape(close_encounters2)[1]
-                    number_of_new_bins = np.shape(close_encounters2)[1]
-                    #print("number of new bins", number_of_new_bins)
-                    # make new binaries
-                    binary_bh_array = add_new_binary.add_to_binary_array2(
-                        rng,
-                        binary_bh_array,
-                        prograde_blackholes.orbit_a, #prograde_bh_locations,
-                        prograde_blackholes.mass, #prograde_bh_masses,
-                        prograde_blackholes.spin, #prograde_bh_spins,
-                        prograde_blackholes.spin_angle, #prograde_bh_spin_angles,
-                        prograde_blackholes.generations, #prograde_bh_generations,
-                        close_encounters2,
-                        bin_index,
-                        frac_bin_retro,
-                        opts.mass_smbh,
-                    )
-                    bin_index = bin_index + number_of_new_bins
-                    #Count towards total of any binary ever made (including those that are ionized)
-                    nbin_ever_made_index = nbin_ever_made_index + number_of_new_bins
-                    #print("Binary array",binary_bh_array[:,0])
-                    # delete corresponding entries for new binary members from singleton arrays
-                    """ prograde_bh_locations = np.delete(prograde_bh_locations, close_encounters2)
-                    prograde_bh_masses = np.delete(prograde_bh_masses, close_encounters2)
-                    prograde_bh_spins = np.delete(prograde_bh_spins, close_encounters2)
-                    prograde_bh_spin_angles = np.delete(prograde_bh_spin_angles, close_encounters2)
-                    prograde_bh_generations = np.delete(prograde_bh_generations, close_encounters2)
-                    prograde_bh_orb_ecc = np.delete(prograde_bh_orb_ecc, close_encounters2)
-                    prograde_bh_orb_incl = np.delete(prograde_bh_orb_incl, close_encounters2) """
-                    #print(close_encounters2)
-                    #print(ff)
-                    #print(close_encounters2)
-                    #print(len(prograde_blackholes.mass))
-                    #print(len(prograde_blackholes.id_num))
-                    prograde_blackholes.remove_objects(idx_remove=close_encounters2)
+                # number of new binaries is length of 2nd dimension of close_encounters2
+                number_of_new_bins = np.shape(close_encounters2)[1]
+                # make new binaries
+                binary_bh_array = add_new_binary.add_to_binary_array2(
+                    rng,
+                    binary_bh_array,
+                    prograde_blackholes.orbit_a,
+                    prograde_blackholes.mass,
+                    prograde_blackholes.spin,
+                    prograde_blackholes.spin_angle,
+                    prograde_blackholes.generations,
+                    close_encounters2,
+                    bin_index,
+                    frac_bin_retro,
+                    opts.mass_smbh,
+                )
+                bin_index = bin_index + number_of_new_bins
+                #Count towards total of any binary ever made (including those that are ionized)
+                bin_num_total = bin_num_total + number_of_new_bins
+                # delete corresponding entries for new binary members from singleton arrays
+                prograde_blackholes.remove_objects(idx_remove=close_encounters2)
 
-                    #Empty close encounters
-                    empty = []
-                    close_encounters2 = np.array(empty)
+                #Empty close encounters
+                empty = []
+                close_encounters2 = np.array(empty)
 
             #After this time period, was there a disk capture via orbital grind-down?
             # To do: What eccentricity do we want the captured BH to have? Right now ecc=0.0? Should it be ecc<h at a?             
@@ -1475,50 +1055,29 @@ def main():
                 bh_capture_gen = [1]
                 bh_capture_orb_ecc = [0.0]
                 bh_capture_orb_incl = [0.0]
-                #print("CAPTURED BH",bh_capture_location,bh_capture_mass,bh_capture_spin,bh_capture_spin_angle)
                 # Append captured BH to existing singleton arrays. Assume prograde and 1st gen BH.
-                #prograde_bh_locations = np.append(prograde_bh_locations,bh_capture_location) 
-                #prograde_bh_masses = np.append(prograde_bh_masses,bh_capture_mass)
-                #prograde_bh_spins = np.append(prograde_bh_spins,bh_capture_spin)
-                #prograde_bh_spin_angles = np.append(prograde_bh_spin_angles,bh_capture_spin_angle) 
-                #prograde_bh_generations = np.append(prograde_bh_generations,bh_capture_gen)
-                #prograde_bh_orb_ecc = np.append(prograde_bh_orb_ecc,bh_capture_orb_ecc)
-                #prograde_bh_orb_incl = np.append(prograde_bh_orb_incl,bh_capture_orb_incl)
-                prograde_blackholes.add_blackholes(new_mass = bh_capture_mass,
-                                                   new_spin = bh_capture_spin,
-                                                   new_spin_angle = bh_capture_spin_angle,
-                                                   new_orb_a = bh_capture_location,
-                                                   new_orb_inclination = bh_capture_orb_incl,
-                                                   new_orb_ang_mom = np.ones(bh_capture_mass.size),
-                                                   new_orb_e = bh_capture_orb_ecc,
-                                                   new_orb_arg_periapse = np.ones(bh_capture_mass.size),
-                                                   new_generation = bh_capture_gen,
-                                                   new_id_num = np.arange(prograde_blackholes.id_num.max()+1,len(bh_capture_mass) + prograde_blackholes.id_num.max()+1,1))
+                prograde_blackholes.add_blackholes(new_mass=bh_capture_mass,
+                                                   new_spin=bh_capture_spin,
+                                                   new_spin_angle=bh_capture_spin_angle,
+                                                   new_orb_a=bh_capture_location,
+                                                   new_orb_inclination=bh_capture_orb_incl,
+                                                   new_orb_ang_mom=np.ones(bh_capture_mass.size),
+                                                   new_orb_e=bh_capture_orb_ecc,
+                                                   new_orb_arg_periapse=np.ones(bh_capture_mass.size),
+                                                   new_generation=bh_capture_gen,
+                                                   new_id_num=np.arange(prograde_blackholes.id_num.max()+1, len(bh_capture_mass) + prograde_blackholes.id_num.max()+1,1))
             
-            # Test if any BH or BBH are in the danger-zone (<mininum_safe_distance, default =50r_g) from SMBH. 
+            # Test if any BH or BBH are in the danger-zone (<mininum_safe_distance, default =50r_g) from SMBH.
             # Potential EMRI/BBH EMRIs.
             # Find prograde BH in inner disk. Define inner disk as <=50r_g. 
-            # Since a 10Msun BH will decay into a 10^8Msun SMBH at 50R_g in ~38Myr and decay time propto a^4. 
+            # Since a 10Msun BH will decay into a 10^8Msun SMBH at 50R_g in ~38Myr and decay time propto a^4.
             # e.g at 25R_g, decay time is only 2.3Myr.
             min_safe_distance = 50.0
-            #inner_disk_indices = np.where(prograde_bh_locations < min_safe_distance)
             inner_disk_indices = np.where(prograde_blackholes.orbit_a < min_safe_distance)
             # adding retros too
-            #retro_inner_disk_indices = np.where(retrograde_bh_locations < min_safe_distance)
             retro_inner_disk_indices = np.where(retrograde_blackholes.orbit_a < min_safe_distance)
-            #retrograde_orb_ang_mom_indices = np.where(bh_orb_ang_mom_indices == -1)
-            #print("inner disk indices",inner_disk_indices)
-            #print(prograde_bh_locations[inner_disk_indices],np.size(inner_disk_indices))
             if np.size(inner_disk_indices) > 0:
                 # Add BH to inner_disk_arrays
-                """ inner_disk_locations = np.append(inner_disk_locations,prograde_bh_locations[inner_disk_indices])
-                inner_disk_masses = np.append(inner_disk_masses,prograde_bh_masses[inner_disk_indices])
-                inner_disk_spins = np.append(inner_disk_spins,prograde_bh_spins[inner_disk_indices])
-                inner_disk_spin_angles = np.append(inner_disk_spin_angles,prograde_bh_spin_angles[inner_disk_indices])
-                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc,prograde_bh_orb_ecc[inner_disk_indices])
-                inner_disk_orb_inc = np.append(inner_disk_orb_inc,prograde_bh_orb_incl[inner_disk_indices])
-                inner_disk_gens = np.append(inner_disk_gens,prograde_bh_generations[inner_disk_indices]) """
-
                 inner_disk_locations = np.append(inner_disk_locations,prograde_blackholes.orbit_a[inner_disk_indices])
                 inner_disk_masses = np.append(inner_disk_masses,prograde_blackholes.mass[inner_disk_indices])
                 inner_disk_spins = np.append(inner_disk_spins,prograde_blackholes.spin[inner_disk_indices])
@@ -1527,47 +1086,22 @@ def main():
                 inner_disk_orb_inc = np.append(inner_disk_orb_inc,prograde_blackholes.orbit_inclination[inner_disk_indices])
                 inner_disk_gens = np.append(inner_disk_gens,prograde_blackholes.generations[inner_disk_indices])
                 #Remove BH from prograde_disk_arrays
-                """ prograde_bh_locations = np.delete(prograde_bh_locations,inner_disk_indices)
-                prograde_bh_masses = np.delete(prograde_bh_masses, inner_disk_indices)
-                prograde_bh_spins = np.delete(prograde_bh_spins, inner_disk_indices)
-                prograde_bh_spin_angles = np.delete(prograde_bh_spin_angles, inner_disk_indices)
-                prograde_bh_orb_ecc = np.delete(prograde_bh_orb_ecc, inner_disk_indices)
-                prograde_bh_orb_incl = np.delete(prograde_bh_orb_incl,inner_disk_indices)
-                prograde_bh_generations = np.delete(prograde_bh_generations,inner_disk_indices) """
-
                 prograde_blackholes.remove_objects(idx_remove=inner_disk_indices)
                 # Empty disk_indices array
-                empty=[]
+                empty = []
                 inner_disk_indices = np.array(empty)
 
             if np.size(retro_inner_disk_indices) > 0:
                 # Add BH to inner_disk_arrays
-                """ inner_disk_locations = np.append(inner_disk_locations,retrograde_bh_locations[retro_inner_disk_indices])
-                inner_disk_masses = np.append(inner_disk_masses,retrograde_bh_masses[retro_inner_disk_indices])
-                inner_disk_spins = np.append(inner_disk_spins,retrograde_bh_spins[retro_inner_disk_indices])
-                inner_disk_spin_angles = np.append(inner_disk_spin_angles,retrograde_bh_spin_angles[retro_inner_disk_indices])
-                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc,retrograde_bh_orb_ecc[retro_inner_disk_indices])
-                inner_disk_orb_inc = np.append(inner_disk_orb_inc,retrograde_bh_orb_incl[retro_inner_disk_indices])
-                inner_disk_gens = np.append(inner_disk_gens,retrograde_bh_generations[retro_inner_disk_indices])"""
+                inner_disk_locations = np.append(inner_disk_locations, retrograde_blackholes.orbit_a[retro_inner_disk_indices])
+                inner_disk_masses = np.append(inner_disk_masses, retrograde_blackholes.mass[retro_inner_disk_indices])
+                inner_disk_spins = np.append(inner_disk_spins, retrograde_blackholes.spin[retro_inner_disk_indices])
+                inner_disk_spin_angles = np.append(inner_disk_spin_angles, retrograde_blackholes.spin_angle[retro_inner_disk_indices])
+                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc, retrograde_blackholes.orbit_e[retro_inner_disk_indices])
+                inner_disk_orb_inc = np.append(inner_disk_orb_inc, retrograde_blackholes.orbit_inclination[retro_inner_disk_indices])
+                inner_disk_gens = np.append(inner_disk_gens, retrograde_blackholes.generations[retro_inner_disk_indices])
                 
-                inner_disk_locations = np.append(inner_disk_locations,retrograde_blackholes.orbit_a[retro_inner_disk_indices])
-                inner_disk_masses = np.append(inner_disk_masses,retrograde_blackholes.mass[retro_inner_disk_indices])
-                inner_disk_spins = np.append(inner_disk_spins,retrograde_blackholes.spin[retro_inner_disk_indices])
-                inner_disk_spin_angles = np.append(inner_disk_spin_angles,retrograde_blackholes.spin_angle[retro_inner_disk_indices])
-                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc,retrograde_blackholes.orbit_e[retro_inner_disk_indices])
-                inner_disk_orb_inc = np.append(inner_disk_orb_inc,retrograde_blackholes.orbit_inclination[retro_inner_disk_indices])
-                inner_disk_gens = np.append(inner_disk_gens,retrograde_blackholes.generations[retro_inner_disk_indices])
-                
-                #Remove BH from retrograde_disk_arrays (don't forget arg periapse!)
-                """ retrograde_bh_locations = np.delete(retrograde_bh_locations,retro_inner_disk_indices)
-                retrograde_bh_masses = np.delete(retrograde_bh_masses, retro_inner_disk_indices)
-                retrograde_bh_spins = np.delete(retrograde_bh_spins, retro_inner_disk_indices)
-                retrograde_bh_spin_angles = np.delete(retrograde_bh_spin_angles, retro_inner_disk_indices)
-                retrograde_bh_orb_ecc = np.delete(retrograde_bh_orb_ecc, retro_inner_disk_indices)
-                retrograde_bh_orb_incl = np.delete(retrograde_bh_orb_incl, retro_inner_disk_indices)
-                retrograde_bh_orb_arg_periapse = np.delete(retrograde_bh_orb_arg_periapse, retro_inner_disk_indices)
-                retrograde_bh_generations = np.delete(retrograde_bh_generations, retro_inner_disk_indices) """
-
+                # Remove BH from retrograde_disk_arrays (don't forget arg periapse!)
                 retrograde_blackholes.remove_objects(idx_remove=retro_inner_disk_indices)
                 # Empty disk_indices array
                 empty=[]
@@ -1592,14 +1126,11 @@ def main():
                                                                     opts.timestep,
                                                                     old_gw_freq)
                 
-                #print("EMRI gw strain",emri_gw_strain)
-                #print("EMRI gw freq",emri_gw_freq)
 
             num_in_inner_disk = np.size(inner_disk_locations)
             nemri = nemri + num_in_inner_disk
             if num_in_inner_disk > 0:
                 for i in range(0,num_in_inner_disk):
-                    #print(iteration,time_passed,inner_disk_locations[i],inner_disk_masses[i],inner_disk_orb_ecc[i],emri_gw_strain[i],emri_gw_freq[i])        
                     temp_emri_array[0] = iteration
                     temp_emri_array[1] = time_passed
                     temp_emri_array[2] = inner_disk_locations[i]
@@ -1639,42 +1170,22 @@ def main():
             flip_to_prograde_indices = np.where((np.abs(retrograde_blackholes.orbit_inclination) <= inc_threshhold) | (retrograde_blackholes.orbit_e == 0.0))
             if np.size(flip_to_prograde_indices) > 0:
                 # add to prograde arrays
-                """ prograde_bh_locations = np.append(prograde_bh_locations,retrograde_bh_locations[flip_to_prograde_indices])
-                prograde_bh_masses = np.append(prograde_bh_masses, retrograde_bh_masses[flip_to_prograde_indices])
-                prograde_bh_spins = np.append(prograde_bh_spins, retrograde_bh_spins[flip_to_prograde_indices])
-                prograde_bh_spin_angles = np.append(prograde_bh_spin_angles, retrograde_bh_spin_angles[flip_to_prograde_indices])
-                prograde_bh_orb_ecc = np.append(prograde_bh_orb_ecc, retrograde_bh_orb_ecc[flip_to_prograde_indices])
-                prograde_bh_orb_incl = np.append(prograde_bh_orb_incl, retrograde_bh_orb_incl[flip_to_prograde_indices])
-                prograde_bh_orb_arg_periapse = np.append(prograde_bh_orb_arg_periapse, retrograde_bh_orb_arg_periapse[flip_to_prograde_indices])
-                prograde_bh_generations = np.append(prograde_bh_generations, retrograde_bh_generations[flip_to_prograde_indices]) """
-
-                prograde_blackholes.add_blackholes(new_mass = retrograde_blackholes.mass[flip_to_prograde_indices],
-                                                   new_orb_a = retrograde_blackholes.orbit_a[flip_to_prograde_indices],
-                                                   new_spin = retrograde_blackholes.spin[flip_to_prograde_indices],
-                                                   new_spin_angle = retrograde_blackholes.spin_angle[flip_to_prograde_indices],
-                                                   new_orb_inclination = retrograde_blackholes.orbit_inclination[flip_to_prograde_indices],
-                                                   new_orb_ang_mom = np.ones(retrograde_blackholes.mass[flip_to_prograde_indices].size),
-                                                   new_orb_e = retrograde_blackholes.orbit_e[flip_to_prograde_indices],
-                                                   new_orb_arg_periapse = retrograde_blackholes.orbit_arg_periapse[flip_to_prograde_indices],
-                                                   new_generation = retrograde_blackholes.generations[flip_to_prograde_indices],
-                                                   new_id_num = retrograde_blackholes.id_num[flip_to_prograde_indices])
+                prograde_blackholes.add_blackholes(new_mass=retrograde_blackholes.mass[flip_to_prograde_indices],
+                                                   new_orb_a=retrograde_blackholes.orbit_a[flip_to_prograde_indices],
+                                                   new_spin=retrograde_blackholes.spin[flip_to_prograde_indices],
+                                                   new_spin_angle=retrograde_blackholes.spin_angle[flip_to_prograde_indices],
+                                                   new_orb_inclination=retrograde_blackholes.orbit_inclination[flip_to_prograde_indices],
+                                                   new_orb_ang_mom=np.ones(retrograde_blackholes.mass[flip_to_prograde_indices].size),
+                                                   new_orb_e=retrograde_blackholes.orbit_e[flip_to_prograde_indices],
+                                                   new_orb_arg_periapse=retrograde_blackholes.orbit_arg_periapse[flip_to_prograde_indices],
+                                                   new_generation=retrograde_blackholes.generations[flip_to_prograde_indices],
+                                                   new_id_num=retrograde_blackholes.id_num[flip_to_prograde_indices])
                 # delete from retro arrays
-                """ retrograde_bh_locations = np.delete(retrograde_bh_locations,flip_to_prograde_indices)
-                retrograde_bh_masses = np.delete(retrograde_bh_masses,flip_to_prograde_indices)
-                retrograde_bh_spins = np.delete(retrograde_bh_spins,flip_to_prograde_indices)
-                retrograde_bh_spin_angles = np.delete(retrograde_bh_spin_angles,flip_to_prograde_indices)
-                retrograde_bh_orb_ecc = np.delete(retrograde_bh_orb_ecc,flip_to_prograde_indices)
-                retrograde_bh_orb_incl = np.delete(retrograde_bh_orb_incl,flip_to_prograde_indices)
-                retrograde_bh_orb_arg_periapse = np.delete(retrograde_bh_orb_arg_periapse,flip_to_prograde_indices)
-                retrograde_bh_generations = np.delete(retrograde_bh_generations,flip_to_prograde_indices) """
-
                 retrograde_blackholes.remove_objects(idx_remove=flip_to_prograde_indices)
             # empty array for flipping to prograde
             empty=[]
             flip_to_prograde_indices = np.array(empty)
-            
-            #binary_bh_array = dynamics.bbh_near_smbh(opts.mass_smbh,bin_index,binary_bh_array)
-            
+                        
             #Iterate the time step
             time_passed = time_passed + opts.timestep
             #Print time passed every 10 timesteps for now
@@ -1693,7 +1204,7 @@ def main():
         print("Number of binaries = ",bin_index)
         print("Total number of mergers = ",number_of_mergers)
         print("Mergers", merged_bh_array.shape)
-        print("Nbh_disk",n_bh)
+        print("Nbh_disk",disk_bh_num)
         #Number of rows in each array, EMRIs and BBH_GW
         # If emri_array is 2-d then this line is ok, but if emri-array is empty then this line defaults to 7 (#elements in 1d)
         if len(emri_array.shape) > 1:
@@ -1716,12 +1227,7 @@ def main():
         # Need total of 1) size of prograde_bh_array for number of singles at end of run and 
         # 2) size of bin_array for number of BH in binaries at end of run for
         # number of survivors.
-        # print("No. of singles",prograde_bh_locations.shape[0])
-        # print("No of bh in bins",2*bin_index)
-        # print("binary array",binary_bh_array)
-        #total_bh_survived = prograde_bh_locations.shape[0] + 2*bin_index
         total_bh_survived = prograde_blackholes.orbit_a.shape[0] + 2*bin_index
-        # print("Total bh=",total_bh_survived)
         num_properties_stored = 5
         # Set up arrays for properties:
         bin_r1 = np.zeros(bin_index)
@@ -1750,38 +1256,26 @@ def main():
         total_emri_array = np.zeros((total_emris,num_of_emri_properties))
         surviving_bh_array = np.zeros((total_bh_survived,num_properties_stored))
         total_bbh_gw_array = np.zeros((total_bbh_gws,num_of_bbh_gw_properties))
-        #print("BH locs,bin_r1,bin_r2",prograde_bh_locations,bin_r1,bin_r2)
-        """ prograde_bh_locations = np.append(prograde_bh_locations,bin_r1)
-        prograde_bh_locations = np.append(prograde_bh_locations,bin_r2) """
-        #print("prograde BH locs =",prograde_bh_locations)
-        """ prograde_bh_masses = np.append(prograde_bh_masses,bin_m1)
-        prograde_bh_masses = np.append(prograde_bh_masses,bin_m2)
-        prograde_bh_spins = np.append(prograde_bh_spins,bin_a1)
-        prograde_bh_spins = np.append(prograde_bh_spins,bin_a2)
-        prograde_bh_spin_angles = np.append(prograde_bh_spin_angles,bin_theta1)
-        prograde_bh_spin_angles = np.append(prograde_bh_spin_angles,bin_theta2)
-        prograde_bh_generations = np.append(prograde_bh_generations,bin_gen1)
-        prograde_bh_generations = np.append(prograde_bh_generations,bin_gen2) """
 
         # inclination is set to random value bc no set here
-        prograde_blackholes.add_blackholes(new_mass = np.concatenate([bin_m1, bin_m2]),
-                                           new_spin = np.concatenate([bin_a1, bin_a2]),
-                                           new_spin_angle = np.concatenate([bin_theta1, bin_theta2]),
-                                           new_orb_a = np.concatenate([bin_r1, bin_r2]),
-                                           new_orb_inclination = np.ones(np.concatenate([bin_m1, bin_m2]).size),
-                                           new_orb_ang_mom = np.ones(np.concatenate([bin_m1, bin_m2]).size),
-                                           new_orb_e = np.ones(np.concatenate([bin_m1, bin_m2]).size),
-                                           new_orb_arg_periapse = np.ones(np.concatenate([bin_m1, bin_m2]).size),
-                                           new_generation = np.concatenate([bin_gen1, bin_gen2]),
-                                           new_id_num = np.arange(prograde_blackholes.id_num.max()+1,len(bin_m1) + len(bin_m2) + prograde_blackholes.id_num.max()+1, 1))
+        prograde_blackholes.add_blackholes(new_mass=np.concatenate([bin_m1, bin_m2]),
+                                           new_spin=np.concatenate([bin_a1, bin_a2]),
+                                           new_spin_angle=np.concatenate([bin_theta1, bin_theta2]),
+                                           new_orb_a=np.concatenate([bin_r1, bin_r2]),
+                                           new_orb_inclination=np.ones(np.concatenate([bin_m1, bin_m2]).size),
+                                           new_orb_ang_mom=np.ones(np.concatenate([bin_m1, bin_m2]).size),
+                                           new_orb_e=np.ones(np.concatenate([bin_m1, bin_m2]).size),
+                                           new_orb_arg_periapse=np.ones(np.concatenate([bin_m1, bin_m2]).size),
+                                           new_generation=np.concatenate([bin_gen1, bin_gen2]),
+                                           new_id_num=np.arange(prograde_blackholes.id_num.max()+1,len(bin_m1) + len(bin_m2) + prograde_blackholes.id_num.max()+1, 1))
 
         print(len(prograde_blackholes.id_num))
         print(len(prograde_blackholes.mass))
-        surviving_bh_array[:,0] = prograde_blackholes.orbit_a #prograde_bh_locations
-        surviving_bh_array[:,1] = prograde_blackholes.mass #prograde_bh_masses
-        surviving_bh_array[:,2] = prograde_blackholes.spin #prograde_bh_spins
-        surviving_bh_array[:,3] = prograde_blackholes.spin_angle #prograde_bh_spin_angles
-        surviving_bh_array[:,4] = prograde_blackholes.generations #prograde_bh_generations
+        surviving_bh_array[:,0] = prograde_blackholes.orbit_a
+        surviving_bh_array[:,1] = prograde_blackholes.mass
+        surviving_bh_array[:,2] = prograde_blackholes.spin
+        surviving_bh_array[:,3] = prograde_blackholes.spin_angle
+        surviving_bh_array[:,4] = prograde_blackholes.generations
 
         total_emri_array = emri_array
         total_bbh_gw_array = bbh_gw_array
@@ -1801,36 +1295,13 @@ def main():
         merged_bh_array_pop.append(np.concatenate((iteration_row[np.newaxis], merged_bh_array[:,:number_of_mergers])).T)
         #surviving_bh_array_pop.append(np.concatenate((survivor_row[np.newaxis], surviving_bh_array[:,:total_bh_survived])).T)
         surviving_bh_array_pop.append(np.concatenate((survivor_row[np.newaxis], surviving_bh_array[:total_bh_survived,:])))
-        
-        #print("total_emris,total_bbh_gws",total_emris,total_bbh_gws)
-        #print("gw_row",gw_row)
-        #print("gw_array_pop",gw_array_pop)
-        #print("total_bbh_gw_array",total_bbh_gw_array)
-        #if np.any(total_bbh_gw_array):
-        #    print("total_bbh_gw_array[]",total_bbh_gw_array[:,:total_bbh_gws])
-        #    print("total_bbh_gw_array[,:]",total_bbh_gw_array[:total_bbh_gws,:])
-        #print("concatenate",np.concatenate((gw_row,total_bbh_gw_array)))
-        #If there are non-zero elements in total_emri_array, concatenate to main EMRI file
-        
+                
         #print("total_emris",total_emris)
         if total_emris > 0:
-        #if np.any(total_emri_array):
-        #emris_array_pop.append(np.concatenate((emri_row[np.newaxis],total_emri_array[:total_emris,:])))
-        
-            #emris_array_pop.append(np.concatenate((emri_row[np.newaxis],total_emri_array[:,:total_emris])))
-            #emris_array_pop.append(total_emri_array[:,:total_emris])
             emris_array_pop.append(total_emri_array[:total_emris,:])
-            #print("emris_array_pop",emris_array_pop)
-        #    emris_array_pop.append(np.concatenate((emri_row[np.newaxis],total_emri_array[:total_emris,:])).T)
         #If there are non-zero elements in total_bbh_gw_array
         if total_bbh_gws > 0:
-        #if np.any(total_bbh_gw_array):
-        #gw_array_pop.append(np.concatenate((gw_row[np.newaxis],total_bbh_gw_array[:total_bbh_gws,:])))
-            #gw_array_pop.append(np.concatenate((gw_row[np.newaxis],total_bbh_gw_array[:,:total_bbh_gws])))
             gw_array_pop.append(total_bbh_gw_array[:total_bbh_gws,:])
-            #gw_array_pop.append(np.concatenate((gw_row[np.newaxis],total_bbh_gw_array[:total_bbh_gws,:])).T)
-        #if n_its == 1:
-        #    print("emris_array_pop",emris_array_pop)
      # save all mergers from Monte Carlo
     merger_pop_field_names = "iter " + merger_field_names # Add "Iter" to field names
     population_header = f"Initial seed: {opts.seed}\n{merger_pop_field_names}" # Include initial seed
@@ -1839,11 +1310,9 @@ def main():
     survivors_save_name = f"{basename}_survivors{extension}"
     emris_save_name = f"{basename}_emris{extension}"
     gws_save_name = f"{basename}_lvk{extension}"
-    #print("emris_array_pop",emris_array_pop)
     np.savetxt(os.path.join(opts.work_directory, population_save_name), np.vstack(merged_bh_array_pop), header=population_header)
     np.savetxt(os.path.join(opts.work_directory, survivors_save_name), np.vstack(surviving_bh_array_pop))
     np.savetxt(os.path.join(opts.work_directory,emris_save_name),np.vstack(emris_array_pop))
-    #np.savetxt(os.path.join(opts.work_directory,emris_save_name),(emris_array_pop))
     np.savetxt(os.path.join(opts.work_directory,gws_save_name),np.vstack(gw_array_pop))
 if __name__ == "__main__":
     main()

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -69,8 +69,8 @@ def arg():
                         help="Set the random seed. Randomly sets one if not passed. Default: None")
     parser.add_argument("--fname-log", default="mcfacts_sim.log", type=str,
                         help="Specify a file to save the arguments for mcfacts")
-    
-    ## Add inifile arguments
+
+    # Add inifile arguments
     # Read default inifile
     _variable_inputs = ReadInputs.ReadInputs_ini(DEFAULT_INI, False)
     # Loop the arguments
@@ -287,12 +287,12 @@ def main():
                                           )
         filing_cabinet.add_objects(create_id=False, new_id_num=stars.id_num, new_category=np.full(stars.mass.shape, 2),
                                    new_direction=np.full(stars.mass.shape, 0),
-                                   new_mass=stars.mass, 
-                                   new_spin=stars.spin, 
-                                   new_spin_angle=stars.spin_angle, 
-                                   new_orb_a=stars.orbit_a, 
-                                   new_orb_inclination=stars.orbit_inclination, 
-                                   new_orb_ang_mom=stars.orb_ang_mom, 
+                                   new_mass=stars.mass,
+                                   new_spin=stars.spin,
+                                   new_spin_angle=stars.spin_angle,
+                                   new_orb_a=stars.orbit_a,
+                                   new_orb_inclination=stars.orbit_inclination,
+                                   new_orb_ang_mom=stars.orb_ang_mom,
                                    new_orb_e=stars.orbit_e,
                                    new_orb_arg_periapse=stars.orbit_arg_periapse,
                                    new_generation=stars.generations)
@@ -361,7 +361,6 @@ def main():
         bin_index = 0
         bin_num_total = 0
         number_of_mergers = 0
-        int_n_timesteps = int(opts.timestep_num)
         frac_bin_retro = opts.fraction_bin_retro
         
         # Set up EMRI output array with properties we want to record (iteration, time, R,M,e,h_char,f_gw)
@@ -414,7 +413,7 @@ def main():
             prior_ecc_factor = 0.3
             prograde_blackholes.orbit_e = setupdiskblackholes.setup_disk_blackholes_eccentricity_uniform_modified(prior_ecc_factor, num_of_progrades)
             print("prior ecc", prograde_blackholes.orbit_e)
-  
+
         # Start Loop of Timesteps
         print("Start Loop!")
         time_passed = initial_time
@@ -464,7 +463,6 @@ def main():
             )
 
             # then migrate as usual
-
             prograde_blackholes.orbit_a = type1.type1_migration(
                 opts.smbh_mass,
                 prograde_blackholes.orbit_a,
@@ -554,7 +552,7 @@ def main():
             prograde_stars.mass = changestarsmass.change_mass(
                 prograde_stars.mass,
                 opts.disk_star_eddington_ratio,
-                disk_bh_eddington_mass_growth_rate, #do we need to alter this for stars?
+                disk_bh_eddington_mass_growth_rate,  # do we need to alter this for stars?
                 opts.timestep_duration_yr
             )
             # Spin up
@@ -595,7 +593,7 @@ def main():
             # change retrograde eccentricity (some damping, some pumping)
             # damp orbital inclination
             
-            # This is not working for retrograde stars
+            # This is not working for retrograde stars, just says parameters are unreliable
             # retrograde_stars.orbit_e, retrograde_stars.orbit_a, retrograde_stars.orbit_inclination = crude_retro_evol.crude_retro_bh(
             #     opts.smbh_mass,
             #     retrograde_stars.mass,
@@ -647,7 +645,7 @@ def main():
                 #     Please explain what this is and how it works right here?
                 reality_flag = evolve.reality_check(binary_bh_array, bin_index, bin_properties_num)
                 if reality_flag >= 0:
-                   #One of the key parameter (mass or location is zero). Not real. Delete binary. Remove column at index = ionization_flag
+                    # One of the key parameter (mass or location is zero). Not real. Delete binary. Remove column at index = ionization_flag
                     binary_bh_array = np.delete(binary_bh_array, reality_flag, 1)
                     bin_index = bin_index - 1
                 else:
@@ -702,7 +700,7 @@ def main():
                         bin_index,
                         time_passed,
                     )
-                    #Check closeness of binary. Are black holes at merger condition separation
+                    # Check closeness of binary. Are black holes at merger condition separation
                     binary_bh_array = evolve.contact_check(binary_bh_array, bin_index, opts.smbh_mass)
                     # Accrete gas onto binary components
                     binary_bh_array = evolve.change_bin_mass(
@@ -734,7 +732,7 @@ def main():
                     )
 
                     if (opts.flag_dynamic_enc > 0):
-                        #Spheroid encounters
+                        # Spheroid encounters
                         binary_bh_array = dynamics.bin_spheroid_encounter(
                             rng,
                             opts.smbh_mass,
@@ -749,7 +747,7 @@ def main():
                         )
 
                     if (opts.flag_dynamic_enc > 0):
-                        #Recapture bins out of disk plane
+                        # Recapture bins out of disk plane
                         binary_bh_array = dynamics.bin_recapture(
                             bin_index,
                             binary_bh_array,
@@ -766,7 +764,7 @@ def main():
                             opts.disk_alpha_viscosity
                         )
                     else:
-                        ratio_heat_mig_torques_bin_com = np.ones(len(binary_bh_array[9,:]))   
+                        ratio_heat_mig_torques_bin_com = np.ones(len(binary_bh_array[9, :]))
 
                     # Migrate binaries center of mass
                     binary_bh_array = evolve.bin_migration(
@@ -785,11 +783,11 @@ def main():
                     # Minimum BBH separation (in units of r_g)
                     min_bbh_gw_separation = 2.0
                     # If there are binaries AND if any separations are < min_bbh_gw_separation
-                    bbh_gw_indices = np.where((binary_bh_array[8,:] < min_bbh_gw_separation) & (binary_bh_array[8,:]>0))
+                    bbh_gw_indices = np.where((binary_bh_array[8, :] < min_bbh_gw_separation) & (binary_bh_array[8, :] > 0))
                     
                     # If bbh_indices exists (ie is not empty)
                     if bbh_gw_indices:
-                        #1st time around.
+                        # 1st time around.
                         if num_bbh_gw_tracked == 0:
                             old_bbh_gw_freq = 9.e-7*np.ones(np.size(bbh_gw_indices, 1))    
                         if num_bbh_gw_tracked > 0:
@@ -808,14 +806,14 @@ def main():
                             old_bbh_gw_freq
                         )
                         
-                        if num_bbh_gw_tracked == 1:        
+                        if num_bbh_gw_tracked == 1:
                             index = bbh_gw_indices[0]
 
                             temp_bbh_gw_array[0] = iteration
                             temp_bbh_gw_array[1] = time_passed
-                            temp_bbh_gw_array[2] = binary_bh_array[8,index]
-                            temp_bbh_gw_array[3] = binary_bh_array[2,index] + binary_bh_array[3,index]
-                            temp_bbh_gw_array[4] = binary_bh_array[13,index]
+                            temp_bbh_gw_array[2] = binary_bh_array[8, index]
+                            temp_bbh_gw_array[3] = binary_bh_array[2, index] + binary_bh_array[3, index]
+                            temp_bbh_gw_array[4] = binary_bh_array[13, index]
                             temp_bbh_gw_array[5] = bbh_gw_strain
                             temp_bbh_gw_array[6] = bbh_gw_freq
 
@@ -823,31 +821,30 @@ def main():
 
                         if num_bbh_gw_tracked > 1:
                             index = 0
-                            for i in range(0,num_bbh_gw_tracked-1):
+                            for i in range(0, num_bbh_gw_tracked-1):
 
                                 index = bbh_gw_indices[0][i]
 
                                 # Record: iteration, time_passed, bin sep, bin_mass, bin_ecc(around c.o.m.),bin strain, bin freq       
                                 temp_bbh_gw_array[0] = iteration
                                 temp_bbh_gw_array[1] = time_passed
-                                temp_bbh_gw_array[2] = binary_bh_array[8,index]
-                                temp_bbh_gw_array[3] = binary_bh_array[2,index] + binary_bh_array[3,index]
-                                temp_bbh_gw_array[4] = binary_bh_array[13,index]
+                                temp_bbh_gw_array[2] = binary_bh_array[8, index]
+                                temp_bbh_gw_array[3] = binary_bh_array[2, index] + binary_bh_array[3, index]
+                                temp_bbh_gw_array[4] = binary_bh_array[13, index]
                                 temp_bbh_gw_array[5] = bbh_gw_strain[i]
                                 temp_bbh_gw_array[6] = bbh_gw_freq[i]
-                                #print("temp_bbh_gw_array",temp_bbh_gw_array)
-                                bbh_gw_array = np.vstack((bbh_gw_array, temp_bbh_gw_array))
-                                #print("bbh_gw_array",bbh_gw_array)
 
-                    #Evolve GW frequency and strain
+                                bbh_gw_array = np.vstack((bbh_gw_array, temp_bbh_gw_array))
+
+                    # Evolve GW frequency and strain
                     binary_bh_array = evolve.evolve_gw(
                         binary_bh_array,
                         bin_index,
                         opts.smbh_mass
                     )
-                    
-                    #Check and see if merger flagged during hardening (row 11, if negative)
-                    merger_flags = binary_bh_array[11,:]
+
+                    # Check and see if merger flagged during hardening (row 11, if negative)
+                    merger_flags = binary_bh_array[11, :]
                     any_merger = np.count_nonzero(merger_flags)
 
                     # Check and see if binary ionization flag raised. 
@@ -857,16 +854,16 @@ def main():
                     if ionization_flag >= 0:
                         # Append 2 new BH to arrays of single BH locations, masses, spins, spin angles & gens
                         # For now add 2 new orb ecc term of 0.01. TO DO: calculate v_kick and resulting perturbation to orb ecc.
-                        new_location_1 = binary_bh_array[0,ionization_flag]
-                        new_location_2 = binary_bh_array[1,ionization_flag]
-                        new_mass_1 = binary_bh_array[2,ionization_flag]
-                        new_mass_2 = binary_bh_array[3,ionization_flag]
-                        new_spin_1 = binary_bh_array[4,ionization_flag]
-                        new_spin_2 = binary_bh_array[5,ionization_flag]
-                        new_spin_angle_1 = binary_bh_array[6,ionization_flag]
-                        new_spin_angle_2 = binary_bh_array[7,ionization_flag]
-                        new_gen_1 = binary_bh_array[14,ionization_flag]
-                        new_gen_2 = binary_bh_array[15,ionization_flag]
+                        new_location_1 = binary_bh_array[0, ionization_flag]
+                        new_location_2 = binary_bh_array[1, ionization_flag]
+                        new_mass_1 = binary_bh_array[2, ionization_flag]
+                        new_mass_2 = binary_bh_array[3, ionization_flag]
+                        new_spin_1 = binary_bh_array[4, ionization_flag]
+                        new_spin_2 = binary_bh_array[5, ionization_flag]
+                        new_spin_angle_1 = binary_bh_array[6, ionization_flag]
+                        new_spin_angle_2 = binary_bh_array[7, ionization_flag]
+                        new_gen_1 = binary_bh_array[14, ionization_flag]
+                        new_gen_2 = binary_bh_array[15, ionization_flag]
                         new_orb_ecc_1 = 0.01
                         new_orb_ecc_2 = 0.01
                         new_orb_inc_1 = 0.0
@@ -901,46 +898,45 @@ def main():
                         merger_indices = merger_indices[0]
                     if opts.verbose:
                         print(merger_indices)
-                    #print(binary_bh_array[:,merger_indices])
                     if any_merger > 0:
                         for i in range(any_merger):
                             if time_passed <= opts.timestep_duration_yr:
-                                print("time_passed,loc1,loc2",time_passed,binary_bh_array[0,merger_indices[i]],binary_bh_array[1,merger_indices[i]])
+                                print("time_passed,loc1,loc2", time_passed, binary_bh_array[0, merger_indices[i]], binary_bh_array[1, merger_indices[i]])
 
                         # calculate merger properties
                             merged_mass = tichy08.merged_mass(
-                                binary_bh_array[2,merger_indices[i]],
-                                binary_bh_array[3,merger_indices[i]],
-                                binary_bh_array[4,merger_indices[i]],
-                                binary_bh_array[5,merger_indices[i]]
+                                binary_bh_array[2, merger_indices[i]],
+                                binary_bh_array[3, merger_indices[i]],
+                                binary_bh_array[4, merger_indices[i]],
+                                binary_bh_array[5, merger_indices[i]]
                             )
                             merged_spin = tichy08.merged_spin(
-                                binary_bh_array[2,merger_indices[i]],
-                                binary_bh_array[3,merger_indices[i]],
-                                binary_bh_array[4,merger_indices[i]],
-                                binary_bh_array[5,merger_indices[i]],
-                                binary_bh_array[16,merger_indices[i]]
+                                binary_bh_array[2, merger_indices[i]],
+                                binary_bh_array[3, merger_indices[i]],
+                                binary_bh_array[4, merger_indices[i]],
+                                binary_bh_array[5, merger_indices[i]],
+                                binary_bh_array[16, merger_indices[i]]
                             )
                             merged_chi_eff = chieff.chi_effective(
-                                binary_bh_array[2,merger_indices[i]],
-                                binary_bh_array[3,merger_indices[i]],
-                                binary_bh_array[4,merger_indices[i]],
-                                binary_bh_array[5,merger_indices[i]],
-                                binary_bh_array[6,merger_indices[i]],
-                                binary_bh_array[7,merger_indices[i]],
-                                binary_bh_array[16,merger_indices[i]]
+                                binary_bh_array[2, merger_indices[i]],
+                                binary_bh_array[3, merger_indices[i]],
+                                binary_bh_array[4, merger_indices[i]],
+                                binary_bh_array[5, merger_indices[i]],
+                                binary_bh_array[6, merger_indices[i]],
+                                binary_bh_array[7, merger_indices[i]],
+                                binary_bh_array[16, merger_indices[i]]
                             )
                             merged_chi_p = chieff.chi_p(
-                                binary_bh_array[2,merger_indices[i]],
-                                binary_bh_array[3,merger_indices[i]],
-                                binary_bh_array[4,merger_indices[i]],
-                                binary_bh_array[5,merger_indices[i]],
-                                binary_bh_array[6,merger_indices[i]],
-                                binary_bh_array[7,merger_indices[i]],
-                                binary_bh_array[16,merger_indices[i]],
-                                binary_bh_array[17,merger_indices[i]]
+                                binary_bh_array[2, merger_indices[i]],
+                                binary_bh_array[3, merger_indices[i]],
+                                binary_bh_array[4, merger_indices[i]],
+                                binary_bh_array[5, merger_indices[i]],
+                                binary_bh_array[6, merger_indices[i]],
+                                binary_bh_array[7, merger_indices[i]],
+                                binary_bh_array[16, merger_indices[i]],
+                                binary_bh_array[17, merger_indices[i]]
                             )
-                            merged_bh_array[:,n_mergers_so_far + i] = mergerfile.merged_bh(
+                            merged_bh_array[:, n_mergers_so_far + i] = mergerfile.merged_bh(
                                 merged_bh_array,
                                 binary_bh_array,
                                 merger_indices,
@@ -954,23 +950,23 @@ def main():
                                 time_passed
                             )
                         # do another thing
-                        merger_array[:,merger_indices] = binary_bh_array[:,merger_indices]
-                        #Reset merger marker to zero
-                        #Remove merged binary from binary array. Delete column where merger_indices is the label.
-                        binary_bh_array=np.delete(binary_bh_array,merger_indices,1)
+                        merger_array[:, merger_indices] = binary_bh_array[:, merger_indices]
+                        # Reset merger marker to zero
+                        # Remove merged binary from binary array. Delete column where merger_indices is the label.
+                        binary_bh_array = np.delete(binary_bh_array, merger_indices, 1)
                 
-                        #Reduce number of binaries by number of mergers
+                        # Reduce number of binaries by number of mergers
                         bin_index = bin_index - len(merger_indices)
-                        #Find relevant properties of merged BH to add to single BH arrays
+                        # Find relevant properties of merged BH to add to single BH arrays
                         num_mergers_this_timestep = len(merger_indices)
                 
-                        for i in range (0, num_mergers_this_timestep):
-                            merged_bh_com = merged_bh_array[0,n_mergers_so_far + i]
-                            merged_mass = merged_bh_array[1,n_mergers_so_far + i]
-                            merged_spin = merged_bh_array[3,n_mergers_so_far + i]
-                            merged_spin_angle = merged_bh_array[4,n_mergers_so_far + i]
-                        #New bh generation is max of generations involved in merger plus 1
-                            merged_bh_gen = np.maximum(merged_bh_array[11,n_mergers_so_far + i],merged_bh_array[12,n_mergers_so_far + i]) + 1.0 
+                        for i in range(0, num_mergers_this_timestep):
+                            merged_bh_com = merged_bh_array[0, n_mergers_so_far + i]
+                            merged_mass = merged_bh_array[1, n_mergers_so_far + i]
+                            merged_spin = merged_bh_array[3, n_mergers_so_far + i]
+                            merged_spin_angle = merged_bh_array[4, n_mergers_so_far + i]
+                        # New bh generation is max of generations involved in merger plus 1
+                            merged_bh_gen = np.maximum(merged_bh_array[11, n_mergers_so_far + i], merged_bh_array[12, n_mergers_so_far + i]) + 1.0
                         # Add to number of mergers
                         n_mergers_so_far += len(merger_indices)
                         number_of_mergers += len(merger_indices)
@@ -992,19 +988,19 @@ def main():
                             print("New BH locations", prograde_blackholes.orbit_a)
                         if opts.verbose:
                             print(merger_array)
-                    else:                
+                    else:
                         # No merger
                         # do nothing! hardening should happen FIRST (and now it does!)
                         if opts.verbose:
-                            if bin_index>0: # verbose:
-                                print(binary_bh_array[:,:int(bin_index)].T)  # this makes printing work as expected
-            else:            
-                    if opts.verbose:
-                        print("No binaries formed yet")
+                            if bin_index > 0:  # verbose:
+                                print(binary_bh_array[:, :int(bin_index)].T)  # this makes printing work as expected
+            else:
+                if opts.verbose:
+                    print("No binaries formed yet")
                     # No Binaries present in bin_array. Nothing to do.
-                #Finished evolving binaries
+                # Finished evolving binaries
 
-                #If a close encounter within mutual Hill sphere add a new Binary
+                # If a close encounter within mutual Hill sphere add a new Binary
 
                 # check which binaries should get made
             close_encounters2 = hillsphere.binary_check2(
@@ -1029,16 +1025,16 @@ def main():
                     opts.smbh_mass,
                 )
                 bin_index = bin_index + number_of_new_bins
-                #Count towards total of any binary ever made (including those that are ionized)
+                # Count towards total of any binary ever made (including those that are ionized)
                 bin_num_total = bin_num_total + number_of_new_bins
                 # delete corresponding entries for new binary members from singleton arrays
                 prograde_blackholes.remove_objects(idx_remove=close_encounters2)
 
-                #Empty close encounters
+                # Empty close encounters
                 empty = []
                 close_encounters2 = np.array(empty)
 
-            #After this time period, was there a disk capture via orbital grind-down?
+            # After this time period, was there a disk capture via orbital grind-down?
             # To do: What eccentricity do we want the captured BH to have? Right now ecc=0.0? Should it be ecc<h at a?             
             # Assume 1st gen BH captured and orb ecc =0.0
             # To do: Bias disk capture to more massive BH!
@@ -1078,14 +1074,14 @@ def main():
             retro_inner_disk_indices = np.where(retrograde_blackholes.orbit_a < min_safe_distance)
             if np.size(inner_disk_indices) > 0:
                 # Add BH to inner_disk_arrays
-                inner_disk_locations = np.append(inner_disk_locations,prograde_blackholes.orbit_a[inner_disk_indices])
-                inner_disk_masses = np.append(inner_disk_masses,prograde_blackholes.mass[inner_disk_indices])
-                inner_disk_spins = np.append(inner_disk_spins,prograde_blackholes.spin[inner_disk_indices])
-                inner_disk_spin_angles = np.append(inner_disk_spin_angles,prograde_blackholes.spin_angle[inner_disk_indices])
-                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc,prograde_blackholes.orbit_e[inner_disk_indices])
-                inner_disk_orb_inc = np.append(inner_disk_orb_inc,prograde_blackholes.orbit_inclination[inner_disk_indices])
-                inner_disk_gens = np.append(inner_disk_gens,prograde_blackholes.generations[inner_disk_indices])
-                #Remove BH from prograde_disk_arrays
+                inner_disk_locations = np.append(inner_disk_locations, prograde_blackholes.orbit_a[inner_disk_indices])
+                inner_disk_masses = np.append(inner_disk_masses, prograde_blackholes.mass[inner_disk_indices])
+                inner_disk_spins = np.append(inner_disk_spins, prograde_blackholes.spin[inner_disk_indices])
+                inner_disk_spin_angles = np.append(inner_disk_spin_angles, prograde_blackholes.spin_angle[inner_disk_indices])
+                inner_disk_orb_ecc = np.append(inner_disk_orb_ecc, prograde_blackholes.orbit_e[inner_disk_indices])
+                inner_disk_orb_inc = np.append(inner_disk_orb_inc, prograde_blackholes.orbit_inclination[inner_disk_indices])
+                inner_disk_gens = np.append(inner_disk_gens, prograde_blackholes.generations[inner_disk_indices])
+                # Remove BH from prograde_disk_arrays
                 prograde_blackholes.remove_objects(idx_remove=inner_disk_indices)
                 # Empty disk_indices array
                 empty = []
@@ -1104,7 +1100,7 @@ def main():
                 # Remove BH from retrograde_disk_arrays (don't forget arg periapse!)
                 retrograde_blackholes.remove_objects(idx_remove=retro_inner_disk_indices)
                 # Empty disk_indices array
-                empty=[]
+                empty = []
                 retro_inner_disk_indices = np.array(empty)
             
             if np.size(inner_disk_locations) > 0:
@@ -1115,22 +1111,21 @@ def main():
                                                              opts.timestep_duration_yr)
                 num_in_inner_disk = np.size(inner_disk_locations)
                 # On 1st run through define old GW freqs (at say 9.e-7 Hz, since evolution change is 1e-6Hz)
-                if nemri ==0:
+                if nemri == 0:
                     old_gw_freq = 9.e-7*np.ones(num_in_inner_disk)
                 if nemri > 0:
                     old_gw_freq = emri_gw_freq
-                #Now update emris & generate NEW frequency & evolve   
-                emri_gw_strain,emri_gw_freq = evolve.evolve_emri_gw(inner_disk_locations,
-                                                                    inner_disk_masses, 
-                                                                    opts.smbh_mass,
-                                                                    opts.timestep_duration_yr,
-                                                                    old_gw_freq)
-                
+                # Now update emris & generate NEW frequency & evolve   
+                emri_gw_strain, emri_gw_freq = evolve.evolve_emri_gw(inner_disk_locations,
+                                                                     inner_disk_masses, 
+                                                                     opts.smbh_mass,
+                                                                     opts.timestep_duration_yr,
+                                                                     old_gw_freq)
 
             num_in_inner_disk = np.size(inner_disk_locations)
             nemri = nemri + num_in_inner_disk
             if num_in_inner_disk > 0:
-                for i in range(0,num_in_inner_disk):
+                for i in range(0, num_in_inner_disk):
                     temp_emri_array[0] = iteration
                     temp_emri_array[1] = time_passed
                     temp_emri_array[2] = inner_disk_locations[i]
@@ -1138,9 +1133,8 @@ def main():
                     temp_emri_array[4] = inner_disk_orb_ecc[i]
                     temp_emri_array[5] = emri_gw_strain[i]
                     temp_emri_array[6] = emri_gw_freq[i]
-                    
-                    
-                    emri_array = np.vstack((emri_array,temp_emri_array))
+
+                    emri_array = np.vstack((emri_array, temp_emri_array))
                 
             # if inner_disk_locations[i] <1R_g then merger!
             merger_dist = 1.0
@@ -1158,7 +1152,7 @@ def main():
                 inner_disk_orb_inc = np.delete(inner_disk_orb_inc, emri_merger_indices)
                 inner_disk_gens = np.delete(inner_disk_gens, emri_merger_indices)
             # Empty emri_merger_indices array
-            empty=[]
+            empty = []
             emri_merger_indices = np.array(empty)
             
             # Here is where we need to move retro to prograde if they've flipped in this timestep
@@ -1166,7 +1160,6 @@ def main():
             # stop treating them with crude retro evolution--it will be sad
             # SF: fix the inc threshhold later!!!
             inc_threshhold = 5.0 * np.pi/180.0
-            #flip_to_prograde_indices = np.where((np.abs(retrograde_bh_orb_incl) <= inc_threshhold) | (retrograde_bh_orb_ecc == 0.0))
             flip_to_prograde_indices = np.where((np.abs(retrograde_blackholes.orbit_inclination) <= inc_threshhold) | (retrograde_blackholes.orbit_e == 0.0))
             if np.size(flip_to_prograde_indices) > 0:
                 # add to prograde arrays
@@ -1183,52 +1176,51 @@ def main():
                 # delete from retro arrays
                 retrograde_blackholes.remove_objects(idx_remove=flip_to_prograde_indices)
             # empty array for flipping to prograde
-            empty=[]
+            empty = []
             flip_to_prograde_indices = np.array(empty)
-                        
-            #Iterate the time step
+
+            # Iterate the time step
             time_passed = time_passed + opts.timestep_duration_yr
-            #Print time passed every 10 timesteps for now
+            # Print time passed every 10 timesteps for now
             time_iteration_tracker = 10.0*opts.timestep_duration_yr
             if time_passed % time_iteration_tracker == 0:
-                print("Time passed=",time_passed)
+                print("Time passed=", time_passed)
             n_its = n_its + 1
-        #End Loop of Timesteps at Final Time, end all changes & print out results
-    
+        # End Loop of Timesteps at Final Time, end all changes & print out results
+
         print("End Loop!")
-        print("Final Time (yrs) = ",time_passed)
+        print("Final Time (yrs) = ", time_passed)
         if opts.verbose:
             print("BH locations at Final Time")
-            #print(prograde_bh_locations)
             print(prograde_blackholes.orbit_a)
-        print("Number of binaries = ",bin_index)
-        print("Total number of mergers = ",number_of_mergers)
+        print("Number of binaries = ", bin_index)
+        print("Total number of mergers = ", number_of_mergers)
         print("Mergers", merged_bh_array.shape)
-        print("Nbh_disk",disk_bh_num)
-        #Number of rows in each array, EMRIs and BBH_GW
+        print("Nbh_disk", disk_bh_num)
+        # Number of rows in each array, EMRIs and BBH_GW
         # If emri_array is 2-d then this line is ok, but if emri-array is empty then this line defaults to 7 (#elements in 1d)
         if len(emri_array.shape) > 1:
             total_emris = emri_array.shape[0]
         elif len(emri_array.shape) == 1:
             total_emris = 0
-    
+
         if len(bbh_gw_array.shape) > 1:
             total_bbh_gws = bbh_gw_array.shape[0]
         elif len(bbh_gw_array.shape) == 1:
             total_bbh_gws = 0
 
-            
         # Write out all the singletons after AGN episode, so can use this as input to another AGN phase.
         # Want to store [Radius, Mass, Spin mag., Spin. angle, gen.]
         # So num_properties_stored = 5 (for now)
         # Note eccentricity will relax, so ignore. Inclination assumed 0deg.
-        
+
         # Set up array for population that survives AGN episode, so can use as a draw for next episode.
         # Need total of 1) size of prograde_bh_array for number of singles at end of run and 
         # 2) size of bin_array for number of BH in binaries at end of run for
         # number of survivors.
         total_bh_survived = prograde_blackholes.orbit_a.shape[0] + 2*bin_index
         num_properties_stored = 5
+
         # Set up arrays for properties:
         bin_r1 = np.zeros(bin_index)
         bin_r2 = np.zeros(bin_index)
@@ -1242,22 +1234,22 @@ def main():
         bin_gen2 = np.zeros(bin_index)        
 
         for i in range(0,bin_index):
-            bin_r1[i] = binary_bh_array[0,i]
-            bin_r2[i] = binary_bh_array[1,i]
-            bin_m1[i] = binary_bh_array[2,i]
-            bin_m2[i] = binary_bh_array[3,i]
-            bin_a1[i] = binary_bh_array[4,i]
-            bin_a2[i] = binary_bh_array[5,i]
-            bin_theta1[i] = binary_bh_array[6,i]
-            bin_theta2[i] = binary_bh_array[7,i]
-            bin_gen1[i] = binary_bh_array[14,i]
-            bin_gen2[i] = binary_bh_array[15,i]
+            bin_r1[i] = binary_bh_array[0, i]
+            bin_r2[i] = binary_bh_array[1, i]
+            bin_m1[i] = binary_bh_array[2, i]
+            bin_m2[i] = binary_bh_array[3, i]
+            bin_a1[i] = binary_bh_array[4, i]
+            bin_a2[i] = binary_bh_array[5, i]
+            bin_theta1[i] = binary_bh_array[6, i]
+            bin_theta2[i] = binary_bh_array[7, i]
+            bin_gen1[i] = binary_bh_array[14, i]
+            bin_gen2[i] = binary_bh_array[15, i]
 
-        total_emri_array = np.zeros((total_emris,num_of_emri_properties))
-        surviving_bh_array = np.zeros((total_bh_survived,num_properties_stored))
-        total_bbh_gw_array = np.zeros((total_bbh_gws,num_of_bbh_gw_properties))
+        total_emri_array = np.zeros((total_emris, num_of_emri_properties))
+        surviving_bh_array = np.zeros((total_bh_survived, num_properties_stored))
+        total_bbh_gw_array = np.zeros((total_bbh_gws, num_of_bbh_gw_properties))
 
-        # inclination is set to random value bc no set here
+        # inclination is set to random value bc not set above
         prograde_blackholes.add_blackholes(new_mass=np.concatenate([bin_m1, bin_m2]),
                                            new_spin=np.concatenate([bin_a1, bin_a2]),
                                            new_spin_angle=np.concatenate([bin_theta1, bin_theta2]),
@@ -1271,40 +1263,36 @@ def main():
 
         print(len(prograde_blackholes.id_num))
         print(len(prograde_blackholes.mass))
-        surviving_bh_array[:,0] = prograde_blackholes.orbit_a
-        surviving_bh_array[:,1] = prograde_blackholes.mass
-        surviving_bh_array[:,2] = prograde_blackholes.spin
-        surviving_bh_array[:,3] = prograde_blackholes.spin_angle
-        surviving_bh_array[:,4] = prograde_blackholes.generations
+        surviving_bh_array[:, 0] = prograde_blackholes.orbit_a
+        surviving_bh_array[:, 1] = prograde_blackholes.mass
+        surviving_bh_array[:, 2] = prograde_blackholes.spin
+        surviving_bh_array[:, 3] = prograde_blackholes.spin_angle
+        surviving_bh_array[:, 4] = prograde_blackholes.generations
 
         total_emri_array = emri_array
         total_bbh_gw_array = bbh_gw_array
-        if True and number_of_mergers > 0: #verbose:
-                print(merged_bh_array[:,:number_of_mergers].T)
+        if True and number_of_mergers > 0:  # verbose:
+            print(merged_bh_array[:, :number_of_mergers].T)
 
         iteration_save_name = f"run{iteration_zfilled_str}/{opts.fname_output_mergers}"
-        np.savetxt(os.path.join(opts.work_directory, iteration_save_name), merged_bh_array[:,:number_of_mergers].T, header=merger_field_names)
+        np.savetxt(os.path.join(opts.work_directory, iteration_save_name), merged_bh_array[:, :number_of_mergers].T, header=merger_field_names)
 
         # Add mergers to population array including the iteration number 
         # this line is linebreak between iteration outputs consisting of the repeated iteration number in each column
         iteration_row = np.repeat(iteration, number_of_mergers)
-        survivor_row = np.repeat(iteration,num_properties_stored)
-        emri_row = np.repeat(iteration,num_of_emri_properties)
-        gw_row = np.repeat(iteration,num_of_bbh_gw_properties)
-        #Append each iteration result to output arrays
-        merged_bh_array_pop.append(np.concatenate((iteration_row[np.newaxis], merged_bh_array[:,:number_of_mergers])).T)
-        #surviving_bh_array_pop.append(np.concatenate((survivor_row[np.newaxis], surviving_bh_array[:,:total_bh_survived])).T)
-        surviving_bh_array_pop.append(np.concatenate((survivor_row[np.newaxis], surviving_bh_array[:total_bh_survived,:])))
-                
-        #print("total_emris",total_emris)
+        survivor_row = np.repeat(iteration, num_properties_stored)
+        # Append each iteration result to output arrays
+        merged_bh_array_pop.append(np.concatenate((iteration_row[np.newaxis], merged_bh_array[:, :number_of_mergers])).T)
+        surviving_bh_array_pop.append(np.concatenate((survivor_row[np.newaxis], surviving_bh_array[:total_bh_survived, :])))
+
         if total_emris > 0:
-            emris_array_pop.append(total_emri_array[:total_emris,:])
-        #If there are non-zero elements in total_bbh_gw_array
+            emris_array_pop.append(total_emri_array[:total_emris, :])
+        # If there are non-zero elements in total_bbh_gw_array
         if total_bbh_gws > 0:
-            gw_array_pop.append(total_bbh_gw_array[:total_bbh_gws,:])
-     # save all mergers from Monte Carlo
-    merger_pop_field_names = "iter " + merger_field_names # Add "Iter" to field names
-    population_header = f"Initial seed: {opts.seed}\n{merger_pop_field_names}" # Include initial seed
+            gw_array_pop.append(total_bbh_gw_array[:total_bbh_gws, :])
+    # save all mergers from Monte Carlo
+    merger_pop_field_names = "iter " + merger_field_names  # Add "Iter" to field names
+    population_header = f"Initial seed: {opts.seed}\n{merger_pop_field_names}"  # Include initial seed
     basename, extension = os.path.splitext(opts.fname_output_mergers)
     population_save_name = f"{basename}_population{extension}"
     survivors_save_name = f"{basename}_survivors{extension}"
@@ -1312,7 +1300,9 @@ def main():
     gws_save_name = f"{basename}_lvk{extension}"
     np.savetxt(os.path.join(opts.work_directory, population_save_name), np.vstack(merged_bh_array_pop), header=population_header)
     np.savetxt(os.path.join(opts.work_directory, survivors_save_name), np.vstack(surviving_bh_array_pop))
-    np.savetxt(os.path.join(opts.work_directory,emris_save_name),np.vstack(emris_array_pop))
-    np.savetxt(os.path.join(opts.work_directory,gws_save_name),np.vstack(gw_array_pop))
+    np.savetxt(os.path.join(opts.work_directory, emris_save_name),np.vstack(emris_array_pop))
+    np.savetxt(os.path.join(opts.work_directory, gws_save_name),np.vstack(gw_array_pop))
+
+
 if __name__ == "__main__":
     main()

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -319,7 +319,7 @@ def construct_disk_direct(
     disk_model_properties ={}
     disk_model_properties['Sigma'] = surf_dens_func
     disk_model_properties['h_over_r'] = aspect_ratio_func
-    return surf_dens_func_log, aspect_ratio_func_log, disk_model_properties
+    return surf_dens_func, aspect_ratio_func, disk_model_properties
 
 def construct_disk_pAGN(
     disk_model_name,

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -32,7 +32,7 @@ Inifile
     "nsc_density_index_outer"       : float
         Index of radial density profile of NSC outside r_nsc_crit 
         (e.g. 2.5 in Generozov+18 or 2.25 if Peebles)
-    "flag_disk_aspect_ratio_avg"    : float
+    "disk_aspect_ratio_avg"    : float
         Average disk scale height (e.g. about 3% in Sirko & Goodman 2003 out to ~0.3pc)
     "nsc_spheroid_normalization"    : float
         Spheroid normalization
@@ -124,7 +124,7 @@ from io import StringIO
 
 # Grab those txt files
 from importlib import resources as impresources
-from mcfacts.inputs import data
+from mcfacts.inputs import data as mcfacts_input_data
 
 # Dictionary of types
 INPUT_TYPES = {
@@ -142,7 +142,7 @@ INPUT_TYPES = {
     "nsc_ratio_bh_mass_star_mass"   : float,
     "nsc_density_index_inner"       : float,
     "nsc_density_index_outer"       : float,
-    "flag_disk_aspect_ratio_avg"    : float,
+    "disk_aspect_ratio_avg"         : float,
     "nsc_spheroid_normalization"    : float,
     "nsc_bh_imf_mode"               : float,
     "nsc_bh_imf_powerlaw_index"     : float,
@@ -180,25 +180,15 @@ INPUT_TYPES = {
 
 
 def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
-    """This function reads your input choices from a file user specifies or
+    """Input file parser
+
+    This function reads your input choices from a file user specifies or
     default (inputs/model_choice.txt), and returns the chosen variables for 
     manipulation by main.    
 
     Required input formats and units are given in IOdocumentation.txt file.
 
-    See below for full output list, including units & formats
-
-    Example
-    -------
-    To run, ensure a model_choice.txt is in the same directory and type:
-
-        $ python ReadInputs_ini.py
-
-    Notes
-    -----
-    Function will tell you what it is doing via print statements along the way.
-
-    Attributes
+    Parameters
     ----------
     Output variables:
     disk_model_radius_array : float array
@@ -338,7 +328,7 @@ def construct_disk_interp(
     if not(flag_use_pagn):
         infile_suffix = '_surface_density.txt'
         infile = disk_model_name+infile_suffix
-        infile = impresources.files(data) / infile
+        infile = impresources.files(mcfacts_input_data) / infile
         dat = np.loadtxt(infile)
         disk_model_radius_array = dat[:,1]
         surface_density_array = dat[:,0]
@@ -358,7 +348,7 @@ def construct_disk_interp(
         #   filename = model_aspect_ratio.txt, where model is user choice
         infile_suffix = '_aspect_ratio.txt'
         infile = disk_model_name+infile_suffix
-        infile = impresources.files(data) / infile
+        infile = impresources.files(mcfacts_input_data) / infile
         dat = np.loadtxt(infile)
         aspect_ratio_array = dat[:,0]
         truncated_aspect_ratio_array=aspect_ratio_array[0:len(truncated_disk)]

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -2,48 +2,104 @@
 
 Inifile
 -------
+Attributes
+----------
     "disk_model_name"               : str
     "flag_use_pagn"                 : bool
     "smbh_mass"                     : float
+        Mass of the supermassive black hole (solMass)
     "disk_radius_trap"              : float
+        Radius of migration trap in gravitational radii (r_g = G*`smbh_mass`/c^2)
+        Should be set to zero if disk model has no trap
     "disk_radius_outer"             : float
+        final element of disk_model_radius_array (units of r_g)
     "disk_radius_max_pc"            : float
+        Maximum disk size in parsecs (0. for off)
     "disk_alpha_viscosity"          : float
     "nsc_radius_outer"              : float
+        Radius of NSC (units of pc)
     "nsc_mass"                      : float
+        Mass of NSC (units of M_sun)
     "nsc_radius_crit"               : float
+        Radius where NSC density profile flattens (transition to Bahcall-Wolf) (units of pc)
     "nsc_ratio_bh_num_star_num"     : float
+        Ratio of number of BH to stars in NSC (typically spans 3x10^-4 to 10^-2 in Generozov+18)
     "nsc_ratio_bh_mass_star_mass"   : float
+        Ratio of mass of typical BH to typical star in NSC (typically 10:1 in Generozov+18)
     "nsc_density_index_inner"       : float
+        Index of radial density profile of NSC inside r_nsc_crit (usually Bahcall-Wolf, 1.75)
     "nsc_density_index_outer"       : float
-    "flag_pisk_aspect_ratio_avg"    : float
+        Index of radial density profile of NSC outside r_nsc_crit 
+        (e.g. 2.5 in Generozov+18 or 2.25 if Peebles)
+    "flag_disk_aspect_ratio_avg"    : float
+        Average disk scale height (e.g. about 3% in Sirko & Goodman 2003 out to ~0.3pc)
     "nsc_spheroid_normalization"    : float
     "nsc_bh_imf_mode"               : float
+        Initial mass distribution for stellar bh is assumed to be Pareto
+        with high mass cutoff--mode of initial mass dist (M_sun)
     "nsc_bh_imf_powerlaw_index"     : float
+        Initial mass distribution for stellar bh is assumed to be Pareto
+        with high mass cutoff--powerlaw index for Pareto dist
     "nsc_bh_imf_mass_max"           : float
+        Initial mass distribution for stellar bh is assumed to be Pareto
+        with high mass cutoff--mass of cutoff (M_sun)
     "nsc_bh_spin_dist_mu"           : float
+        Initial spin distribution for stellar bh is assumed to be Gaussian
+        --mean of spin dist
     "nsc_bh_spin_dist_sigma"        : float
+        Initial spin distribution for stellar bh is assumed to be Gaussian
+        --standard deviation of spin dist
     "disk_bh_torque_condition"      : float
+        fraction of initial mass required to be accreted before BH spin is torqued 
+        fully into alignment with the AGN disk. We don't know for sure but 
+        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
     "disk_bh_eddington_ratio"       : float
     "disk_bh_orb_ecc_max_init"      : float
+        assumed accretion rate onto stellar bh from disk gas, in units of Eddington
+        accretion rate
     "disk_star_mass_max_init"       : float
+        Initial mass distribution for stars is assumed Salpeter
     "disk_star_mass_min_init"       : float
+        Initial mass distribution for stars is assumed Salpeter
     "nsc_imf_star_powerlaw_index"   : float
+        Initial mass distribution for stars is assumed Salpeter, disk_alpha_viscosity = 2.35
     "nsc_star_spin_dist_mu"         : float
+        Initial spin distribution for stars is assumed to be Gaussian
     "nsc_star_spin_dist_sigma"      : float
+        Initial spin distribution for stars is assumed to be Gaussian
+        --standard deviation of spin dist
     "disk_star_torque_condition"    : float
+        fraction of initial mass required to be accreted before star spin is torqued 
+        fully into alignment with the AGN disk. We don't know for sure but 
+        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
     "disk_star_eddington_ratio"     : float
+        assumed accretion rate onto stars from disk gas, in units of Eddington
+        accretion rate
     "disk_star_orb_ecc_max_init"    : float
+        assuming initially flat eccentricity distribution among single orbiters around SMBH
+        out to max_initial_eccentricity. Eventually this will become smarter.
     "nsc_star_metallicity_x_init"   : float
+        Stellar initial hydrogen mass fraction
     "nsc_star_metallicity_y_init"   : float
+        Stellar initial helium mass fraction
     "nsc_star_metallicity_z_init"   : float
+        Stellar initial metallicity mass fraction
     "timestep_duration_yr"          : float
+        How long is your timestep in years?
     "timestep_num"                  : int
+        How many timesteps are you taking (timestep*number_of_timesteps = disk_lifetime)
     "iteration_num"                 : int
+        Number of iterations of code run (e.g. 1 for testing, 30 for a quick run)
     "fraction_retro"                : float
+        Fraction of BBH that form retrograde to test (q,X_eff) relation.
+        Default retro=0.1. Possibly overwritten by initial retro population
     "fraction_bin_retro"            : float
+        Fraction of BBH that form retrograde to test (q,X_eff) relation. Default retro=0.1     
     "flag_thermal_feedback"         : int
+        Switch (1) turns feedback from embedded BH on.
     "flag_orb_ecc_damping"          : int
+        Switch (1) turns orb. ecc damping on.
+        If switch = 0, assumes all bh are circularized (at e=e_crit)
     "capture_time_myr"              : float
     "disk_radius_capture_outer"     : float
     "orb_ecc_crit"                  : float
@@ -75,7 +131,7 @@ INPUT_TYPES = {
     "nsc_ratio_bh_mass_star_mass"   : float,
     "nsc_density_index_inner"       : float,
     "nsc_density_index_outer"       : float,
-    "flag_pisk_aspect_ratio_avg"    : float,
+    "flag_disk_aspect_ratio_avg"    : float,
     "nsc_spheroid_normalization"    : float,
     "nsc_bh_imf_mode"               : float,
     "nsc_bh_imf_powerlaw_index"     : float,
@@ -134,78 +190,11 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     Attributes
     ----------
     Output variables:
-    smbh_mass : float
-        Mass of the supermassive black hole (M_sun)
-    trap_radius : float
-        Radius of migration trap in gravitational radii (r_g = G*smbh_mass/c^2)
-        Should be set to zero if disk model has no trap
-    n_iterations : int
-        Number of iterations of code run (e.g. 1 for testing, 30 for a quick run)
-    mode_mbh_init : float
-        Initial mass distribution for stellar bh is assumed to be Pareto
-        with high mass cutoff--mode of initial mass dist (M_sun)
-    max_initial_bh_mass : float
-        Initial mass distribution for stellar bh is assumed to be Pareto
-        with high mass cutoff--mass of cutoff (M_sun)
-    mbh_powerlaw_index : float
-        Initial mass distribution for stellar bh is assumed to be Pareto
-        with high mass cutoff--powerlaw index for Pareto dist
-    min_initial_star_mass : float
-        Initial mass distribution for stars is assumed Salpeter
-    max_initial_star_mass : float
-        Initial mass distribution for stars is assumed Salpeter
-    star_mass_powerlaw_index : float
-        Initial mass distribution for stars is assumed Salpeter, disk_alpha_viscosity = 2.35
-    mu_spin_distribution : float
-        Initial spin distribution for stellar bh is assumed to be Gaussian
-        --mean of spin dist
-    sigma_spin_distribution : float
-        Initial spin distribution for stellar bh is assumed to be Gaussian
-        --standard deviation of spin dist
-    spin_torque_condition : float
-        fraction of initial mass required to be accreted before BH spin is torqued 
-        fully into alignment with the AGN disk. We don't know for sure but 
-        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
-    disk_bh_orb_ecc_max_init : float
-        assumed accretion rate onto stellar bh from disk gas, in units of Eddington
-        accretion rate
-    max_initial_eccentricity : float
-        assuming initially flat eccentricity distribution among single orbiters around SMBH
-        out to max_initial_eccentricity. Eventually this will become smarter.
-    mu_star_spin_distribution : float
-        Initial spin distribution for stars is assumed to be Gaussian
-    sigma_star_spin_distribution : float
-        Initial spin distribution for stars is assumed to be Gaussian
-        --standard deviation of spin dist
-    spin_star_torque_condition : float
-        fraction of initial mass required to be accreted before star spin is torqued 
-        fully into alignment with the AGN disk. We don't know for sure but 
-        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
-    frac_star_Eddington_ratio : float
-        assumed accretion rate onto stars from disk gas, in units of Eddington
-        accretion rate
-    max_initial_star_eccentricity : float
-        assuming initially flat eccentricity distribution among single orbiters around SMBH
-        out to max_initial_eccentricity. Eventually this will become smarter.
-    stars_initial_X  : float
-        Stellar initial hydrogen mass fraction
-    stars_initial_Y : float
-        Stellar initial helium mass fraction
-    stars_initial_Z : float
-        Stellar initial metallicity mass fraction
-    timestep : float
-        How long is your timestep in years?
-    number_of_timesteps : int
-        How many timesteps are you taking (timestep*number_of_timesteps = disk_lifetime)
     disk_model_radius_array : float array
         The radii along which your disk model is defined in units of r_g (=G*smbh_mass/c^2)
         drawn from modelname_surface_density.txt
     disk_inner_radius : float
         0th element of disk_model_radius_array (units of r_g)
-    disk_radius_outer : float
-        final element of disk_model_radius_array (units of r_g)
-    disk_radius_max_pc: float
-        Maximum disk size in parsecs (0. for off)
     surface_density_array : float array
         Surface density corresponding to radii in disk_model_radius_array (units of kg/m^2)
         Yes, it's in SI not cgs. Get over it. Kisses.
@@ -213,33 +202,7 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     aspect_ratio_array : float array
         Aspect ratio corresponding to radii in disk_model_radius_array
         drawn from modelname_aspect_ratio.txt
-    retro : float
-        Fraction of BBH that form retrograde to test (q,X_eff) relation.
-        Default retro=0.1. Possibly overwritten by initial retro population
-    frac_bin_retro : float
-        Fraction of BBH that form retrograde to test (q,X_eff) relation. Default retro=0.1     
-    feedback : int
-        Switch (1) turns feedback from embedded BH on.
-    orb_ecc_damping : int
-        Switch (1) turns orb. ecc damping on.
-        If switch = 0, assumes all bh are circularized (at e=e_crit)
-    r_nsc_out : float
-        Radius of NSC (units of pc)
-    M_nsc : float
-        Mass of NSC (units of M_sun)
-    r_nsc_crit : float
-        Radius where NSC density profile flattens (transition to Bahcall-Wolf) (units of pc)
-    nbh_nstar_ratio : float
-        Ratio of number of BH to stars in NSC (typically spans 3x10^-4 to 10^-2 in Generozov+18)
-    mbh_mstar_ratio : float
-        Ratio of mass of typical BH to typical star in NSC (typically 10:1 in Generozov+18)
-    nsc_index_inner : float
-        Index of radial density profile of NSC inside r_nsc_crit (usually Bahcall-Wolf, 1.75)
-    nsc_index_outer : float
-        Index of radial density profile of NSC outside r_nsc_crit 
-        (e.g. 2.5 in Generozov+18 or 2.25 if Peebles)
     h_disk_average : float
-        Average disk scale height (e.g. about 3% in Sirko & Goodman 2003 out to ~0.3pc)
     dynamic_enc : int
         Switch (1) turns dynamical encounters between embedded BH on.
     de : float

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -1,52 +1,55 @@
-"""
-smbh_mass = 1.e8
-disk_model_name = 'sirko_goodman'
-flag_use_pagn = 0
-disk_radius_trap = 700.
-disk_radius_outer = 50000.
-disk_radius_max_pc = 0.
-disk_alpha_viscosity = 0.01
-nsc_radius_outer = 5.0
-nsc_mass = 3.e7
-nsc_radius_crit = 0.25
-nsc_ratio_bh_num_star_num = 1.e-3
-nsc_ratio_bh_mass_star_mass = 10.0
-nsc_density_index_inner = 1.75
-nsc_density_index_outer = 2.5
-flag_pisk_aspect_ratio_avg = 0.03
-nsc_spheroid_normalization = 1.0
-nsc_bh_imf_mode = 10.
-nsc_bh_imf_powerlaw_index = 2.
-nsc_bh_imf_mass_max = 40.
-nsc_bh_spin_dist_mu = 0.
-nsc_bh_spin_dist_sigma = 0.1
-disk_bh_torque_condition = 0.1
-disk_bh_eddington_ratio = 1.0
-disk_bh_orb_ecc_max_init = 0.3
-disk_star_mass_max_init = 5.
-disk_star_mass_min_init = 40.
-nsc_imf_star_powerlaw_index = 2.35
-nsc_star_spin_dist_mu = 100.
-nsc_star_spin_dist_sigma = 20.
-disk_star_torque_condition = 0.1
-disk_star_eddington_ratio = 1.0
-disk_star_orb_ecc_max_init = 0.3
-nsc_star_metallicity_x_init = 0.7274
-nsc_star_metallicity_y_init = 0.2638
-nsc_star_metallicity_z_init = 0.0088
-timestep_duration = 1.e4
-timestep_num = 100
-iteration_num = 1
-fraction_retro = 0.5
-fraction_bin_retro = 0.0
-flag_thermal_feedback = 1
-flag_orb_ecc_damping = 1
-capture_time_myr = 1.e5
-disk_radius_capture_outer = 1.e3
-orb_ecc_crit = 0.01
-flag_dynamic_enc = 1
-delta_energy_strong = 0.1
-flag_prior_agn = 0
+"""Define input handling functions for mcfacts_sim
+
+Inifile
+-------
+    disk_model_name : str,
+    flag_use_pagn : bool,
+    smbh_mass : float,
+    disk_radius_trap  : float,
+    disk_radius_outer : float,
+    disk_radius_max_pc: float,
+    disk_alpha_viscosity : float,
+    nsc_radius_outer  : float,
+    nsc_mass  : float,
+    nsc_radius_crit   : float,
+    nsc_ratio_bh_num_star_num: float,
+    nsc_ratio_bh_mass_star_mass : float,
+    nsc_density_index_inner : float,
+    nsc_density_index_outer : float,
+    flag_pisk_aspect_ratio_avg : float,
+    nsc_spheroid_normalization : float,
+    nsc_bh_imf_mode : float,
+    nsc_bh_imf_powerlaw_index : float,
+    nsc_bh_imf_mass_max : float,
+    nsc_bh_spin_dist_mu : float,
+    nsc_bh_spin_dist_sigma : float,
+    disk_bh_torque_condition: float,
+    disk_bh_eddington_ratio : float,
+    disk_bh_orb_ecc_max_init : float,
+    disk_star_mass_max_init: float,
+    disk_star_mass_min_init : float,
+    nsc_imf_star_powerlaw_index : float,
+    nsc_star_spin_dist_mu : float,
+    nsc_star_spin_dist_sigma : float,
+    disk_star_torque_condition : float
+    disk_star_eddington_ratio : float,
+    disk_star_orb_ecc_max_init : float,
+    nsc_star_metallicity_x_init : float,
+    nsc_star_metallicity_y_init : float,
+    nsc_star_metallicity_z_init : float,
+    timestep_duration_yr : float,
+    timestep_num: int
+    iteration_num: int
+    fraction_retro: float,
+    fraction_bin_retro: float,
+    flag_thermal_feedback: int,
+    flag_orb_ecc_damping: int,
+    capture_time_myr : float,
+    disk_radius_capture_outer: float,
+    orb_ecc_crit : float,
+    flag_dynamic_enc int,
+    delta_energy_strong: float,
+    flag_prior_agn : int,
 """
 import numpy as np
 import configparser as ConfigParser
@@ -58,54 +61,54 @@ from mcfacts.inputs import data
 
 # Dictionary of types
 INPUT_TYPES = {
-    "disk_model_name" : str,
-    "flag_use_pagn" : bool,
-    "smbh_mass" : float,
-    "disk_radius_trap"  : float,
-    "disk_radius_outer" : float,
-    "disk_radius_max_pc": float,
-    "disk_alpha_viscosity" : float,
-    "nsc_radius_outer"  : float,
-    "nsc_mass"  : float,
-    "nsc_radius_crit"   : float,
-    "nsc_ratio_bh_num_star_num": float,
-    "nsc_ratio_bh_mass_star_mass" : float,
-    "nsc_density_index_inner" : float,
-    "nsc_density_index_outer" : float,
-    "flag_pisk_aspect_ratio_avg" : float,
-    "nsc_spheroid_normalization" : float,
-    "nsc_bh_imf_mode" : float,
-    "nsc_bh_imf_powerlaw_index" : float,
-    "nsc_bh_imf_mass_max" : float,
-    "nsc_bh_spin_dist_mu" : float,
-    "nsc_bh_spin_dist_sigma" : float,
-    "disk_bh_torque_condition": float,
-    "disk_bh_eddington_ratio" : float,
-    "disk_bh_orb_ecc_max_init" : float,
-    "disk_star_mass_max_init": float,
-    "disk_star_mass_min_init" : float,
-    "nsc_imf_star_powerlaw_index" : float,
-    "nsc_star_spin_dist_mu" : float,
-    "nsc_star_spin_dist_sigma" : float,
-    "disk_star_torque_condition" : float
-    "disk_star_eddington_ratio" : float,
-    "disk_star_orb_ecc_max_init" : float,
-    "nsc_star_metallicity_x_init" : float,
-    "nsc_star_metallicity_y_init" : float,
-    "nsc_star_metallicity_z_init" : float,
-    "timestep_duration_yr" : float,
-    "timestep_num": int
-    "iteration_num": int
-    "fraction_retro": float,
-    "fraction_bin_retro": float,
-    "flag_thermal_feedback": int,
-    "flag_orb_ecc_damping": int,
-    "capture_time_myr" : float,
-    "disk_radius_capture_outer": float,
-    "orb_ecc_crit" : float,
-    "flag_dynamic_enc" int,
-    "delta_energy_strong": float,
-    "flag_prior_agn" : int,
+    "disk_model_name"               : str,
+    "flag_use_pagn"                 : bool,
+    "smbh_mass"                     : float,
+    "disk_radius_trap"              : float,
+    "disk_radius_outer"             : float,
+    "disk_radius_max_pc"            : float,
+    "disk_alpha_viscosity"          : float,
+    "nsc_radius_outer"              : float,
+    "nsc_mass"                      : float,
+    "nsc_radius_crit"               : float,
+    "nsc_ratio_bh_num_star_num"     : float,
+    "nsc_ratio_bh_mass_star_mass"   : float,
+    "nsc_density_index_inner"       : float,
+    "nsc_density_index_outer"       : float,
+    "flag_pisk_aspect_ratio_avg"    : float,
+    "nsc_spheroid_normalization"    : float,
+    "nsc_bh_imf_mode"               : float,
+    "nsc_bh_imf_powerlaw_index"     : float,
+    "nsc_bh_imf_mass_max"           : float,
+    "nsc_bh_spin_dist_mu"           : float,
+    "nsc_bh_spin_dist_sigma"        : float,
+    "disk_bh_torque_condition"      : float,
+    "disk_bh_eddington_ratio"       : float,
+    "disk_bh_orb_ecc_max_init"      : float,
+    "disk_star_mass_max_init"       : float,
+    "disk_star_mass_min_init"       : float,
+    "nsc_imf_star_powerlaw_index"   : float,
+    "nsc_star_spin_dist_mu"         : float,
+    "nsc_star_spin_dist_sigma"      : float,
+    "disk_star_torque_condition"    : float
+    "disk_star_eddington_ratio"     : float,
+    "disk_star_orb_ecc_max_init"    : float,
+    "nsc_star_metallicity_x_init"   : float,
+    "nsc_star_metallicity_y_init"   : float,
+    "nsc_star_metallicity_z_init"   : float,
+    "timestep_duration_yr"          : float,
+    "timestep_num"                  : int,
+    "iteration_num"                 : int,
+    "fraction_retro"                : float,
+    "fraction_bin_retro"            : float,
+    "flag_thermal_feedback"         : int,
+    "flag_orb_ecc_damping"          : int,
+    "capture_time_myr"              : float,
+    "disk_radius_capture_outer"     : float,
+    "orb_ecc_crit"                  : float,
+    "flag_dynamic_enc"              : int,
+    "delta_energy_strong"           : float,
+    "flag_prior_agn"                : int,
 }
 
 

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -2,10 +2,10 @@
 
 Inifile
 -------
-Attributes
-----------
     "disk_model_name"               : str
+        'sirko_goodman' or 'thompson_etal'
     "flag_use_pagn"                 : bool
+        Use pAGN to generate disk model?
     "smbh_mass"                     : float
         Mass of the supermassive black hole (solMass)
     "disk_radius_trap"              : float
@@ -16,6 +16,7 @@ Attributes
     "disk_radius_max_pc"            : float
         Maximum disk size in parsecs (0. for off)
     "disk_alpha_viscosity"          : float
+        disk viscosity 'alpha'
     "nsc_radius_outer"              : float
         Radius of NSC (units of pc)
     "nsc_mass"                      : float
@@ -34,6 +35,7 @@ Attributes
     "flag_disk_aspect_ratio_avg"    : float
         Average disk scale height (e.g. about 3% in Sirko & Goodman 2003 out to ~0.3pc)
     "nsc_spheroid_normalization"    : float
+        Spheroid normalization
     "nsc_bh_imf_mode"               : float
         Initial mass distribution for stellar bh is assumed to be Pareto
         with high mass cutoff--mode of initial mass dist (M_sun)
@@ -54,6 +56,7 @@ Attributes
         fully into alignment with the AGN disk. We don't know for sure but 
         Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
     "disk_bh_eddington_ratio"       : float
+        Eddington ratio for disk bh
     "disk_bh_orb_ecc_max_init"      : float
         assumed accretion rate onto stellar bh from disk gas, in units of Eddington
         accretion rate
@@ -100,12 +103,20 @@ Attributes
     "flag_orb_ecc_damping"          : int
         Switch (1) turns orb. ecc damping on.
         If switch = 0, assumes all bh are circularized (at e=e_crit)
-    "capture_time_myr"              : float
+    "capture_time_yr"              : float
+        Capture time in years Secunda et al. (2021) assume capture rate 1/0.1 Myr
     "disk_radius_capture_outer"     : float
+        Disk capture outer radius (units of r_g)
+        Secunda et al. (2001) assume <2000r_g from Fabj et al. (2020)
     "orb_ecc_crit"                  : float
+        Critical eccentricity (limiting eccentricity, below which assumed circular orbit)
     "flag_dynamic_enc"              : int
+        Switch (1) turns dynamical encounters between embedded BH on.
     "delta_energy_strong"           : float
+        Average energy change per strong interaction.
+        de can be 20% in cluster interactions. May be 10% on average (with gas)                
     "flag_prior_agn"                : int
+        Prior AGN sims BH output used as input
 """
 import numpy as np
 import configparser as ConfigParser
@@ -159,7 +170,7 @@ INPUT_TYPES = {
     "fraction_bin_retro"            : float,
     "flag_thermal_feedback"         : int,
     "flag_orb_ecc_damping"          : int,
-    "capture_time_myr"              : float,
+    "capture_time_yr"              : float,
     "disk_radius_capture_outer"     : float,
     "orb_ecc_crit"                  : float,
     "flag_dynamic_enc"              : int,
@@ -202,12 +213,6 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     aspect_ratio_array : float array
         Aspect ratio corresponding to radii in disk_model_radius_array
         drawn from modelname_aspect_ratio.txt
-    h_disk_average : float
-    dynamic_enc : int
-        Switch (1) turns dynamical encounters between embedded BH on.
-    de : float
-        Average energy change per strong interaction.
-        de can be 20% in cluster interactions. May be 10% on average (with gas)                
     prior_agn : int
         Switch (1) uses BH from a prior AGN episode (in file /recipes/postagn_bh_pop1.dat)
     """

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -108,7 +108,7 @@ Inifile
     "disk_radius_capture_outer"     : float
         Disk capture outer radius (units of r_g)
         Secunda et al. (2001) assume <2000r_g from Fabj et al. (2020)
-    "orb_ecc_crit"                  : float
+    "disk_bh_pro_orb_ecc_crit"      : float
         Critical eccentricity (limiting eccentricity, below which assumed circular orbit)
     "flag_dynamic_enc"              : int
         Switch (1) turns dynamical encounters between embedded BH on.
@@ -170,9 +170,9 @@ INPUT_TYPES = {
     "fraction_bin_retro"            : float,
     "flag_thermal_feedback"         : int,
     "flag_orb_ecc_damping"          : int,
-    "capture_time_yr"              : float,
+    "capture_time_yr"               : float,
     "disk_radius_capture_outer"     : float,
-    "orb_ecc_crit"                  : float,
+    "disk_bh_pro_orb_ecc_crit"      : float,
     "flag_dynamic_enc"              : int,
     "delta_energy_strong"           : float,
     "flag_prior_agn"                : int,

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -330,9 +330,9 @@ def construct_disk_direct(
 
     Returns
     -------
-    surf_dens_func : lambda
+    disk_surf_dens_func : lambda
         Surface density (radius)
-    aspect_ratio_func : lambda
+    disk_aspect_ratio_func : lambda
         Aspect ratio (radius)
     disk_model_properties : dict
         Other disk model things we may want
@@ -345,19 +345,19 @@ def construct_disk_direct(
         )
     # Now geenerate interpolating functions
     # create surface density & aspect ratio functions from input arrays
-    surf_dens_func_log = scipy.interpolate.CubicSpline(
+    disk_surf_dens_func_log = scipy.interpolate.CubicSpline(
         np.log(disk_model_radii), np.log(surface_densities))
-    surf_dens_func = lambda x, f=surf_dens_func_log: np.exp(f(np.log(x)))
+    disk_surf_dens_func = lambda x, f=disk_surf_dens_func_log: np.exp(f(np.log(x)))
 
-    aspect_ratio_func_log = scipy.interpolate.CubicSpline(
+    disk_aspect_ratio_func_log = scipy.interpolate.CubicSpline(
             np.log(disk_model_radii), np.log(aspect_ratios))
-    aspect_ratio_func = lambda x, f=aspect_ratio_func_log: np.exp(f(np.log(x)))
+    disk_aspect_ratio_func = lambda x, f=disk_aspect_ratio_func_log: np.exp(f(np.log(x)))
 
     # Define properties we want to return
     disk_model_properties ={}
-    disk_model_properties['Sigma'] = surf_dens_func
-    disk_model_properties['h_over_r'] = aspect_ratio_func
-    return surf_dens_func, aspect_ratio_func, disk_model_properties
+    disk_model_properties['Sigma'] = disk_surf_dens_func
+    disk_model_properties['h_over_r'] = disk_aspect_ratio_func
+    return disk_surf_dens_func, disk_aspect_ratio_func, disk_model_properties
 
 def construct_disk_pAGN(
     disk_model_name,
@@ -383,9 +383,9 @@ def construct_disk_pAGN(
 
     Returns
     -------
-    surf_dens_func : lambda
+    disk_surf_dens_func : lambda
         Surface density (radius)
-    aspect_ratio_func : lambda
+    disk_aspect_ratio_func : lambda
         Aspect ratio (radius)
     disk_model_properties : dict
         Other disk model things we may want
@@ -406,14 +406,15 @@ def construct_disk_pAGN(
 
     # Run pAGN
     pagn_model =dm_pagn.AGNGasDiskModel(disk_type=pagn_name,**base_args)
-    surf_dens_func, aspect_ratio_func, bonus_structures  = pagn_model.return_disk_surf_model()
+    disk_surf_dens_func, disk_aspect_ratio_func, bonus_structures  = \
+        pagn_model.return_disk_surf_model()
 
     # Define properties we want to return
     disk_model_properties ={}
-    disk_model_properties['Sigma'] = surf_dens_func
-    disk_model_properties['h_over_r'] = aspect_ratio_func
+    disk_model_properties['Sigma'] = disk_surf_dens_func
+    disk_model_properties['h_over_r'] = disk_aspect_ratio_func
 
-    return  surf_dens_func, aspect_ratio_func, disk_model_properties, bonus_structures
+    return  disk_surf_dens_func, disk_aspect_ratio_func, disk_model_properties, bonus_structures
 
 
 def construct_disk_interp(
@@ -445,9 +446,9 @@ def construct_disk_interp(
 
     Returns
     ------
-    surf_dens_func : lambda
+    disk_surf_dens_func : lambda
         Surface density (radius)
-    aspect_ratio_func : lambda
+    disk_aspect_ratio_func : lambda
         Aspect ratio (radius)
     """
     ## Check inputs ##
@@ -483,7 +484,7 @@ def construct_disk_interp(
     #   infile = model_surface_density.txt, where model is user choice
     if not(flag_use_pagn):
         # Load interpolators
-        surf_dens_func, aspect_ratio_func, disk_model_properties = \
+        disk_surf_dens_func, disk_aspect_ratio_func, disk_model_properties = \
             construct_disk_direct(
                 disk_model_name,
                 disk_radius_outer,
@@ -491,7 +492,7 @@ def construct_disk_interp(
 
     else:
         # instead, populate with pagn
-        surf_dens_func, aspect_ratio_func, disk_model_properties, bonus_structures = \
+        disk_surf_dens_func, disk_aspect_ratio_func, disk_model_properties, bonus_structures = \
             construct_disk_pAGN(
                 disk_model_name,
                 smbh_mass,
@@ -505,7 +506,7 @@ def construct_disk_interp(
         print("I read and digested your disk model")
         print("Sending variables back")
 
-    return surf_dens_func, aspect_ratio_func
+    return disk_surf_dens_func, disk_aspect_ratio_func
 
 def ReadInputs_prior_mergers(fname='recipes/sg1Myrx2_survivors.dat', verbose=False):
     """This function reads your prior mergers from a file user specifies or

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -2,54 +2,54 @@
 
 Inifile
 -------
-    disk_model_name : str,
-    flag_use_pagn : bool,
-    smbh_mass : float,
-    disk_radius_trap  : float,
-    disk_radius_outer : float,
-    disk_radius_max_pc: float,
-    disk_alpha_viscosity : float,
-    nsc_radius_outer  : float,
-    nsc_mass  : float,
-    nsc_radius_crit   : float,
-    nsc_ratio_bh_num_star_num: float,
-    nsc_ratio_bh_mass_star_mass : float,
-    nsc_density_index_inner : float,
-    nsc_density_index_outer : float,
-    flag_pisk_aspect_ratio_avg : float,
-    nsc_spheroid_normalization : float,
-    nsc_bh_imf_mode : float,
-    nsc_bh_imf_powerlaw_index : float,
-    nsc_bh_imf_mass_max : float,
-    nsc_bh_spin_dist_mu : float,
-    nsc_bh_spin_dist_sigma : float,
-    disk_bh_torque_condition: float,
-    disk_bh_eddington_ratio : float,
-    disk_bh_orb_ecc_max_init : float,
-    disk_star_mass_max_init: float,
-    disk_star_mass_min_init : float,
-    nsc_imf_star_powerlaw_index : float,
-    nsc_star_spin_dist_mu : float,
-    nsc_star_spin_dist_sigma : float,
-    disk_star_torque_condition : float
-    disk_star_eddington_ratio : float,
-    disk_star_orb_ecc_max_init : float,
-    nsc_star_metallicity_x_init : float,
-    nsc_star_metallicity_y_init : float,
-    nsc_star_metallicity_z_init : float,
-    timestep_duration_yr : float,
-    timestep_num: int
-    iteration_num: int
-    fraction_retro: float,
-    fraction_bin_retro: float,
-    flag_thermal_feedback: int,
-    flag_orb_ecc_damping: int,
-    capture_time_myr : float,
-    disk_radius_capture_outer: float,
-    orb_ecc_crit : float,
-    flag_dynamic_enc int,
-    delta_energy_strong: float,
-    flag_prior_agn : int,
+    "disk_model_name"               : str
+    "flag_use_pagn"                 : bool
+    "smbh_mass"                     : float
+    "disk_radius_trap"              : float
+    "disk_radius_outer"             : float
+    "disk_radius_max_pc"            : float
+    "disk_alpha_viscosity"          : float
+    "nsc_radius_outer"              : float
+    "nsc_mass"                      : float
+    "nsc_radius_crit"               : float
+    "nsc_ratio_bh_num_star_num"     : float
+    "nsc_ratio_bh_mass_star_mass"   : float
+    "nsc_density_index_inner"       : float
+    "nsc_density_index_outer"       : float
+    "flag_pisk_aspect_ratio_avg"    : float
+    "nsc_spheroid_normalization"    : float
+    "nsc_bh_imf_mode"               : float
+    "nsc_bh_imf_powerlaw_index"     : float
+    "nsc_bh_imf_mass_max"           : float
+    "nsc_bh_spin_dist_mu"           : float
+    "nsc_bh_spin_dist_sigma"        : float
+    "disk_bh_torque_condition"      : float
+    "disk_bh_eddington_ratio"       : float
+    "disk_bh_orb_ecc_max_init"      : float
+    "disk_star_mass_max_init"       : float
+    "disk_star_mass_min_init"       : float
+    "nsc_imf_star_powerlaw_index"   : float
+    "nsc_star_spin_dist_mu"         : float
+    "nsc_star_spin_dist_sigma"      : float
+    "disk_star_torque_condition"    : float
+    "disk_star_eddington_ratio"     : float
+    "disk_star_orb_ecc_max_init"    : float
+    "nsc_star_metallicity_x_init"   : float
+    "nsc_star_metallicity_y_init"   : float
+    "nsc_star_metallicity_z_init"   : float
+    "timestep_duration_yr"          : float
+    "timestep_num"                  : int
+    "iteration_num"                 : int
+    "fraction_retro"                : float
+    "fraction_bin_retro"            : float
+    "flag_thermal_feedback"         : int
+    "flag_orb_ecc_damping"          : int
+    "capture_time_myr"              : float
+    "disk_radius_capture_outer"     : float
+    "orb_ecc_crit"                  : float
+    "flag_dynamic_enc"              : int
+    "delta_energy_strong"           : float
+    "flag_prior_agn"                : int
 """
 import numpy as np
 import configparser as ConfigParser
@@ -90,7 +90,7 @@ INPUT_TYPES = {
     "nsc_imf_star_powerlaw_index"   : float,
     "nsc_star_spin_dist_mu"         : float,
     "nsc_star_spin_dist_sigma"      : float,
-    "disk_star_torque_condition"    : float
+    "disk_star_torque_condition"    : float,
     "disk_star_eddington_ratio"     : float,
     "disk_star_orb_ecc_max_init"    : float,
     "nsc_star_metallicity_x_init"   : float,

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -1,5 +1,54 @@
+"""
+smbh_mass = 1.e8
+disk_model_name = 'sirko_goodman'
+flag_use_pagn = 0
+disk_radius_trap = 700.
+disk_radius_outer = 50000.
+disk_radius_max_pc = 0.
+disk_alpha_viscosity = 0.01
+nsc_radius_outer = 5.0
+nsc_mass = 3.e7
+nsc_radius_crit = 0.25
+nsc_ratio_bh_num_star_num = 1.e-3
+nsc_ratio_bh_mass_star_mass = 10.0
+nsc_density_index_inner = 1.75
+nsc_density_index_outer = 2.5
+flag_pisk_aspect_ratio_avg = 0.03
+nsc_spheroid_normalization = 1.0
+nsc_bh_imf_mode = 10.
+nsc_bh_imf_powerlaw_index = 2.
+nsc_bh_imf_mass_max = 40.
+nsc_bh_spin_dist_mu = 0.
+nsc_bh_spin_dist_sigma = 0.1
+disk_bh_torque_condition = 0.1
+disk_bh_eddington_ratio = 1.0
+disk_bh_orb_ecc_max_init = 0.3
+disk_star_mass_max_init = 5.
+disk_star_mass_min_init = 40.
+nsc_imf_star_powerlaw_index = 2.35
+nsc_star_spin_dist_mu = 100.
+nsc_star_spin_dist_sigma = 20.
+disk_star_torque_condition = 0.1
+disk_star_eddington_ratio = 1.0
+disk_star_orb_ecc_max_init = 0.3
+nsc_star_metallicity_x_init = 0.7274
+nsc_star_metallicity_y_init = 0.2638
+nsc_star_metallicity_z_init = 0.0088
+timestep_duration = 1.e4
+timestep_num = 100
+iteration_num = 1
+fraction_retro = 0.5
+fraction_bin_retro = 0.0
+flag_thermal_feedback = 1
+flag_orb_ecc_damping = 1
+capture_time_myr = 1.e5
+disk_radius_capture_outer = 1.e3
+orb_ecc_crit = 0.01
+flag_dynamic_enc = 1
+delta_energy_strong = 0.1
+flag_prior_agn = 0
+"""
 import numpy as np
-
 import configparser as ConfigParser
 from io import StringIO
 
@@ -9,42 +58,56 @@ from mcfacts.inputs import data
 
 # Dictionary of types
 INPUT_TYPES = {
-    'disk_model_name' : str,
-    'disk_model_use_pagn': bool,
-    'mass_smbh' : float,
-    'trap_radius' : float,
-    'disk_outer_radius' : float,
-    'max_disk_radius_pc' : float,
-    'alpha' : float,
-    'n_iterations' : int,
-    'mode_mbh_init' : float,
-    'max_initial_bh_mass' : float,
-    'mbh_powerlaw_index' : float,
-    'mu_spin_distribution' : float,
-    'sigma_spin_distribution' : float,
-    'spin_torque_condition' : float,
-    'frac_Eddington_ratio' : float,
-    'max_initial_eccentricity' : float,
-    'timestep' : float,
-    'number_of_timesteps' : int,
-    'retro' : float,
-    'frac_bin_retro' : float,
-    'feedback' : int,
-    'capture_time' : float,
-    'outer_capture_radius' : float,
-    'crit_ecc' : float,
-    'r_nsc_out' : float,
-    'M_nsc' : float,
-    'r_nsc_crit' : float,
-    'nbh_nstar_ratio' : float,
-    'mbh_mstar_ratio' : float,
-    'nsc_index_inner' : float,
-    'nsc_index_outer' : float,
-    'h_disk_average' : float,
-    'dynamic_enc' : int,
-    'de' : float,
-    'orb_ecc_damping' : int,
+    "disk_model_name" : str,
+    "flag_use_pagn" : bool,
+    "smbh_mass" : float,
+    "disk_radius_trap"  : float,
+    "disk_radius_outer" : float,
+    "disk_radius_max_pc": float,
+    "disk_alpha_viscosity" : float,
+    "nsc_radius_outer"  : float,
+    "nsc_mass"  : float,
+    "nsc_radius_crit"   : float,
+    "nsc_ratio_bh_num_star_num": float,
+    "nsc_ratio_bh_mass_star_mass" : float,
+    "nsc_density_index_inner" : float,
+    "nsc_density_index_outer" : float,
+    "flag_pisk_aspect_ratio_avg" : float,
+    "nsc_spheroid_normalization" : float,
+    "nsc_bh_imf_mode" : float,
+    "nsc_bh_imf_powerlaw_index" : float,
+    "nsc_bh_imf_mass_max" : float,
+    "nsc_bh_spin_dist_mu" : float,
+    "nsc_bh_spin_dist_sigma" : float,
+    "disk_bh_torque_condition": float,
+    "disk_bh_eddington_ratio" : float,
+    "disk_bh_orb_ecc_max_init" : float,
+    "disk_star_mass_max_init": float,
+    "disk_star_mass_min_init" : float,
+    "nsc_imf_star_powerlaw_index" : float,
+    "nsc_star_spin_dist_mu" : float,
+    "nsc_star_spin_dist_sigma" : float,
+    "disk_star_torque_condition" : float
+    "disk_star_eddington_ratio" : float,
+    "disk_star_orb_ecc_max_init" : float,
+    "nsc_star_metallicity_x_init" : float,
+    "nsc_star_metallicity_y_init" : float,
+    "nsc_star_metallicity_z_init" : float,
+    "timestep_duration_yr" : float,
+    "timestep_num": int
+    "iteration_num": int
+    "fraction_retro": float,
+    "fraction_bin_retro": float,
+    "flag_thermal_feedback": int,
+    "flag_orb_ecc_damping": int,
+    "capture_time_myr" : float,
+    "disk_radius_capture_outer": float,
+    "orb_ecc_crit" : float,
+    "flag_dynamic_enc" int,
+    "delta_energy_strong": float,
+    "flag_prior_agn" : int,
 }
+
 
 def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     """This function reads your input choices from a file user specifies or
@@ -68,10 +131,10 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     Attributes
     ----------
     Output variables:
-    mass_smbh : float
+    smbh_mass : float
         Mass of the supermassive black hole (M_sun)
     trap_radius : float
-        Radius of migration trap in gravitational radii (r_g = G*mass_smbh/c^2)
+        Radius of migration trap in gravitational radii (r_g = G*smbh_mass/c^2)
         Should be set to zero if disk model has no trap
     n_iterations : int
         Number of iterations of code run (e.g. 1 for testing, 30 for a quick run)
@@ -89,7 +152,7 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     max_initial_star_mass : float
         Initial mass distribution for stars is assumed Salpeter
     star_mass_powerlaw_index : float
-        Initial mass distribution for stars is assumed Salpeter, alpha = 2.35
+        Initial mass distribution for stars is assumed Salpeter, disk_alpha_viscosity = 2.35
     mu_spin_distribution : float
         Initial spin distribution for stellar bh is assumed to be Gaussian
         --mean of spin dist
@@ -100,7 +163,7 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
         fraction of initial mass required to be accreted before BH spin is torqued 
         fully into alignment with the AGN disk. We don't know for sure but 
         Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
-    frac_Eddington_ratio : float
+    disk_bh_orb_ecc_max_init : float
         assumed accretion rate onto stellar bh from disk gas, in units of Eddington
         accretion rate
     max_initial_eccentricity : float
@@ -132,13 +195,13 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     number_of_timesteps : int
         How many timesteps are you taking (timestep*number_of_timesteps = disk_lifetime)
     disk_model_radius_array : float array
-        The radii along which your disk model is defined in units of r_g (=G*mass_smbh/c^2)
+        The radii along which your disk model is defined in units of r_g (=G*smbh_mass/c^2)
         drawn from modelname_surface_density.txt
     disk_inner_radius : float
         0th element of disk_model_radius_array (units of r_g)
-    disk_outer_radius : float
+    disk_radius_outer : float
         final element of disk_model_radius_array (units of r_g)
-    max_disk_radius_pc: float
+    disk_radius_max_pc: float
         Maximum disk size in parsecs (0. for off)
     surface_density_array : float array
         Surface density corresponding to radii in disk_model_radius_array (units of kg/m^2)
@@ -148,13 +211,15 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
         Aspect ratio corresponding to radii in disk_model_radius_array
         drawn from modelname_aspect_ratio.txt
     retro : float
-        Fraction of BBH that form retrograde to test (q,X_eff) relation. Default retro=0.1. Possibly overwritten by initial retro population
+        Fraction of BBH that form retrograde to test (q,X_eff) relation.
+        Default retro=0.1. Possibly overwritten by initial retro population
     frac_bin_retro : float
         Fraction of BBH that form retrograde to test (q,X_eff) relation. Default retro=0.1     
     feedback : int
         Switch (1) turns feedback from embedded BH on.
     orb_ecc_damping : int
-        Switch (1) turns orb. ecc damping on. If switch = 0, assumes all bh are circularized (at e=e_crit)
+        Switch (1) turns orb. ecc damping on.
+        If switch = 0, assumes all bh are circularized (at e=e_crit)
     r_nsc_out : float
         Radius of NSC (units of pc)
     M_nsc : float
@@ -168,13 +233,15 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     nsc_index_inner : float
         Index of radial density profile of NSC inside r_nsc_crit (usually Bahcall-Wolf, 1.75)
     nsc_index_outer : float
-        Index of radial density profile of NSC outside r_nsc_crit (e.g. 2.5 in Generozov+18 or 2.25 if Peebles)
+        Index of radial density profile of NSC outside r_nsc_crit 
+        (e.g. 2.5 in Generozov+18 or 2.25 if Peebles)
     h_disk_average : float
         Average disk scale height (e.g. about 3% in Sirko & Goodman 2003 out to ~0.3pc)
     dynamic_enc : int
         Switch (1) turns dynamical encounters between embedded BH on.
     de : float
-        Average energy change per strong interaction. de can be 20% in cluster interactions. May be 10% on average (with gas)                
+        Average energy change per strong interaction.
+        de can be 20% in cluster interactions. May be 10% on average (with gas)                
     prior_agn : int
         Switch (1) uses BH from a prior AGN episode (in file /recipes/postagn_bh_pop1.dat)
     """
@@ -211,8 +278,8 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
             input_variables[name] = input_variables[name].strip("'")
 
     # Set default : not use pagn.  this allows us not to provide it
-    if not('disk_model_use_pagn' in input_variables):
-        input_variables['disk_model_use_pagn'] = False
+    if not('flag_use_pagn' in input_variables):
+        input_variables['flag_use_pagn'] = False
 
     # Make sure you got all of the ones you were expecting
     for name in INPUT_TYPES:
@@ -230,31 +297,31 @@ def ReadInputs_ini(fname='inputs/model_choice.txt', verbose=False):
     return input_variables
 
 def construct_disk_interp(
-    mass_smbh,
-    disk_outer_radius,
+    smbh_mass,
+    disk_radius_outer,
     disk_model_name,
-    alpha,
-    frac_Eddington_ratio,
-    max_disk_radius_pc=0.,
-    disk_model_use_pagn=False,
+    disk_alpha_viscosity,
+    disk_bh_orb_ecc_max_init,
+    disk_radius_max_pc=0.,
+    flag_use_pagn=False,
     verbose=False,
     ):
     '''Construct the disk array interpolators
 
     Parameters
     ----------
-        mass_smbh : float
+        smbh_mass : float
             Mass of the supermassive black hole (M_sun)
-        disk_outer_radius : float
+        disk_radius_outer : float
             final element of disk_model_radius_array (units of r_g)
-        alpha : ???
+        disk_alpha_viscosity : ???
             ??? #TODO
-        frac_Eddington_ratio : float
+        disk_bh_orb_ecc_max_init : float
             assumed accretion rate onto stellar bh from disk gas, in units of Eddington
             accretion rate
-        max_disk_radius_pc : float
+        disk_radius_max_pc : float
             Maximum disk size in parsecs (0. for off)
-        disk_model_use_pagn : bool
+        flag_use_pagn : bool
             use pAGN?
         verbose : bool
             Print extra stuff?
@@ -267,37 +334,37 @@ def construct_disk_interp(
             Aspect ratio interpolator
     '''
     ## Check inputs ##
-    # Check mass_smbh
-    assert type(mass_smbh) == float, "mass_smbh expected float, got %s"%(type(mass_smbh))
+    # Check smbh_mass
+    assert type(smbh_mass) == float, "smbh_mass expected float, got %s"%(type(smbh_mass))
         
     ## Check outer disk radius in parsecs
     # Scale factor for parsec distance in r_g
-    pc_dist = 2.e5*((mass_smbh/1.e8)**(-1.0))
+    pc_dist = 2.e5*((smbh_mass/1.e8)**(-1.0))
     # Calculate outer disk radius in pc
-    disk_outer_radius_pc = disk_outer_radius/pc_dist
-    # Check max_disk_radius_pc argument
-    if max_disk_radius_pc == 0.:
-        # Case 1: max_disk_radius_pc is disabled
+    disk_radius_outer_pc = disk_radius_outer/pc_dist
+    # Check disk_radius_max_pc argument
+    if disk_radius_max_pc == 0.:
+        # Case 1: disk_radius_max_pc is disabled
         pass
-    elif max_disk_radius_pc < 0.:
-        # Case 2: max_disk_radius_pc is negative
-        # Always assign disk_outer_radius to given distance in parsecs
-        disk_outer_radius = -1. * max_disk_radius_pc * pc_dist
+    elif disk_radius_max_pc < 0.:
+        # Case 2: disk_radius_max_pc is negative
+        # Always assign disk_radius_outer to given distance in parsecs
+        disk_radius_outer = -1. * disk_radius_max_pc * pc_dist
     else:
-        # Case 3: max_disk_radius_pc is positive
-        # Cap disk_outer_radius at given value
-        if disk_outer_radius_pc > max_disk_radius_pc:
+        # Case 3: disk_radius_max_pc is positive
+        # Cap disk_radius_outer at given value
+        if disk_radius_outer_pc > disk_radius_max_pc:
             # calculate scale factor
-            disk_radius_scale = max_disk_radius_pc / disk_outer_radius_pc
-            # Adjust disk_outer_radius as needed
-            disk_outer_radius = disk_outer_radius * disk_radius_scale
+            disk_radius_scale = disk_radius_max_pc / disk_radius_outer_pc
+            # Adjust disk_radius_outer as needed
+            disk_radius_outer = disk_radius_outer * disk_radius_scale
         
     # open the disk model surface density file and read it in
     # Note format is assumed to be comments with #
     #   density in SI in first column
     #   radius in r_g in second column
     #   infile = model_surface_density.txt, where model is user choice
-    if not(disk_model_use_pagn):
+    if not(flag_use_pagn):
         infile_suffix = '_surface_density.txt'
         infile = disk_model_name+infile_suffix
         infile = impresources.files(data) / infile
@@ -306,7 +373,7 @@ def construct_disk_interp(
         surface_density_array = dat[:,0]
         #truncate disk at outer radius
         truncated_disk = np.extract(
-            np.where(disk_model_radius_array < disk_outer_radius),
+            np.where(disk_model_radius_array < disk_radius_outer),
             disk_model_radius_array
         )
         #print('truncated disk', truncated_disk)
@@ -347,14 +414,14 @@ def construct_disk_interp(
         import mcfacts.external.DiskModelsPAGN as dm_pagn
         import pagn.constants as ct
         pagn_name = "Sirko"
-        base_args = { 'Mbh': mass_smbh*ct.MSun,\
-                      'alpha':alpha, \
-                      'le':frac_Eddington_ratio}                    
+        base_args = { 'Mbh': smbh_mass*ct.MSun,\
+                      'alpha':disk_alpha_viscosity, \
+                      'le':disk_bh_orb_ecc_max_init}                    
         if 'thompson' in disk_model_name:
             pagn_name = 'Thompson'
-            base_args = { 'Mbh': mass_smbh*ct.MSun}
-            Rg = mass_smbh*ct.MSun * ct.G / (ct.c ** 2)
-            base_args['Rout'] = disk_outer_radius*Rg;  # remember pagn uses SI units, but we provide r/rg
+            base_args = { 'Mbh': smbh_mass*ct.MSun}
+            Rg = smbh_mass*ct.MSun * ct.G / (ct.c ** 2)
+            base_args['Rout'] = disk_radius_outer*Rg;  # remember pagn uses SI units, but we provide r/rg
         # note Rin default is 3 Rs
         
         pagn_model =dm_pagn.AGNGasDiskModel(disk_type=pagn_name,**base_args)

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -79,7 +79,7 @@ nsc_star_metallicity_z_init = 0.0088
 # Timing:
 # 
 # timestep in years (float)
-timestep_duration = 1.e4
+timestep_duration_yr = 1.e4
 # For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
 timestep_num = 100
 

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -39,7 +39,7 @@ nsc_density_index_inner = 1.75
 #Radial density index for outer NSC, for r>r_nsc_crit. n propto r^-2.5 for Generozov+18, r^-2.25 Peebles
 nsc_density_index_outer = 2.5
 #Average aspect ratio of disk (calculate this based on r_disk_outer?). Roughly 3% or so for Sirko&Goodman03.
-flag_pisk_aspect_ratio_avg = 0.03
+flag_disk_aspect_ratio_avg = 0.03
 #Normalize spheroid component rate of interactions (default = 1.0)
 nsc_spheroid_normalization = 1.0
 

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -5,109 +5,109 @@
 # See IOdocumentation.txt for details.
 #
 # SMBH mass in units of M_sun:
-mass_smbh = 1.e8
+smbh_mass = 1.e8
 #
 # SMBH accretion disk:
 #
 # Specify prefix to filenames for input disk model
 disk_model_name = 'sirko_goodman'
 # pAGN flag (0/1) boolean
-disk_model_use_pagn = 0
+flag_use_pagn = 0
 # trap radius in r_g
-trap_radius = 700.
+disk_radius_trap = 700.
 # disk outer radius in r_g
-disk_outer_radius = 50000.
+disk_radius_outer = 50000.
 # Maximum disk outer radius (pc) (0. turns this off)
-max_disk_radius_pc = 0.
+disk_radius_max_pc = 0.
 # disk alpha parameter (viscosity parameter, alpha=0.01 in sirko_goodman)
-alpha = 0.01
+disk_alpha_viscosity = 0.01
 #
 # Nuclear Star Cluster Population:
 #
 #Outer radius of NSC (1-10pc) in units of pc
-r_nsc_out = 5.0
-#Mass of NSC in M_sun. Milky Way NSC is 3x10^7Msun. Typically 10^6-8Msun from obs.
-M_nsc = 3.e7
+nsc_radius_outer = 5.0
+#Mass of NSC in M_sun. Milky Way NSC is 3x10^7Msun. Typically 10^6-8Msun from obs
+nsc_mass = 3.e7
 #Inner critial NSC radius (where radial number density changes) in units of pc. 0.25pc for SgrA* (Generozov+18).
-r_nsc_crit = 0.25
+nsc_radius_crit = 0.25
 #Ratio of number of BH to number of Stars (spans 3x10^-4 to 10^-2 in Generozov+18)
-nbh_nstar_ratio = 1.e-3
+nsc_ratio_bh_num_star_num = 1.e-3
 #Typical ratio of mass of BH to mass of star (10Msun:1Msun in Generozov+18)
-mbh_mstar_ratio = 10.0
+nsc_ratio_bh_mass_star_mass = 10.0
 #Radial density index for inner NSC, for r<r_nsc_crit. n propto r^-7/4 for Bahcall-Wolf (& Generozov+18)
-nsc_index_inner = 1.75
-#Radial density index for outer NSC, for r>r_nsc_crit. n propto r^-2.5 for Generozov+18, r^-2.25 Peebles)
-nsc_index_outer = 2.5
+nsc_density_index_inner = 1.75
+#Radial density index for outer NSC, for r>r_nsc_crit. n propto r^-2.5 for Generozov+18, r^-2.25 Peebles
+nsc_density_index_outer = 2.5
 #Average aspect ratio of disk (calculate this based on r_disk_outer?). Roughly 3% or so for Sirko&Goodman03.
-h_disk_average = 0.03
+flag_pisk_aspect_ratio_avg = 0.03
 #Normalize spheroid component rate of interactions (default = 1.0)
-sph_norm = 1.0
+nsc_spheroid_normalization = 1.0
 
 # Mode of initial BH mass distribution in M_sun (peak of Pareto fn)
-mode_mbh_init = 10.
+nsc_bh_imf_mode = 10.
 # Pareto (powerlaw) initial BH mass index
-mbh_powerlaw_index = 2.
+nsc_bh_imf_powerlaw_index = 2.
 # Maximum initial BH mass in distribution in M_sun
-max_initial_bh_mass = 40.
+nsc_bh_imf_mass_max = 40.
 # Mean of Gaussian initial spin distribution 
-mu_spin_distribution = 0.
+nsc_bh_spin_dist_mu = 0.
 # Sigma of Gaussian initial spin distribution 
-sigma_spin_distribution = 0.1
+nsc_bh_spin_dist_sigma = 0.1
 # Spin torque condition
-spin_torque_condition = 0.1
+disk_bh_torque_condition = 0.1
 # Accretion rate of fully embedded stellar mass black hole in units of 
 #   Eddington accretion rate
-frac_Eddington_ratio = 1.0
+disk_bh_eddington_ratio = 1.0
 # Maximum initial eccentricity
-max_initial_eccentricity = 0.3
+disk_bh_orb_ecc_max_init = 0.3
 #
 #
 #Star stuff
-min_initial_star_mass = 5.
-max_initial_star_mass = 40.
-star_mass_powerlaw_index = 2.35
-mu_star_spin_distribution = 100.
-sigma_star_spin_distribution = 20.
-spin_star_torque_condition = 0.1
-frac_star_Eddington_ratio = 1.0
-max_initial_star_eccentricity = 0.3
+disk_star_mass_max_init = 5.
+disk_star_mass_min_init = 40.
+nsc_imf_star_powerlaw_index = 2.35
+nsc_star_spin_dist_mu = 100.
+nsc_star_spin_dist_sigma = 20.
+disk_star_torque_condition = 0.1
+disk_star_eddington_ratio = 1.0
+disk_star_orb_ecc_max_init = 0.3
 #These values are from Brott+2011
-stars_initial_X = 0.7274
-stars_initial_Y = 0.2638
-stars_initial_Z = 0.0088
+nsc_star_metallicity_x_init = 0.7274
+nsc_star_metallicity_y_init = 0.2638
+nsc_star_metallicity_z_init = 0.0088
 
 # Timing:
 # 
 # timestep in years (float)
-timestep = 1.e4
+timestep_duration = 1.e4
 # For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
-number_of_timesteps = 100
+timestep_num = 100
 
 # number of iterations of code (1 for testing. 30 for a quick run.)
-n_iterations = 1
+iteration_num = 1
 #
 # Other physics choices: 
 #
 # retrograde binaries on/off (1/0) switch. Retrograde = 0(1) means retrograde bins are suppressed(allowed)
-retro = 0.5
+fraction_retro = 0.5
 # New retrograde binary switch
-frac_bin_retro = 0.0
+fraction_bin_retro = 0.0
 # feedback on/off switch. Feedback = 1(0) means feedback is allowed(off)
-feedback = 1
+flag_thermal_feedback = 1
 # eccentricity damping (1/0) switch. 
 # orb_ecc_damping = 1 means orbital damping is on & orb ecc is drawn from e.g. uniform or thermal distribution
 # orb_ecc_damping = 0 means orbital damping is off and all BH are assumed to be on circularized orbits (=e_crit)
-orb_ecc_damping = 1
+flag_orb_ecc_damping = 1
 # Disk capture 
 # capture time in years (float). Secunda et al. (2021) assume capture rate 1/0.1Myr
-capture_time = 1.e5
+capture_time_myr = 1.e5
 # Disk capture outer radius (in units of r_g). Secunda et al. (2021) assume <2000r_g from Fabj et al. (2020)
-outer_capture_radius = 1.e3
+disk_radius_capture_outer = 1.e3
 #Critical eccentricity (limiting eccentricity, below which assumed circular orbit)
-crit_ecc = 0.01
+orb_ecc_crit = 0.01
 #Dynamics on/off switch. Dynamics = 0(1) means dynamical encounters are off (on)
-dynamic_enc = 1
+flag_dynamic_enc = 1
 # Delta Energy per Strong interaction (can be up to 20%,0.2)
-de = 0.1
+delta_energy_strong = 0.1
 # Prior AGN sims BH output (output_mergers_survivors.dat) used as input ( renamed & located as /recipes/postagn_bh_pop1.dat)
-prior_agn = 0
+flag_prior_agn = 0

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -104,7 +104,7 @@ capture_time_yr = 1.e5
 # Disk capture outer radius (in units of r_g). Secunda et al. (2021) assume <2000r_g from Fabj et al. (2020)
 disk_radius_capture_outer = 1.e3
 #Critical eccentricity (limiting eccentricity, below which assumed circular orbit)
-orb_ecc_crit = 0.01
+disk_bh_pro_orb_ecc_crit = 0.01
 #Dynamics on/off switch. Dynamics = 0(1) means dynamical encounters are off (on)
 flag_dynamic_enc = 1
 # Delta Energy per Strong interaction (can be up to 20%,0.2)

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -39,7 +39,7 @@ nsc_density_index_inner = 1.75
 #Radial density index for outer NSC, for r>r_nsc_crit. n propto r^-2.5 for Generozov+18, r^-2.25 Peebles
 nsc_density_index_outer = 2.5
 #Average aspect ratio of disk (calculate this based on r_disk_outer?). Roughly 3% or so for Sirko&Goodman03.
-flag_disk_aspect_ratio_avg = 0.03
+disk_aspect_ratio_avg = 0.03
 #Normalize spheroid component rate of interactions (default = 1.0)
 nsc_spheroid_normalization = 1.0
 

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -63,8 +63,8 @@ disk_bh_orb_ecc_max_init = 0.3
 #
 #
 #Star stuff
-disk_star_mass_max_init = 5.
-disk_star_mass_min_init = 40.
+disk_star_mass_min_init = 5.
+disk_star_mass_max_init = 40.
 nsc_imf_star_powerlaw_index = 2.35
 nsc_star_spin_dist_mu = 100.
 nsc_star_spin_dist_sigma = 20.
@@ -100,7 +100,7 @@ flag_thermal_feedback = 1
 flag_orb_ecc_damping = 1
 # Disk capture 
 # capture time in years (float). Secunda et al. (2021) assume capture rate 1/0.1Myr
-capture_time_myr = 1.e5
+capture_time_yr = 1.e5
 # Disk capture outer radius (in units of r_g). Secunda et al. (2021) assume <2000r_g from Fabj et al. (2020)
 disk_radius_capture_outer = 1.e3
 #Critical eccentricity (limiting eccentricity, below which assumed circular orbit)

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -44,42 +44,42 @@ class AGNObject(object):
     def __init__(self,  mass = None,
                         spin = None, #internal quantity. total J for a binary
                         spin_angle = None, #angle between J and orbit around SMBH for binary
-                        orbit_a = None, #location
-                        orbit_inclination= None, #of CoM for binary around SMBH
+                        orb_a = None, #location
+                        orb_inc= None, #of CoM for binary around SMBH
                         #orb_ang_mom = None,  # redundant, should be computed from keplerian orbit formula for L in terms of mass, a, eccentricity
-                        orbit_e = None,
-                        orbit_arg_periapse = None,
-                        mass_smbh = None,
-                        nsystems = None,
+                        orb_ecc = None,
+                        orb_arg_periapse = None,
+                        smbh_mass = None,
+                        obj_num = None,
                         id_start_val = None):
         
         #Make sure all inputs are included
         """ if mass is None: raise AttributeError("mass is not included in inputs")
         if spin is None: raise AttributeError('spin is not included in inputs')
         if spin_angle is None: raise AttributeError('spin_angle is not included in inputs')
-        if orbit_a is None: raise AttributeError('orbit_a is not included in inputs')
-        if orbit_inclination is None: raise AttributeError('orbit_inclination is not included in inputs')
+        if orb_a is None: raise AttributeError('orb_a is not included in inputs')
+        if orb_inc is None: raise AttributeError('orb_inc is not included in inputs')
 #        if orb_ang_mom is None: raise AttributeError('orb_ang_mom is not included in inputs')
-        if orbit_e is None: raise AttributeError('orbit_e is not included in inputs') """
+        if orb_ecc is None: raise AttributeError('orb_ecc is not included in inputs') """
 
         """
 
-        assert mass.shape == (nsystems,),"mass: all arrays must be 1d and the same length"
-        assert spin.shape == (nsystems,),"spin: all arrays must be 1d and the same length"
-        assert spin_angle.shape == (nsystems,),"spin_angle: all arrays must be 1d and the same length"
-        assert orbit_a.shape == (nsystems,),"orbit_a: all arrays must be 1d and the same length"
-        assert orbit_inclination.shape == (nsystems,),"orbit_inclination: all arrays must be 1d and the same length"
-#        assert orb_ang_mom.shape == (nsystems,),"orb_ang_mom: all arrays must be 1d and the same length"
-        assert orbit_e.shape == (nsystems,),"orbit_e: all arrays must be 1d and the same length" """
+        assert mass.shape == (obj_num,),"mass: all arrays must be 1d and the same length"
+        assert spin.shape == (obj_num,),"spin: all arrays must be 1d and the same length"
+        assert spin_angle.shape == (obj_num,),"spin_angle: all arrays must be 1d and the same length"
+        assert orb_a.shape == (obj_num,),"orb_a: all arrays must be 1d and the same length"
+        assert orb_inc.shape == (obj_num,),"orb_inc: all arrays must be 1d and the same length"
+#        assert orb_ang_mom.shape == (obj_num,),"orb_ang_mom: all arrays must be 1d and the same length"
+        assert orb_ecc.shape == (obj_num,),"orb_ecc: all arrays must be 1d and the same length" """
         
         if mass is None:
             #creating an empty object
             #i know this is a terrible way to do things
-            self.generations = None
+            self.gen = None
             self.id_num = None
         else:
-            if nsystems is None: nsystems = mass.size
-            self.generations = np.full(nsystems,1)
+            if obj_num is None: obj_num = mass.size
+            self.gen = np.full(obj_num,1)
             if id_start_val is None:
                 self.id_num = np.arange(0,len(mass)) #creates ID numbers sequentially from 0
             else: #if we have an id_start_val aka these aren't the first objects in the disk
@@ -88,12 +88,12 @@ class AGNObject(object):
         self.mass = mass #Should be array. TOTAL masses.
         self.spin = spin #Should be array
         self.spin_angle = spin_angle #should be array
-        self.orbit_a = orbit_a #Should be array. Semimajor axis
-        self.orbit_inclination = orbit_inclination #Should be array. Allows for misaligned orbits.
+        self.orb_a = orb_a #Should be array. Semimajor axis
+        self.orb_inc = orb_inc #Should be array. Allows for misaligned orbits.
         #self.orb_ang_mom = orb_ang_mom #needs to be added in!
-        self.orbit_e = orbit_e #Should be array. Allows for eccentricity.
-        #self.__mass_smbh = mass_smbh
-        self.orbit_arg_periapse = orbit_arg_periapse
+        self.orb_ecc = orb_ecc #Should be array. Allows for eccentricity.
+        #self.__smbh_mass = smbh_mass
+        self.orb_arg_periapse = orb_arg_periapse
 
 
 
@@ -101,13 +101,13 @@ class AGNObject(object):
                               new_spin = None,
                               new_spin_angle = None,
                               new_orb_a = None,
-                              new_orb_inclination = None,
+                              new_orb_inc = None,
                               new_orb_ang_mom = None,
-                              new_orb_e = None,
+                              new_orb_ecc = None,
                               new_orb_arg_periapse = None,
-                              new_generation = None,
+                              new_gen = None,
                               new_id_num = None,
-                              nsystems = None):
+                              obj_num = None):
         """
         Adds new values to the end of existing arrays
         """
@@ -117,40 +117,40 @@ class AGNObject(object):
         if new_spin is None: raise AttributeError('new_spin is not included in inputs')
         if new_spin_angle is None: raise AttributeError('new_spin_angle is not included in inputs')
         if new_a is None: raise AttributeError('new_a is not included in inputs')
-        if new_inclination is None: raise AttributeError('new_inclination is not included in inputs')
+        if new_inc is None: raise AttributeError('new_inc is not included in inputs')
 #        if new_orb_ang_mom is None: raise AttributeError('new_orb_ang_mom is not included in inputs')
         if new_e is None: raise AttributeError('new_e is not included in inputs')
 
-        if nsystems is None: nsystems = new_mass.size
+        if obj_num is None: obj_num = new_mass.size
 
-        assert new_mass.shape == (nsystems,),"new mass: all arrays must be 1d and the same length"
-        assert new_spin.shape == (nsystems,),"new_spin: all arrays must be 1d and the same length"
-        assert new_spin_angle.shape == (nsystems,),"new_spin_angle: all arrays must be 1d and the same length"
-        assert new_a.shape == (nsystems,),"new_a: all arrays must be 1d and the same length"
-        assert new_inclination.shape == (nsystems,),"new_inclination: all arrays must be 1d and the same length"
-#        assert new_orb_ang_mom.shape == (nsystems,),"new_orb_ang_mom: all arrays must be 1d and the same length"
-        assert new_e.shape == (nsystems,),"new_e: all arrays must be 1d and the same length" """
+        assert new_mass.shape == (obj_num,),"new mass: all arrays must be 1d and the same length"
+        assert new_spin.shape == (obj_num,),"new_spin: all arrays must be 1d and the same length"
+        assert new_spin_angle.shape == (obj_num,),"new_spin_angle: all arrays must be 1d and the same length"
+        assert new_a.shape == (obj_num,),"new_a: all arrays must be 1d and the same length"
+        assert new_inc.shape == (obj_num,),"new_inc: all arrays must be 1d and the same length"
+#        assert new_orb_ang_mom.shape == (obj_num,),"new_orb_ang_mom: all arrays must be 1d and the same length"
+        assert new_e.shape == (obj_num,),"new_e: all arrays must be 1d and the same length" """
 
-        #new_M = new_mass + mass_smbh
-        #new_M_reduced = new_mass*mass_smbh/new_M
-        #new_orb_ang_mom = new_M_reduced*np.sqrt(G.to('m^3/(M_sun s^2)').value*new_M*new_a*(1-new_inclination**2))
+        #new_M = new_mass + smbh_mass
+        #new_M_reduced = new_mass*smbh_mass/new_M
+        #new_orb_ang_mom = new_M_reduced*np.sqrt(G.to('m^3/(M_sun s^2)').value*new_M*new_a*(1-new_inc**2))
         #self.new_orb_ang_mom = setupdiskstars.setup_disk_stars_orb_ang_mom(
-        #                                                               n_stars=nsystems,
+        #                                                               star_num=obj_num,
         #                                                               M_reduced=new_M_reduced,
         #                                                               M=new_M,
-        #                                                               orbit_a = new_a,
-        #                                                               orbit_inclination=new_inclination)
+        #                                                               orb_a = new_a,
+        #                                                               orb_inc=new_inc)
 
 
         self.mass = np.concatenate([self.mass,new_mass])
         self.spin = np.concatenate([self.spin,new_spin])
         self.spin_angle = np.concatenate([self.spin_angle,new_spin_angle])
-        self.orbit_a = np.concatenate([self.orbit_a,new_orb_a])
+        self.orb_a = np.concatenate([self.orb_a,new_orb_a])
         self.orb_ang_mom = np.concatenate([self.orb_ang_mom, new_orb_ang_mom])
-        self.orbit_inclination = np.concatenate([self.orbit_inclination,new_orb_inclination])
-        self.orbit_e = np.concatenate([self.orbit_e,new_orb_e])
-        self.orbit_arg_periapse = np.concatenate([self.orbit_arg_periapse,new_orb_arg_periapse])
-        self.generations = np.concatenate([self.generations,new_generation])
+        self.orb_inc = np.concatenate([self.orb_inc,new_orb_inc])
+        self.orb_ecc = np.concatenate([self.orb_ecc,new_orb_ecc])
+        self.orb_arg_periapse = np.concatenate([self.orb_arg_periapse,new_orb_arg_periapse])
+        self.gen = np.concatenate([self.gen,new_gen])
         self.id_num = np.concatenate([self.id_num, new_id_num])
 
     def remove_objects(self, idx_remove = None):
@@ -288,7 +288,7 @@ class AGNStar(AGNObject):
     An array of single stars. Should include all objects of this type. No other objects should contain objects of this type.
     Takes in initial helium and metals mass fractions, calculates hydrogen mass fraction from that to ensure it adds up to unity.
     """
-    def __init__(self, mass = None, star_radius = None, star_Y = None, star_Z = None, n_stars = None, mass_smbh = None, orbit_a = None, orbit_inclination= None, **kwargs):
+    def __init__(self, mass = None, star_radius = None, star_Y = None, star_Z = None, star_num = None, smbh_mass = None, orb_a = None, orb_inc= None, **kwargs):
         """
         Array of single star objects.
         star_radius should be a 1d numpy array
@@ -299,7 +299,7 @@ class AGNStar(AGNObject):
         """ if star_Y is None: raise AttributeError('star_Y is not included in inputs')
         if star_Z is None: raise AttributeError('star_Z is not included in inputs') """
 
-        if n_stars is None: n_stars = star_radius.size
+        if star_num is None: star_num = star_radius.size
 
         #Make sure inputs are numpy arrays
         if star_radius is None:
@@ -318,9 +318,9 @@ class AGNStar(AGNObject):
             self.star_Z = np.full(len(star_radius),star_Z)
         
         elif ((isinstance(star_Y,np.ndarray) and isinstance(star_Z,np.ndarray))):
-            assert star_radius.shape == (n_stars,),"star_radius: all arrays must be 1d and the same length"
-            assert star_Y.shape == (n_stars,),"star_Y, array: all arrays must be 1d and the same length"
-            assert star_Z.shape == (n_stars,),"star_Z, array: all arrays must be 1d and the same length"
+            assert star_radius.shape == (star_num,),"star_radius: all arrays must be 1d and the same length"
+            assert star_Y.shape == (star_num,),"star_Y, array: all arrays must be 1d and the same length"
+            assert star_Z.shape == (star_num,),"star_Z, array: all arrays must be 1d and the same length"
 
             self.star_X = 1. - star_Y - star_Z
             self.star_Y = star_Y
@@ -329,23 +329,23 @@ class AGNStar(AGNObject):
         else:
             raise TypeError("star_Y and star_Z must be either both floats or numpy arrays")
         
-        M = mass + mass_smbh
-        M_reduced = mass*mass_smbh/M
-        #self.orb_ang_mom = M_reduced*np.sqrt(G.to('m^3/(M_sun s^2)').value*M*self.orbit_a*(1-self.orbit_inclination**2))
-        self.orb_ang_mom = setupdiskstars.setup_disk_stars_orb_ang_mom(n_stars=n_stars,
+        M = mass + smbh_mass
+        M_reduced = mass*smbh_mass/M
+        #self.orb_ang_mom = M_reduced*np.sqrt(G.to('m^3/(M_sun s^2)').value*M*self.orb_a*(1-self.orb_inc**2))
+        self.orb_ang_mom = setupdiskstars.setup_disk_stars_orb_ang_mom(star_num=star_num,
                                                                        M_reduced=M_reduced,
                                                                        M=M,
-                                                                       orbit_a = orbit_a,
-                                                                       orbit_inclination=orbit_inclination)
+                                                                       orb_a = orb_a,
+                                                                       orb_inc=orb_inc)
 
 
 
-        super(AGNStar,self).__init__(mass = mass,orbit_a = orbit_a, orbit_inclination=orbit_inclination, nsystems = n_stars, **kwargs) #calls top level functions
+        super(AGNStar,self).__init__(mass = mass,orb_a = orb_a, orb_inc=orb_inc, obj_num = star_num, **kwargs) #calls top level functions
     
     def __repr__(self):
         return('AGNStar(): {} single stars'.format(len(self.mass)))
 
-    def add_stars(self, new_radius = None, new_Y = None, new_Z = None, nsystems = None, **kwargs):
+    def add_stars(self, new_radius = None, new_Y = None, new_Z = None, obj_num = None, **kwargs):
         """
         Add new star values to the end of existing arrays.
         """
@@ -355,23 +355,23 @@ class AGNStar(AGNObject):
         if new_Y is None: raise AttributeError("new_Y is not included in inputs")
         if new_Z is None: raise AttributeError("new_Z is not included in inputs")
 
-        if nsystems is None: nsystems = new_radius.size
+        if obj_num is None: obj_num = new_radius.size
 
-        assert new_radius.shape == (nsystems,),"new_radius: all arrays must be 1d and the same length"
+        assert new_radius.shape == (obj_num,),"new_radius: all arrays must be 1d and the same length"
         self.star_radius = np.concatenate([self.star_radius,new_radius])
 
         if(np.any(new_Y + new_Z) > 1.): raise ValueError("new_Y and new_Z must sum to 1 or less")
 
         if( (isinstance(new_Y, float)) and (isinstance(new_Z, float))):
-            self.star_X = np.concatenate(self.star_X, np.full(nsystems,1.-new_Y-new_Z))
-            self.star_Y = np.concatenate([self.star_Y, np.full(nsystems,new_Y)])
-            self.star_Z = np.concatenate([self.star_Z, np.full(nsystems,new_Z)])
+            self.star_X = np.concatenate(self.star_X, np.full(obj_num,1.-new_Y-new_Z))
+            self.star_Y = np.concatenate([self.star_Y, np.full(obj_num,new_Y)])
+            self.star_Z = np.concatenate([self.star_Z, np.full(obj_num,new_Z)])
             
         if( (isinstance(new_Y, np.ndarray)) and (isinstance(new_Z, np.ndarray))):
-            self.star_X = np.concatenate([self.star_X, np.ones(nsystems) - new_Y - new_Z])
+            self.star_X = np.concatenate([self.star_X, np.ones(obj_num) - new_Y - new_Z])
             self.star_Y = np.concatenate([self.star_Y, new_Y])
             self.star_Z = np.concatenate([self.star_Z, new_Z])
-        super(AGNStar,self).add_objects(nsystems = nsystems, **kwargs)
+        super(AGNStar,self).add_objects(obj_num = obj_num, **kwargs)
 
 
 class AGNBlackHole(AGNObject):
@@ -388,8 +388,8 @@ class AGNBlackHole(AGNObject):
         return('AGNBlackHole(): {} single black holes'.format(len(self.mass)))
 
 
-    def add_blackholes(self, nsystems = None, **kwargs):
-        super(AGNBlackHole,self).add_objects(nsystems = nsystems, **kwargs)
+    def add_blackholes(self, obj_num = None, **kwargs):
+        super(AGNBlackHole,self).add_objects(obj_num = obj_num, **kwargs)
 
 
 class AGNBinaryStar(AGNObject):
@@ -399,7 +399,7 @@ class AGNBinaryStar(AGNObject):
         * scalar properties of each star:  masses, radius, Y,Z (star_mass1,star_mass2, star_radius1, star_radius2, ...)
          * vector properties of each star: individual angular momentum vectors (spin1,spin_angle_1) *relative to the z axis of the binary orbit*,
            not SMBH
-         * orbit properties: use a reduced mass hamiltonian, you have 'r = r2 - r1' (vector) for which we get binary_a, binary_e, binary_inclination (relative to SMBH)
+         * orbit properties: use a reduced mass hamiltonian, you have 'r = r2 - r1' (vector) for which we get bin_a, bin_e, bin_inc (relative to SMBH)
 
     """
 
@@ -415,13 +415,13 @@ class AGNBinaryStar(AGNObject):
                        star_spin2 = None,
                        star_spin_angle1 = None,
                        star_spin_angle2 = None,
-                       binary_e = None,
-                       binary_a = None,
-                       binary_inclination=None,
-                       cm_orbit_a=None,
-                       cm_orbit_inclination=None,
-                       cm_orbit_e=None,
-                       nsystems = None,
+                       bin_e = None,
+                       bin_a = None,
+                       bin_inc=None,
+                       cm_orb_a=None,
+                       cm_orb_inc=None,
+                       cm_orb_ecc=None,
+                       obj_num = None,
                      **kwargs):
         
         #Make sure all inputs are included
@@ -437,22 +437,22 @@ class AGNBinaryStar(AGNObject):
         if star_spin2 is None: raise AttributeError("star_spin2 is not included in inputs")
         if star_spin_angle1 is None: raise AttributeError("star_spin_angle1 is not included in inputs")
         if star_spin_angle2 is None: raise AttributeError("star_spin_angle2 is not included in inputs")
-        if binary_e is None: raise AttributeError("binary_e is not included in inputs")
-        if binary_a is None: raise AttributeError("binary_a is not included in inputs")
+        if bin_e is None: raise AttributeError("bin_e is not included in inputs")
+        if bin_a is None: raise AttributeError("bin_a is not included in inputs")
 
-        if nsystems is None: nsystems = star_mass1.size
+        if obj_num is None: obj_num = star_mass1.size
 
         #Check that all inputs are 1d numpy arrays
-        assert star_mass1.shape == (nsystems,),"star_mass1: all arrays must be 1d and the same length"
-        assert star_mass2.shape == (nsystems,),"star_mass2: all arrays must be 1d and the same length"
-        assert star_radius1.shape == (nsystems,),"star_radius1: all arrays must be 1d and the same length"
-        assert star_radius2.shape == (nsystems,),"star_radius2: all arrays must be 1d and the same length"
-        assert star_spin1.shape == (nsystems,),"star_spin1: all arrays must be 1d and the same length"
-        assert star_spin2.shape == (nsystems,),"star_spin2: all arrays must be 1d and the same length"
-        assert star_spin_angle1.shape == (nsystems,),"star_spin_angle1: all arrays must be 1d and the same length"
-        assert star_spin_angle2.shape == (nsystems,),"star_spin_angle2: all arrays must be 1d and the same length"
-        assert binary_e.shape == (nsystems,),"binary_e: all arrays must be 1d and the same length"
-        assert binary_a.shape == (nsystems,),"binary_a: all arrays must be 1d and the same length"
+        assert star_mass1.shape == (obj_num,),"star_mass1: all arrays must be 1d and the same length"
+        assert star_mass2.shape == (obj_num,),"star_mass2: all arrays must be 1d and the same length"
+        assert star_radius1.shape == (obj_num,),"star_radius1: all arrays must be 1d and the same length"
+        assert star_radius2.shape == (obj_num,),"star_radius2: all arrays must be 1d and the same length"
+        assert star_spin1.shape == (obj_num,),"star_spin1: all arrays must be 1d and the same length"
+        assert star_spin2.shape == (obj_num,),"star_spin2: all arrays must be 1d and the same length"
+        assert star_spin_angle1.shape == (obj_num,),"star_spin_angle1: all arrays must be 1d and the same length"
+        assert star_spin_angle2.shape == (obj_num,),"star_spin_angle2: all arrays must be 1d and the same length"
+        assert bin_e.shape == (obj_num,),"bin_e: all arrays must be 1d and the same length"
+        assert bin_a.shape == (obj_num,),"bin_a: all arrays must be 1d and the same length"
 
         if (np.any(star_Y1 + star_Z1 > 1.)):
             raise ValueError("star_Y1 and star_Z1 must sum to 1 or less.")
@@ -460,21 +460,21 @@ class AGNBinaryStar(AGNObject):
             raise ValueError("star_Y2 and star_Z2 must sum to 1 or less.")
 
         if((isinstance(star_Y1,float)) and (isinstance(star_Z1,float))):
-            star_X1 = np.full(nsystems,1. - star_Y1 - star_Z1)
-            star_Y1 = np.full(nsystems,star_Y1)
-            star_Z1 = np.full(nsystems,star_Z1)
+            star_X1 = np.full(obj_num,1. - star_Y1 - star_Z1)
+            star_Y1 = np.full(obj_num,star_Y1)
+            star_Z1 = np.full(obj_num,star_Z1)
         if((isinstance(star_Y2,float)) and (isinstance(star_Z2,float))):
-            star_X2 = np.full(nsystems,1. - star_Y2 - star_Z2)
-            star_Y2 = np.full(nsystems,star_Y2)
-            star_Z2 = np.full(nsystems,star_Z2)
+            star_X2 = np.full(obj_num,1. - star_Y2 - star_Z2)
+            star_Y2 = np.full(obj_num,star_Y2)
+            star_Z2 = np.full(obj_num,star_Z2)
         if((isinstance(star_Y1,np.ndarray)) and (isinstance(star_Z1,np.ndarray))):
-            assert star_Y1.shape == (nsystems,),"star_Y1: all arrays must be 1d and the same length"
-            assert star_Z1.shape == (nsystems,),"star_Z1: all arrays must be 1d and the same length"
-            star_X1 = np.ones(nsystems) - star_Y1 - star_Z1
+            assert star_Y1.shape == (obj_num,),"star_Y1: all arrays must be 1d and the same length"
+            assert star_Z1.shape == (obj_num,),"star_Z1: all arrays must be 1d and the same length"
+            star_X1 = np.ones(obj_num) - star_Y1 - star_Z1
         if((isinstance(star_Y2,np.ndarray)) and (isinstance(star_Z2,np.ndarray))):
-            assert star_Y2.shape == (nsystems,),"star_Y2: all arrays must be the same length"
-            assert star_Z2.shape == (nsystems,),"star_Z2: all arrays must be the same length"
-            star_X2 = np.ones(nsystems) - star_Y2 - star_Z2
+            assert star_Y2.shape == (obj_num,),"star_Y2: all arrays must be the same length"
+            assert star_Z2.shape == (obj_num,),"star_Z2: all arrays must be the same length"
+            star_X2 = np.ones(obj_num) - star_Y2 - star_Z2
         else: raise TypeError("star_Y1, star_Z1 and star_Y2, star_Z2 must be either both floats or numpy arrays")
 
 
@@ -493,16 +493,16 @@ class AGNBinaryStar(AGNObject):
         self.star_spin2 = star_spin2
         self.star_spin_angle1 = star_spin_angle1
         self.star_spin_angle2 = star_spin_angle2
-        self.binary_e = binary_e
-        self.binary_a = binary_a
-        self.binary_inclination = binary_inclination
+        self.bin_e = bin_e
+        self.bin_a = bin_a
+        self.bin_inc = bin_inc
 
         #Now calculate properties for the AGNObject class aka the totals
         total_mass = star_mass1 + star_mass2
         total_spin = None # we will pass None for now, until we decide how to treat angular momentum
         total_spin_angle = None  # we will pass None for now, until we decide how to treat angular momentum
 
-        super(AGNBinaryStar,self).__init__(mass = total_mass, spin = star_spin_angle2, spin_angle = star_spin_angle2, orbit_a = cm_orbit_a, orbit_inclination = cm_orbit_inclination, orbit_e = cm_orbit_e, nsystems = nsystems)
+        super(AGNBinaryStar,self).__init__(mass = total_mass, spin = star_spin_angle2, spin_angle = star_spin_angle2, orb_a = cm_orb_a, orb_inc = cm_orb_inc, orb_ecc = cm_orb_ecc, obj_num = obj_num)
         
 
     def __repr__(self):
@@ -520,15 +520,15 @@ class AGNBinaryStar(AGNObject):
                         new_star_spin2 = None,
                         new_star_spin_angle1 = None,
                         new_star_spin_angle2 = None,
-                        new_star_orbit_a1 = None,
-                        new_star_orbit_a2 = None,
-                        new_binary_e = None,
-                        new_binary_a = None,
-                        new_binary_inclination=None,
-                        new_cm_orbit_a=None,
-                        new_cm_orbit_inclination=None,
-                        new_cm_orbit_e=None,
-                        nsystems = None,
+                        new_star_orb_a1 = None,
+                        new_star_orb_a2 = None,
+                        new_bin_e = None,
+                        new_bin_a = None,
+                        new_bin_inc=None,
+                        new_cm_orb_a=None,
+                        new_cm_orb_inc=None,
+                        new_cm_orb_ecc=None,
+                        obj_num = None,
                     **kwargs):
         
 
@@ -545,22 +545,22 @@ class AGNBinaryStar(AGNObject):
         if new_star_spin2 is None: raise AttributeError("new_star_spin2 is not included in inputs")
         if new_star_spin_angle1 is None: raise AttributeError("new_star_spin_angle1 is not included in inputs")
         if new_star_spin_angle2 is None: raise AttributeError("new_star_spin_angle2 is not included in inputs")
-        if new_binary_e is None: raise AttributeError("new_binary_e is not included in inputs")
-        if new_binary_a is None: raise AttributeError("new_binary_a is not included in inputs")
+        if new_bin_e is None: raise AttributeError("new_bin_e is not included in inputs")
+        if new_bin_a is None: raise AttributeError("new_bin_a is not included in inputs")
 
-        if nsystems is None: nsystems = new_star_mass1.size
+        if obj_num is None: obj_num = new_star_mass1.size
 
         #Check that all inputs are 1d numpy arrays
-        assert new_star_mass1.shape == (nsystems,),"new_star_mass1: all arrays must be 1d and the same length"
-        assert new_star_mass2.shape == (nsystems,),"new_star_mass2: all arrays must be 1d and the same length"
-        assert new_star_radius1.shape == (nsystems,),"new_star_radius1: all arrays must be 1d and the same length"
-        assert new_star_radius2.shape == (nsystems,),"new_star_radius2: all arrays must be 1d and the same length"
-        assert new_star_spin1.shape == (nsystems,),"new_star_spin1: all arrays must be 1d and the same length"
-        assert new_star_spin2.shape == (nsystems,),"new_star_spin2: all arrays must be 1d and the same length"
-        assert new_star_spin_angle1.shape == (nsystems,),"new_star_spin_angle1: all arrays must be 1d and the same length"
-        assert new_star_spin_angle2.shape == (nsystems,),"new_star_spin_angle2: all arrays must be 1d and the same length"
-        assert new_binary_e.shape == (nsystems,),"new_binary_e: all arrays must be 1d and the same length"
-        assert new_binary_a.shape == (nsystems,),"new_binary_a: all arrays must be 1d and the same length"
+        assert new_star_mass1.shape == (obj_num,),"new_star_mass1: all arrays must be 1d and the same length"
+        assert new_star_mass2.shape == (obj_num,),"new_star_mass2: all arrays must be 1d and the same length"
+        assert new_star_radius1.shape == (obj_num,),"new_star_radius1: all arrays must be 1d and the same length"
+        assert new_star_radius2.shape == (obj_num,),"new_star_radius2: all arrays must be 1d and the same length"
+        assert new_star_spin1.shape == (obj_num,),"new_star_spin1: all arrays must be 1d and the same length"
+        assert new_star_spin2.shape == (obj_num,),"new_star_spin2: all arrays must be 1d and the same length"
+        assert new_star_spin_angle1.shape == (obj_num,),"new_star_spin_angle1: all arrays must be 1d and the same length"
+        assert new_star_spin_angle2.shape == (obj_num,),"new_star_spin_angle2: all arrays must be 1d and the same length"
+        assert new_bin_e.shape == (obj_num,),"new_bin_e: all arrays must be 1d and the same length"
+        assert new_bin_a.shape == (obj_num,),"new_bin_a: all arrays must be 1d and the same length"
 
         if (np.any(new_star_Y1 + new_star_Z1 > 1.)):
             raise ValueError("new_star_Y1 and new_star_Z1 must sum to 1 or less.")
@@ -568,21 +568,21 @@ class AGNBinaryStar(AGNObject):
             raise ValueError("new_star_Y2 and new_star_Z2 must sum to 1 or less.")
 
         if((isinstance(new_star_Y1,float)) and (isinstance(new_star_Z1,float))):
-            new_star_X1 = np.full(nsystems,1. - new_star_Y1 - new_star_Z1)
-            new_star_Y1 = np.full(nsystems,new_star_Y1)
-            new_star_Z1 = np.full(nsystems,new_star_Z1)
+            new_star_X1 = np.full(obj_num,1. - new_star_Y1 - new_star_Z1)
+            new_star_Y1 = np.full(obj_num,new_star_Y1)
+            new_star_Z1 = np.full(obj_num,new_star_Z1)
         if((isinstance(new_star_Y2,float)) and (isinstance(new_star_Z2,float))):
-            new_star_X2 = np.full(nsystems,1. - new_star_Y2 - new_star_Z2)
-            new_star_Y2 = np.full(nsystems,new_star_Y2)
-            new_star_Z2 = np.full(nsystems,new_star_Z2)
+            new_star_X2 = np.full(obj_num,1. - new_star_Y2 - new_star_Z2)
+            new_star_Y2 = np.full(obj_num,new_star_Y2)
+            new_star_Z2 = np.full(obj_num,new_star_Z2)
         if((isinstance(new_star_Y1,np.ndarray)) and (isinstance(new_star_Z1,np.ndarray))):
-            assert new_star_Y1.shape == (nsystems,),"new_star_Y1: all arrays must be 1d and the same length"
-            assert new_star_Z1.shape == (nsystems,),"new_star_Z1: all arrays must be 1d and the same length"
-            new_star_X1 = np.ones(nsystems) - new_star_Y1 - new_star_Z1
+            assert new_star_Y1.shape == (obj_num,),"new_star_Y1: all arrays must be 1d and the same length"
+            assert new_star_Z1.shape == (obj_num,),"new_star_Z1: all arrays must be 1d and the same length"
+            new_star_X1 = np.ones(obj_num) - new_star_Y1 - new_star_Z1
         if((isinstance(new_star_Y2,np.ndarray)) and (isinstance(new_star_Z2,np.ndarray))):
-            assert new_star_Y2.shape == (nsystems,),"new_star_Y2: all arrays must be the same length"
-            assert new_star_Z2.shape == (nsystems,),"new_star_Z2: all arrays must be the same length"
-            new_star_X2 = np.ones(nsystems) - new_star_Y2 - new_star_Z2
+            assert new_star_Y2.shape == (obj_num,),"new_star_Y2: all arrays must be the same length"
+            assert new_star_Z2.shape == (obj_num,),"new_star_Z2: all arrays must be the same length"
+            new_star_X2 = np.ones(obj_num) - new_star_Y2 - new_star_Z2
         else: raise TypeError("new_star_Y1, new_star_Z1 and new_star_Y2, new_star_Z2 must be either both floats or numpy arrays")
 
 
@@ -601,18 +601,18 @@ class AGNBinaryStar(AGNObject):
         self.star_spin2 = np.concatenate([self.star_spin2, new_star_spin2])
         self.star_spin_angle1 = np.concatenate([self.star_spin_angle1, new_star_spin_angle1])
         self.star_spin_angle2 = np.concatenate([self.star_spin_angle2, new_star_spin_angle2])
-        self.binary_e = np.concatenate([self.binary_e, new_binary_e])
-        self.binary_a = np.concatenate([self.binary_a, new_binary_a])
+        self.bin_e = np.concatenate([self.bin_e, new_bin_e])
+        self.bin_a = np.concatenate([self.bin_a, new_bin_a])
 
         new_total_mass = new_star_mass1 + new_star_mass2
 
         super(AGNBinaryStar,self).add_objects(new_mass = new_total_mass,
                                                    new_spin=None,
                                                    new_spin_angle=None,
-                                                   new_a = new_cm_orbit_a,
-                                                   new_inclination=new_cm_orbit_inclination,
-                                                   new_e=new_cm_orbit_e,
-                                                   nsystems=nsystems)
+                                                   new_a = new_cm_orb_a,
+                                                   new_inc=new_cm_orb_inc,
+                                                   new_e=new_cm_orb_ecc,
+                                                   obj_num=obj_num)
 
 
 class AGNBinaryBlackHole(AGNObject):
@@ -630,17 +630,17 @@ class AGNBinaryBlackHole(AGNObject):
                        bh_spin_angle2 = None,
                        bh_orb_ang_mom1 = None,
                        bh_orb_ang_mom2 = None,
-                       binary_e = None,
-                       binary_a = None,
-                       binary_inclination=None,
-                       #com_orbit_a=None,
-                       com_orbit_inclination=None,
-                       com_orbit_e=None,
-                       nsystems = None,
+                       bin_e = None,
+                       bin_a = None,
+                       bin_inc=None,
+                       #com_orb_a=None,
+                       com_orb_inc=None,
+                       com_orb_ecc=None,
+                       obj_num = None,
                      **kwargs):
         
 
-        #if nsystems is None: nsystems = bh_mass1.size
+        #if obj_num is None: obj_num = bh_mass1.size
 
         self.mass1 = None
         self.mass2 = None
@@ -659,7 +659,7 @@ class AGNBinaryBlackHole(AGNObject):
         self.gen1 = None
         self.gen2 = None
         self.bin_orb_ang_mom = None
-        self.bin_orb_inclination = None
+        self.bin_orb_inc = None
         self.bin_smbh_orb_e = None
 
 
@@ -674,15 +674,15 @@ class AGNBinaryBlackHole(AGNObject):
         self.bh_spin_angle2 = bh_spin_angle2
         self.bh_orb_ang_mom1 = bh_orb_ang_mom1
         self.bh_orb_ang_mom2 = bh_orb_ang_mom2
-        self.binary_e = binary_e
-        self.binary_a = binary_a
-        self.binary_inclination = binary_inclination
-        #self.com_orbit_a = cm_orbit_a
-        self.com_orbit_e = com_orbit_e
-        self.com_orbit_inclination = com_orbit_inclination
+        self.bin_e = bin_e
+        self.bin_a = bin_a
+        self.bin_inc = bin_inc
+        #self.com_orb_a = cm_orb_a
+        self.com_orb_ecc = com_orb_ecc
+        self.com_orb_inc = com_orb_inc
         self.com_orb_ang_mom = None """
 
-        #self.com_orbit_a = np.abs(bh_orb_a1 - bh_orb_a2)
+        #self.com_orb_a = np.abs(bh_orb_a1 - bh_orb_a2)
 
         #Now calculate properties for the AGNObject class aka the totals
         #total_mass = bh_mass1 + bh_mass2
@@ -693,19 +693,19 @@ class AGNBinaryBlackHole(AGNObject):
         """ super(AGNBinaryBlackHole,self).__init__(mass = total_mass,
                                                 spin = total_spin,
                                                 spin_angle = total_spin_angle,
-                                                orbit_a = self.cm_orbit_a,
-                                                orbit_inclination=self.cm_orbit_inclination,
-                                                orbit_e = self.cm_orbit_e,
-                                                orbit_arg_periapse=None,# TODO ISSUE
-                                                mass_smbh = None, # TODO ISSUE
-                                                nsystems=nsystems) # TODO ISSUE """
+                                                orb_a = self.cm_orb_a,
+                                                orb_inc=self.cm_orb_inc,
+                                                orb_ecc = self.cm_orb_ecc,
+                                                orb_arg_periapse=None,# TODO ISSUE
+                                                smbh_mass = None, # TODO ISSUE
+                                                obj_num=obj_num) # TODO ISSUE """
         super(AGNBinaryBlackHole,self).__init__(mass = None,
                                                 spin = None,
                                                 spin_angle = None,
-                                                orbit_a = None,
-                                                orbit_inclination=None,
-                                                orbit_e = None,
-                                                orbit_arg_periapse=None) # TODO ISSUE
+                                                orb_a = None,
+                                                orb_inc=None,
+                                                orb_ecc = None,
+                                                orb_arg_periapse=None) # TODO ISSUE
 
 
     def __repr__(self):
@@ -719,18 +719,18 @@ class AGNBinaryBlackHole(AGNObject):
                        new_bh_spin2 = None,
                        new_bh_spin_angle1 = None,
                        new_bh_spin_angle2 = None,
-                       new_binary_e = None,
-                       new_binary_a = None,
-                       new_binary_inclination=None,
-                       new_cm_orbit_a=None,
-                       new_cm_orbit_inclination=None,
-                       new_cm_orbit_e=None,
-                       nsystems = None,
+                       new_bin_e = None,
+                       new_bin_a = None,
+                       new_bin_inc=None,
+                       new_cm_orb_a=None,
+                       new_cm_orb_inc=None,
+                       new_cm_orb_ecc=None,
+                       obj_num = None,
                     **kwargs):
         
 
 
-        if nsystems is None: nsystems = new_bh_mass1.size
+        if obj_num is None: obj_num = new_bh_mass1.size
 
         self.bh_mass1 = np.concatenate([self.bh_mass1, new_bh_mass1])
         self.bh_mass2 = np.concatenate([self.bh_mass2, new_bh_mass2])
@@ -740,12 +740,12 @@ class AGNBinaryBlackHole(AGNObject):
         self.bh_spin2 = np.concatenate([self.bh_spin2, new_bh_spin2])
         self.bh_spin_angle1 = np.concatenate([self.bh_spin_angle1, new_bh_spin_angle1])
         self.bh_spin_angle2 = np.concatenate([self.bh_spin_angle2, new_bh_spin_angle2])
-        self.binary_e = np.concatenate([self.bh_binary_e, new_bh_binary_e])
-        self.binary_a = np.concatenate([self.bh_binary_a, new_bh_binary_a])
-        self.binary_inclination = np.concatenate([self.binary_inclination, new_binary_inclination])
-        self.cm_orbit_a = np.concatenate([self.cm_orbit_a, new_cm_orbit_a])
-        self.cm_orbit_inclination = np.concatenate([self.cm_orbit_inclination, new_cm_orbit_inclination])
-        self.cm_orbit_e = np.concatenate([self.cm_orbit_e, new_cm_orbit_e])
+        self.bin_e = np.concatenate([self.bh_bin_e, new_bh_bin_e])
+        self.bin_a = np.concatenate([self.bh_bin_a, new_bh_bin_a])
+        self.bin_inc = np.concatenate([self.bin_inc, new_bin_inc])
+        self.cm_orb_a = np.concatenate([self.cm_orb_a, new_cm_orb_a])
+        self.cm_orb_inc = np.concatenate([self.cm_orb_inc, new_cm_orb_inc])
+        self.cm_orb_ecc = np.concatenate([self.cm_orb_ecc, new_cm_orb_ecc])
 
         new_total_mass = new_bh_mass1 + new_bh_mass2
         new_spin = new_bh_spin1 + new_bh_spin2
@@ -754,29 +754,29 @@ class AGNBinaryBlackHole(AGNObject):
         super(AGNBinaryBlackHole,self).add_objects(new_mass = new_total_mass,
                                                    new_spin=None,
                                                    new_spin_angle=None,
-                                                   new_a = new_cm_orbit_a,
-                                                   new_inclination=new_cm_orbit_inclination,
-                                                   new_e=new_cm_orbit_e,
-                                                   nsystems=nsystems) """
+                                                   new_a = new_cm_orb_a,
+                                                   new_inc=new_cm_orb_inc,
+                                                   new_e=new_cm_orb_ecc,
+                                                   obj_num=obj_num) """
 
     def add_binaries(self,
                      blackholes,
                      close_encounters,
                      retro,
-                    nsystems = None,
+                    obj_num = None,
                     **kwargs):
         
-        if nsystems is None: nsystems = blackholes.mass.size
+        if obj_num is None: obj_num = blackholes.mass.size
 
         #need to basically copy the add_new_binary.add_to_binary_array2 function
 
         super(AGNBinaryBlackHole,self).add_objects(new_mass = new_total_mass,
                                                    new_spin=None,
                                                    new_spin_angle=None,
-                                                   new_a = new_cm_orbit_a,
-                                                   new_inclination=new_cm_orbit_inclination,
-                                                   new_e=new_cm_orbit_e,
-                                                   nsystems=nsystems)
+                                                   new_a = new_cm_orb_a,
+                                                   new_inc=new_cm_orb_inc,
+                                                   new_e=new_cm_orb_ecc,
+                                                   obj_num=obj_num)
 
 
 obj_types = {0 : "single black hole",
@@ -811,12 +811,12 @@ class AGNFilingCabinet(AGNObject):
         #self.id_num = id_num
         #self.category = category
         #self.mass = mass
-        #self.orbit_a = orbit_a
+        #self.orb_a = orb_a
 
         self.orb_ang_mom = agnobj.orb_ang_mom
 
 
-        super(AGNFilingCabinet,self).__init__(mass=agnobj.mass, spin=agnobj.spin, spin_angle=agnobj.spin_angle,orbit_a=agnobj.orbit_a, orbit_inclination=agnobj.orbit_inclination, orbit_e=agnobj.orbit_e, orbit_arg_periapse=agnobj.orbit_arg_periapse)
+        super(AGNFilingCabinet,self).__init__(mass=agnobj.mass, spin=agnobj.spin, spin_angle=agnobj.spin_angle,orb_a=agnobj.orb_a, orb_inc=agnobj.orb_inc, orb_ecc=agnobj.orb_ecc, orb_arg_periapse=agnobj.orb_arg_periapse)
 
     def __repr__(self):
         """         totals = "AGN Filing Cabinet\n"

--- a/src/mcfacts/setup/initializediskstars.py
+++ b/src/mcfacts/setup/initializediskstars.py
@@ -7,30 +7,30 @@ def init_single_stars(opts,id_start_val = None):
 
     # Generate initial number of stars
     n_stars_initial = setupdiskstars.setup_disk_nstars(
-            opts.M_nsc,
-            opts.nbh_nstar_ratio,
-            opts.mbh_mstar_ratio,
-            opts.r_nsc_out,
-            opts.nsc_index_outer,
-            opts.mass_smbh,
-            opts.disk_outer_radius,
-            opts.h_disk_average,
-            opts.r_nsc_crit,
-            opts.nsc_index_inner,
+            opts.nsc_mass,
+            opts.nsc_ratio_bh_num_star_num,
+            opts.nsc_ratio_bh_mass_star_mass,
+            opts.nsc_radius_outer,
+            opts.nsc_density_index_outer,
+            opts.smbh_mass,
+            opts.disk_radius_outer,
+            opts.disk_aspect_ratio_avg,
+            opts.nsc_radius_crit,
+            opts.nsc_density_index_inner,
         )
     #print(n_stars_initial) 152_248_329
     n_stars_initial = 1_000_000
     
     # Generate initial masses for the initial number of stars, pre-Hill sphere mergers
     masses_initial = setupdiskstars.setup_disk_stars_masses(n_star = n_stars_initial,
-                                                            min_initial_star_mass = opts.min_initial_star_mass,
-                                                            max_initial_star_mass = opts.max_initial_star_mass,
-                                                            mstar_powerlaw_index = opts.star_mass_powerlaw_index)
+                                                            min_initial_star_mass = opts.disk_star_mass_min_init,
+                                                            max_initial_star_mass = opts.disk_star_mass_max_init,
+                                                            mstar_powerlaw_index = opts.nsc_imf_star_powerlaw_index)
     
     # Generating star locations in an x^2 distribution
     x_vals = np.random.uniform(0.002, 1, n_stars_initial)
     r_locations_initial = np.sqrt(x_vals)
-    r_locations_initial_scaled = r_locations_initial*opts.trap_radius
+    r_locations_initial_scaled = r_locations_initial*opts.disk_radius_trap
 
     # Sort the mass and location arrays by the location array
     sort_idx = np.argsort(r_locations_initial_scaled)
@@ -40,25 +40,25 @@ def init_single_stars(opts,id_start_val = None):
     masses_stars, r_locations_stars = diskstars_hillspheremergers.hillsphere_mergers(n_stars=n_stars_initial,
                                                    masses_initial_sorted=masses_initial_sorted,
                                                    r_locations_initial_sorted=r_locations_initial_sorted,
-                                                   min_initial_star_mass=opts.min_initial_star_mass,
-                                                   R_disk = opts.trap_radius,
-                                                   M_smbh=opts.mass_smbh,
+                                                   min_initial_star_mass=opts.disk_star_mass_min_init,
+                                                   R_disk = opts.disk_radius_trap,
+                                                   M_smbh=opts.smbh_mass,
                                                    P_m = 1.35,
                                                    P_r = 1.)
     n_stars = len(masses_stars)
     
     star_radius = setupdiskstars.setup_disk_stars_radii(masses_stars)
-    star_spin = setupdiskstars.setup_disk_stars_spins(n_stars, opts.mu_star_spin_distribution, opts.sigma_star_spin_distribution)
+    star_spin = setupdiskstars.setup_disk_stars_spins(n_stars, opts.nsc_star_spin_dist_mu, opts.nsc_star_spin_dist_sigma)
     star_spin_angle = setupdiskstars.setup_disk_stars_spin_angles(n_stars, star_spin)
     star_orbit_inclination = setupdiskstars.setup_disk_stars_inclination(n_stars)
     #star_orb_ang_mom = setupdiskstars.setup_disk_stars_orb_ang_mom(rng,n_stars)
     star_orbit_argperiapse = setupdiskstars.setup_disk_stars_arg_periapse(n_stars)
-    if opts.orb_ecc_damping == 1:
+    if opts.flag_orb_ecc_damping == 1:
         star_orbit_e = setupdiskstars.setup_disk_stars_eccentricity_uniform(n_stars)
     else:
-        star_orbit_e = setupdiskstars.setup_disk_stars_circularized(n_stars, opts.crit_ecc)
-    star_Y = opts.stars_initial_Y
-    star_Z = opts.stars_initial_Z
+        star_orbit_e = setupdiskstars.setup_disk_stars_circularized(n_stars, opts.disk_bh_pro_orb_ecc_crit)
+    star_Y = opts.nsc_star_metallicity_y_init
+    star_Z = opts.nsc_star_metallicity_z_init
 
     stars = AGNStar(mass = masses_stars,
                         spin = star_spin,
@@ -71,7 +71,7 @@ def init_single_stars(opts,id_start_val = None):
                         star_radius = star_radius,
                         star_Y = star_Y,
                         star_Z = star_Z,
-                        mass_smbh = opts.mass_smbh,
+                        mass_smbh = opts.smbh_mass,
                         id_start_val=id_start_val,
                         n_stars = n_stars)
 

--- a/src/mcfacts/setup/initializediskstars.py
+++ b/src/mcfacts/setup/initializediskstars.py
@@ -19,15 +19,15 @@ def init_single_stars(opts, id_start_val=None):
             opts.nsc_radius_crit,
             opts.nsc_density_index_inner,
         )
-    # print(n_stars_initial) 152_248_329
+    # giprint(n_stars_initial) 152_248_329
     n_stars_initial = 1_000_000
-    
+
     # Generate initial masses for the initial number of stars, pre-Hill sphere mergers
     masses_initial = setupdiskstars.setup_disk_stars_masses(n_star=n_stars_initial,
                                                             min_initial_star_mass=opts.disk_star_mass_min_init,
                                                             max_initial_star_mass=opts.disk_star_mass_max_init,
                                                             mstar_powerlaw_index=opts.nsc_imf_star_powerlaw_index)
-    
+
     # Generating star locations in an x^2 distribution
     x_vals = np.random.uniform(0.002, 1, n_stars_initial)
     r_locations_initial = np.sqrt(x_vals)

--- a/src/mcfacts/setup/initializediskstars.py
+++ b/src/mcfacts/setup/initializediskstars.py
@@ -3,7 +3,8 @@ from mcfacts.setup import diskstars_hillspheremergers
 from mcfacts.objects.agnobject import AGNStar
 import numpy as np
 
-def init_single_stars(opts,id_start_val = None):
+
+def init_single_stars(opts, id_start_val=None):
 
     # Generate initial number of stars
     n_stars_initial = setupdiskstars.setup_disk_nstars(
@@ -18,14 +19,14 @@ def init_single_stars(opts,id_start_val = None):
             opts.nsc_radius_crit,
             opts.nsc_density_index_inner,
         )
-    #print(n_stars_initial) 152_248_329
+    # print(n_stars_initial) 152_248_329
     n_stars_initial = 1_000_000
     
     # Generate initial masses for the initial number of stars, pre-Hill sphere mergers
-    masses_initial = setupdiskstars.setup_disk_stars_masses(n_star = n_stars_initial,
-                                                            min_initial_star_mass = opts.disk_star_mass_min_init,
-                                                            max_initial_star_mass = opts.disk_star_mass_max_init,
-                                                            mstar_powerlaw_index = opts.nsc_imf_star_powerlaw_index)
+    masses_initial = setupdiskstars.setup_disk_stars_masses(n_star=n_stars_initial,
+                                                            min_initial_star_mass=opts.disk_star_mass_min_init,
+                                                            max_initial_star_mass=opts.disk_star_mass_max_init,
+                                                            mstar_powerlaw_index=opts.nsc_imf_star_powerlaw_index)
     
     # Generating star locations in an x^2 distribution
     x_vals = np.random.uniform(0.002, 1, n_stars_initial)
@@ -41,10 +42,10 @@ def init_single_stars(opts,id_start_val = None):
                                                                                      masses_initial_sorted=masses_initial_sorted,
                                                                                      r_locations_initial_sorted=r_locations_initial_sorted,
                                                                                      min_initial_star_mass=opts.disk_star_mass_min_init,
-                                                                                     R_disk = opts.disk_radius_trap,
+                                                                                     R_disk=opts.disk_radius_trap,
                                                                                      M_smbh=opts.smbh_mass,
-                                                                                     P_m = 1.35,
-                                                                                     P_r = 1.)
+                                                                                     P_m=1.35,
+                                                                                     P_r=1.)
     n_stars = len(masses_stars)
     
     star_radius = setupdiskstars.setup_disk_stars_radii(masses_stars)

--- a/src/mcfacts/setup/initializediskstars.py
+++ b/src/mcfacts/setup/initializediskstars.py
@@ -38,13 +38,13 @@ def init_single_stars(opts,id_start_val = None):
     masses_initial_sorted = masses_initial[sort_idx]
 
     masses_stars, r_locations_stars = diskstars_hillspheremergers.hillsphere_mergers(n_stars=n_stars_initial,
-                                                   masses_initial_sorted=masses_initial_sorted,
-                                                   r_locations_initial_sorted=r_locations_initial_sorted,
-                                                   min_initial_star_mass=opts.disk_star_mass_min_init,
-                                                   R_disk = opts.disk_radius_trap,
-                                                   M_smbh=opts.smbh_mass,
-                                                   P_m = 1.35,
-                                                   P_r = 1.)
+                                                                                     masses_initial_sorted=masses_initial_sorted,
+                                                                                     r_locations_initial_sorted=r_locations_initial_sorted,
+                                                                                     min_initial_star_mass=opts.disk_star_mass_min_init,
+                                                                                     R_disk = opts.disk_radius_trap,
+                                                                                     M_smbh=opts.smbh_mass,
+                                                                                     P_m = 1.35,
+                                                                                     P_r = 1.)
     n_stars = len(masses_stars)
     
     star_radius = setupdiskstars.setup_disk_stars_radii(masses_stars)
@@ -60,20 +60,19 @@ def init_single_stars(opts,id_start_val = None):
     star_Y = opts.nsc_star_metallicity_y_init
     star_Z = opts.nsc_star_metallicity_z_init
 
-    stars = AGNStar(mass = masses_stars,
-                        spin = star_spin,
-                        spin_angle = star_spin_angle,
-                        orbit_a = r_locations_stars, #this is location
-                        orbit_inclination = star_orbit_inclination,
-                        orbit_e = star_orbit_e,
-                        #orb_ang_mom = star_orb_ang_mom,
-                        orbit_arg_periapse = star_orbit_argperiapse,
-                        star_radius = star_radius,
-                        star_Y = star_Y,
-                        star_Z = star_Z,
-                        mass_smbh = opts.smbh_mass,
-                        id_start_val=id_start_val,
-                        n_stars = n_stars)
-
-    
+    stars = AGNStar(mass=masses_stars,
+                    spin=star_spin,
+                    spin_angle=star_spin_angle,
+                    orbit_a=r_locations_stars, #this is location
+                    orbit_inclination=star_orbit_inclination,
+                    orbit_e=star_orbit_e,
+                    #orb_ang_mom= star_orb_ang_mom,
+                    orbit_arg_periapse=star_orbit_argperiapse,
+                    star_radius=star_radius,
+                    star_Y=star_Y,
+                    star_Z=star_Z,
+                    mass_smbh=opts.smbh_mass,
+                    id_start_val=id_start_val,
+                    n_stars=n_stars)
+   
     return(stars,n_stars)

--- a/src/mcfacts/setup/initializediskstars.py
+++ b/src/mcfacts/setup/initializediskstars.py
@@ -7,7 +7,7 @@ import numpy as np
 def init_single_stars(opts, id_start_val=None):
 
     # Generate initial number of stars
-    n_stars_initial = setupdiskstars.setup_disk_nstars(
+    star_num_initial = setupdiskstars.setup_disk_nstars(
             opts.nsc_mass,
             opts.nsc_ratio_bh_num_star_num,
             opts.nsc_ratio_bh_mass_star_mass,
@@ -19,17 +19,17 @@ def init_single_stars(opts, id_start_val=None):
             opts.nsc_radius_crit,
             opts.nsc_density_index_inner,
         )
-    # giprint(n_stars_initial) 152_248_329
-    n_stars_initial = 1_000_000
+    # giprint(star_num_initial) 152_248_329
+    star_num_initial = 1_000_000
 
     # Generate initial masses for the initial number of stars, pre-Hill sphere mergers
-    masses_initial = setupdiskstars.setup_disk_stars_masses(n_star=n_stars_initial,
+    masses_initial = setupdiskstars.setup_disk_stars_masses(n_star=star_num_initial,
                                                             min_initial_star_mass=opts.disk_star_mass_min_init,
                                                             max_initial_star_mass=opts.disk_star_mass_max_init,
                                                             mstar_powerlaw_index=opts.nsc_imf_star_powerlaw_index)
 
     # Generating star locations in an x^2 distribution
-    x_vals = np.random.uniform(0.002, 1, n_stars_initial)
+    x_vals = np.random.uniform(0.002, 1, star_num_initial)
     r_locations_initial = np.sqrt(x_vals)
     r_locations_initial_scaled = r_locations_initial*opts.disk_radius_trap
 
@@ -38,7 +38,7 @@ def init_single_stars(opts, id_start_val=None):
     r_locations_initial_sorted = r_locations_initial_scaled[sort_idx]
     masses_initial_sorted = masses_initial[sort_idx]
 
-    masses_stars, r_locations_stars = diskstars_hillspheremergers.hillsphere_mergers(n_stars=n_stars_initial,
+    masses_stars, r_locations_stars = diskstars_hillspheremergers.hillsphere_mergers(n_stars=star_num_initial,
                                                                                      masses_initial_sorted=masses_initial_sorted,
                                                                                      r_locations_initial_sorted=r_locations_initial_sorted,
                                                                                      min_initial_star_mass=opts.disk_star_mass_min_init,
@@ -46,34 +46,34 @@ def init_single_stars(opts, id_start_val=None):
                                                                                      M_smbh=opts.smbh_mass,
                                                                                      P_m=1.35,
                                                                                      P_r=1.)
-    n_stars = len(masses_stars)
+    star_num = len(masses_stars)
     
     star_radius = setupdiskstars.setup_disk_stars_radii(masses_stars)
-    star_spin = setupdiskstars.setup_disk_stars_spins(n_stars, opts.nsc_star_spin_dist_mu, opts.nsc_star_spin_dist_sigma)
-    star_spin_angle = setupdiskstars.setup_disk_stars_spin_angles(n_stars, star_spin)
-    star_orbit_inclination = setupdiskstars.setup_disk_stars_inclination(n_stars)
-    #star_orb_ang_mom = setupdiskstars.setup_disk_stars_orb_ang_mom(rng,n_stars)
-    star_orbit_argperiapse = setupdiskstars.setup_disk_stars_arg_periapse(n_stars)
+    star_spin = setupdiskstars.setup_disk_stars_spins(star_num, opts.nsc_star_spin_dist_mu, opts.nsc_star_spin_dist_sigma)
+    star_spin_angle = setupdiskstars.setup_disk_stars_spin_angles(star_num, star_spin)
+    star_orb_inc = setupdiskstars.setup_disk_stars_inclination(star_num)
+    #star_orb_ang_mom = setupdiskstars.setup_disk_stars_orb_ang_mom(rng,star_num)
+    star_orb_arg_periapse = setupdiskstars.setup_disk_stars_arg_periapse(star_num)
     if opts.flag_orb_ecc_damping == 1:
-        star_orbit_e = setupdiskstars.setup_disk_stars_eccentricity_uniform(n_stars)
+        star_orb_ecc = setupdiskstars.setup_disk_stars_eccentricity_uniform(star_num)
     else:
-        star_orbit_e = setupdiskstars.setup_disk_stars_circularized(n_stars, opts.disk_bh_pro_orb_ecc_crit)
+        star_orb_ecc = setupdiskstars.setup_disk_stars_circularized(star_num, opts.disk_bh_pro_orb_ecc_crit)
     star_Y = opts.nsc_star_metallicity_y_init
     star_Z = opts.nsc_star_metallicity_z_init
 
     stars = AGNStar(mass=masses_stars,
                     spin=star_spin,
                     spin_angle=star_spin_angle,
-                    orbit_a=r_locations_stars, #this is location
-                    orbit_inclination=star_orbit_inclination,
-                    orbit_e=star_orbit_e,
+                    orb_a=r_locations_stars, #this is location
+                    orb_inc=star_orb_inc,
+                    orb_ecc=star_orb_ecc,
                     #orb_ang_mom= star_orb_ang_mom,
-                    orbit_arg_periapse=star_orbit_argperiapse,
+                    orb_arg_periapse=star_orb_arg_periapse,
                     star_radius=star_radius,
                     star_Y=star_Y,
                     star_Z=star_Z,
-                    mass_smbh=opts.smbh_mass,
+                    smbh_mass=opts.smbh_mass,
                     id_start_val=id_start_val,
-                    n_stars=n_stars)
+                    star_num=star_num)
    
-    return(stars,n_stars)
+    return(stars,star_num)

--- a/src/mcfacts/setup/setupdiskstars.py
+++ b/src/mcfacts/setup/setupdiskstars.py
@@ -61,13 +61,13 @@ def setup_disk_stars_spin_angles(n_stars, stars_initial_spins):
     return stars_initial_spin_angles
 
 
-def setup_disk_stars_orb_ang_mom(n_stars, M_reduced, M, orbit_a, orbit_inclination,):
+def setup_disk_stars_orb_ang_mom(star_num, M_reduced, M, orb_a, orb_inc,):
     #Return an array of BH initial orbital angular momentum.
     #Assume either fully prograde (+1) or retrograde (-1)
-    integer_nstars = int(n_stars)
+    integer_nstars = int(star_num)
     random_uniform_number = rng.random((integer_nstars,))
     stars_initial_orb_ang_mom_sign = (2.0*np.around(random_uniform_number)) - 1.0
-    stars_initial_orb_ang_mom_value = M_reduced*np.sqrt(G.to('m^3/(M_sun s^2)').value*M*orbit_a*(1-orbit_inclination**2))
+    stars_initial_orb_ang_mom_value = M_reduced*np.sqrt(G.to('m^3/(M_sun s^2)').value*M*orb_a*(1-orb_inc**2))
     stars_initial_orb_ang_mom = stars_initial_orb_ang_mom_sign*stars_initial_orb_ang_mom_value
     return stars_initial_orb_ang_mom
 

--- a/test/test_ReadInputs.py
+++ b/test/test_ReadInputs.py
@@ -200,11 +200,11 @@ def test_construct_disk_direct(verbose=True):
         truncated_disk_radii, truncated_surface_densities, truncated_aspect_ratios = \
             load_disk_arrays(disk_model_name, disk_radius_outer)
         # Construct disk
-        surf_dens_func, aspect_ratio_func, disk_model_properties = \
+        disk_surf_dens_func, disk_aspect_ratio_func, disk_model_properties = \
             construct_disk_direct(disk_model_name, disk_radius_outer)
         # Evaluate estimates for each quantity
-        surface_density_estimate = surf_dens_func(truncated_disk_radii)
-        aspect_ratio_estimate = aspect_ratio_func(truncated_disk_radii)
+        surface_density_estimate = disk_surf_dens_func(truncated_disk_radii)
+        aspect_ratio_estimate = disk_aspect_ratio_func(truncated_disk_radii)
         # Check that they're close
         assert np.allclose(surface_density_estimate, truncated_surface_densities), \
             "NumPy allclose failed for %s surface_density interpolation"%(disk_model_name)
@@ -243,7 +243,7 @@ def test_construct_disk_pAGN(verbose=True):
     # Loop tests
     for test_config in test_product_space:
         # Run pAGN
-        surf_dens_func, aspect_ratio_func, disk_model_properties, bonus_structures = \
+        disk_surf_dens_func, disk_aspect_ratio_func, disk_model_properties, bonus_structures = \
             construct_disk_pAGN(
                 test_config.disk_model_name,
                 test_config.smbh_mass,
@@ -288,7 +288,7 @@ def test_construct_disk_interp(
     # Loop tests
     for test_config in test_product_space:
         # Run function
-        surf_dens_func, aspect_ratio_func = construct_disk_interp(
+        disk_surf_dens_func, disk_aspect_ratio_func = construct_disk_interp(
             smbh_mass,
             disk_radius_outer,
             test_config.disk_model_name,

--- a/test/test_ReadInputs.py
+++ b/test/test_ReadInputs.py
@@ -1,0 +1,315 @@
+"""Test mcfacts.inputs.ReadInputs.py functions
+
+Test various things from ReadInputs.py
+"""
+######## Imports ########
+#### Standard ####
+from importlib import resources as impresources
+import os
+from os.path import isdir, isfile, basename
+import itertools
+import collections
+
+#### Third Party ####
+import numpy as np
+
+#### Local ####
+from mcfacts.inputs import data as mcfacts_input_data
+from mcfacts.inputs.ReadInputs import INPUT_TYPES
+from mcfacts.inputs.ReadInputs import ReadInputs_ini
+from mcfacts.inputs.ReadInputs import load_disk_arrays
+from mcfacts.inputs.ReadInputs import construct_disk_direct
+from mcfacts.inputs.ReadInputs import construct_disk_pAGN
+from mcfacts.inputs.ReadInputs import construct_disk_interp
+
+######## Setup ########
+# Disk model names to try
+DISK_MODEL_NAMES = [
+    "sirko_goodman",
+    #"thompson_etal",
+]
+
+# SMBH masses to try
+#SMBH_MASSES = np.asarray([1e6, 1e7, 1e8, 1e9,])
+SMBH_MASSES = np.asarray([1e8,])
+# disk_alpha_viscosities to try
+DISK_ALPHA_VISCOSITIES = np.asarray([0.1, 0.5])
+# disk_bh_eddington_ratios to try
+DISK_BH_EDDINGTON_RATIOS = np.asarray([0.5,0.1])
+# pAGN flag
+FLAG_USE_PAGN = np.asarray([True, False])
+
+######## Functions ########
+
+# Taken from <https://stackoverflow.com/a/9098295/4761692>
+def named_product(**items):
+    Options = collections.namedtuple('Options', items.keys())
+    return itertools.starmap(Options, itertools.product(*items.values()))
+
+######## Tests ########
+def test_input_types(verbose=True):
+    """test the INPUT_TYPES dictionary
+
+    Parameters
+    ----------
+    verbose : bool
+        Verbose output
+    """
+    if verbose:
+        print("Testing INPUT_TYPES")
+    # Check type
+    assert isinstance(INPUT_TYPES, dict), "INPUT_TYPES is not a dict"
+    # Check key/value pairs
+    for key in INPUT_TYPES:
+        # Assign value from dict
+        value = INPUT_TYPES[key]
+        # Check that it is a class
+        assert "class" in str(value)
+        if verbose:
+            print("  INPUT_TYPES[%s] = %s"%(str(key), str(value)))
+    if verbose:
+        print("  pass!")
+
+def test_ReadInputs_ini(verbose=True):
+    """test ReadInputs_ini function and surrounding data
+
+    Parameters
+    ----------
+    verbose : bool
+        Verbose output
+    """
+    if verbose:
+        print("Testing ReadInputs_ini")
+    # Check that the data folder exists
+    data_folder = impresources.files(mcfacts_input_data)
+    assert isdir(data_folder), "Cannot find mcfacts.inputs.data folder"
+    # Find model_choice.ini
+    fname_ini = data_folder / "model_choice.ini"
+    assert isfile(fname_ini), "Cannot find default inifile"
+    # Get input variables
+    input_variables = ReadInputs_ini(fname_ini, verbose=verbose)
+    # Check that this returns a dictionary
+    assert isinstance(input_variables, dict), \
+        "ReadInputs_ini returned %s"%(str(type(input_variables)))
+    # Loop the input variables
+    for key in input_variables:
+        # Find key/value pairs
+        value = input_variables[key]
+        # Check that key is in INPUT_TYPES
+        assert key in INPUT_TYPES, \
+            "%s is not defined in ReadInputs.INPUT_TYPES"%(key)
+        # check the type of value is correct
+        assert isinstance(value, INPUT_TYPES[key]), \
+            "%s is not a %s (ReadInputs.INPUT_TYPES"%(key,str(INPUT_TYPES[key]))
+        # Print key/value pair
+        if verbose:
+            print("  %s = %s (type: %s)"%(key,str(value),str(INPUT_TYPES[key])))
+    if verbose:
+        print("  pass!")
+
+def test_load_disk_arrays(verbose=True):
+    """test mcfacts.inputs.ReadInputs.load_disk_arrays
+
+    Parameters
+    ----------
+    verbose : bool
+        Verbose output
+    """
+    if verbose:
+        print("Testing load_disk_arrays")
+    # Check that the data folder exists
+    data_folder = impresources.files(mcfacts_input_data)
+    assert isdir(data_folder), "Cannot find mcfacts.inputs.data folder"
+    # Identify some files that should exist in the data folder
+    fname_thompson_surface_density      = data_folder / "thompson_etal_surface_density.txt"
+    fname_thompson_aspect_ratio         = data_folder / "thompson_etal_aspect_ratio.txt"
+    fname_sirko_goodman_surface_density = data_folder / "sirko_goodman_surface_density.txt"
+    fname_sirko_goodman_aspect_ratio    = data_folder / "sirko_goodman_aspect_ratio.txt"
+    # Check things that should exist in the data folder
+    assert isfile(fname_thompson_surface_density), \
+        "Cannot find %s"%(basename(fname_thompson_surface_density))
+    assert isfile(fname_thompson_aspect_ratio), \
+        "Cannot find %s"%(basename(fname_thompson_aspect_ratio))
+    assert isfile(fname_sirko_goodman_surface_density), \
+        "Cannot find %s"%(basename(fname_sirko_goodman_surface_density))
+    assert isfile(fname_sirko_goodman_aspect_ratio), \
+        "Cannot find %s"%(basename(fname_sirko_goodman_aspect_ratio))
+    # Find the default inifile
+    fname_default_ini = data_folder / "model_choice.ini"
+    assert isfile(fname_default_ini), "Cannot find default inifile"
+    # Get input variables
+    input_variables = ReadInputs_ini(fname_default_ini, verbose=verbose)
+    # We only want disk_radius_outer
+    disk_radius_outer = input_variables["disk_radius_outer"]
+    # Loop disk models
+    for disk_model_name in DISK_MODEL_NAMES:
+        # Load the disk arrays
+        truncated_disk_radii, truncated_surface_densities, truncated_aspect_ratios = \
+            load_disk_arrays(disk_model_name, disk_radius_outer)
+        # Check the arrays
+        assert isinstance(truncated_disk_radii, np.ndarray), \
+            "load_disk_arrays returned truncated_disk_radii as type %s"%(
+                type(truncated_disk_radii)
+            )
+        assert isinstance(truncated_surface_densities, np.ndarray), \
+            "load_disk_arrays returned truncated_surface_densities as type %s"%(
+                type(truncated_surface_densities)
+            )
+        assert isinstance(truncated_aspect_ratios, np.ndarray), \
+            "load_disk_arrays returned truncated_aspect_ratios as type %s"%(
+                type(truncated_aspect_ratios)
+            )
+        # Check that arrays are one-dimensional
+        assert len(truncated_disk_radii.shape) == 1, \
+            "truncated_disk_radii.shape = %s"%(str(truncated_disk_radii.shape))
+        assert len(truncated_surface_densities.shape) == 1, \
+            "truncated_surface_densities.shape = %s"%(str(truncated_surface_densities.shape))
+        assert len(truncated_aspect_ratios.shape) == 1, \
+            "truncated_aspect_ratios.shape = %s"%(str(truncated_aspect_ratios.shape))
+        # Check that arrays have the same length
+        assert truncated_disk_radii.size == truncated_surface_densities.size, \
+            "truncated_disk_radii and truncated_surface_densities have different length"
+        assert truncated_disk_radii.size == truncated_aspect_ratios.size, \
+            "truncated_disk_radiis and truncated_aspect_ratios have different length"
+    if verbose:
+        print("  pass!")
+        
+def test_construct_disk_direct(verbose=True):
+    """test mcfacts.inputs.ReadInputs.construct_disk_direct
+
+    Parameters
+    ----------
+    verbose : bool
+        Verbose output
+    """
+    if verbose:
+        print("Testing construct_disk_direct")
+    # Check that the data folder exists
+    data_folder = impresources.files(mcfacts_input_data)
+    assert isdir(data_folder), "Cannot find mcfacts.inputs.data folder"
+    # Find the default inifile
+    fname_default_ini = data_folder / "model_choice.ini"
+    assert isfile(fname_default_ini), "Cannot find default inifile"
+    # Get input variables
+    input_variables = ReadInputs_ini(fname_default_ini, verbose=verbose)
+    # We only want disk_radius_outer
+    disk_radius_outer = input_variables["disk_radius_outer"]
+    # Loop disk models
+    for disk_model_name in DISK_MODEL_NAMES:
+        # Load the disk arrays
+        truncated_disk_radii, truncated_surface_densities, truncated_aspect_ratios = \
+            load_disk_arrays(disk_model_name, disk_radius_outer)
+        # Construct disk
+        surf_dens_func, aspect_ratio_func, disk_model_properties = \
+            construct_disk_direct(disk_model_name, disk_radius_outer)
+        # Evaluate estimates for each quantity
+        surface_density_estimate = surf_dens_func(truncated_disk_radii)
+        aspect_ratio_estimate = aspect_ratio_func(truncated_disk_radii)
+        # Check that they're close
+        assert np.allclose(surface_density_estimate, truncated_surface_densities), \
+            "NumPy allclose failed for %s surface_density interpolation"%(disk_model_name)
+        assert np.allclose(aspect_ratio_estimate, truncated_aspect_ratios), \
+            "NumPy allclose failed for %s aspect_ratio interpolation"%(disk_model_name)
+    if verbose:
+        print("  pass!")
+
+def test_construct_disk_pAGN(verbose=True):
+    """test mcfacts.inputs.ReadInputs.construct_disk_pAGN
+
+    Parameters
+    ----------
+    verbose : bool
+        Verbose output
+    """
+    if verbose:
+        print("Testing construct_disk_pAGN")
+    # Check that the data folder exists
+    data_folder = impresources.files(mcfacts_input_data)
+    assert isdir(data_folder), "Cannot find mcfacts.inputs.data folder"
+    # Find the default inifile
+    fname_default_ini = data_folder / "model_choice.ini"
+    assert isfile(fname_default_ini), "Cannot find default inifile"
+    # Get input variables
+    input_variables = ReadInputs_ini(fname_default_ini, verbose=verbose)
+    # We only want disk_radius_outer
+    disk_radius_outer = input_variables["disk_radius_outer"]
+    # Construct productspace 
+    test_product_space = named_product(
+        disk_model_name         = DISK_MODEL_NAMES,
+        smbh_mass               = SMBH_MASSES,
+        disk_alpha_viscosity    = DISK_ALPHA_VISCOSITIES,
+        disk_bh_eddington_ratio = DISK_BH_EDDINGTON_RATIOS,
+    )
+    # Loop tests
+    for test_config in test_product_space:
+        # Run pAGN
+        surf_dens_func, aspect_ratio_func, disk_model_properties, bonus_structures = \
+            construct_disk_pAGN(
+                test_config.disk_model_name,
+                test_config.smbh_mass,
+                disk_radius_outer,
+                test_config.disk_alpha_viscosity,
+                test_config.disk_bh_eddington_ratio,
+            )
+    if verbose:
+        print("  pass!")
+
+def test_construct_disk_interp(
+    verbose=True,
+    ):
+    """Test mcfacts.inputs.ReadInputs.construct_disk_interp
+
+    Parameters
+    ----------
+    verbose : bool
+        Verbose output
+    """
+    if verbose:
+        print("Testing construct_disk_interp")
+    # Check that the data folder exists
+    data_folder = impresources.files(mcfacts_input_data)
+    assert isdir(data_folder), "Cannot find mcfacts.inputs.data folder"
+    # Find the default inifile
+    fname_default_ini = data_folder / "model_choice.ini"
+    assert isfile(fname_default_ini), "Cannot find default inifile"
+    # Get input variables
+    input_variables = ReadInputs_ini(fname_default_ini, verbose=verbose)
+    # We want a few things
+    smbh_mass = input_variables["smbh_mass"]
+    disk_radius_outer = input_variables["disk_radius_outer"]
+    disk_alpha_viscosity = input_variables["disk_alpha_viscosity"]
+    disk_bh_eddington_ratio = input_variables["disk_bh_eddington_ratio"]
+    disk_radius_max_pc = input_variables["disk_radius_max_pc"]
+    # Construct productspace 
+    test_product_space = named_product(
+        disk_model_name = DISK_MODEL_NAMES,
+        flag_use_pagn   = FLAG_USE_PAGN,
+    )
+    # Loop tests
+    for test_config in test_product_space:
+        # Run function
+        surf_dens_func, aspect_ratio_func = construct_disk_interp(
+            smbh_mass,
+            disk_radius_outer,
+            test_config.disk_model_name,
+            disk_alpha_viscosity,
+            disk_bh_eddington_ratio,
+            disk_radius_max_pc=disk_radius_max_pc,
+            flag_use_pagn=test_config.flag_use_pagn,
+            verbose=verbose,
+        )
+    if verbose:
+        print("  pass!")
+
+######## Main ########
+def main():
+    test_input_types()
+    test_ReadInputs_ini()
+    test_load_disk_arrays()
+    test_construct_disk_direct()
+    test_construct_disk_pAGN()
+    test_construct_disk_interp()
+
+######## Execution ########
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
All variable names in `mcfacts_sim.py` are changed to fit the new naming scheme. All variable names for the AGNObject, AGNBlackHole, and AGNStar classes are changed to fit the new naming scheme. `initializediskstars` and `setupdiskstars` are half changed, but everything works together.

`mcfacts_sim` is fully linted with commented out code and redundant lines removed.