### PR TITLE
remove unused function parameters

### DIFF
--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -925,7 +925,6 @@ def main():
                                 binary_bh_array[5, merger_indices[i]],
                                 binary_bh_array[6, merger_indices[i]],
                                 binary_bh_array[7, merger_indices[i]],
-                                binary_bh_array[16, merger_indices[i]],
                                 binary_bh_array[17, merger_indices[i]]
                             )
                             merged_bh_array[:, bh_mergers_current_num + i] = mergerfile.merged_bh(

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -907,7 +907,6 @@ def main():
                                 binary_bh_array[3, merger_indices[i]],
                                 binary_bh_array[4, merger_indices[i]],
                                 binary_bh_array[5, merger_indices[i]],
-                                binary_bh_array[16, merger_indices[i]]
                             )
                             bh_chi_eff_merged = chieff.chi_effective(
                                 binary_bh_array[2, merger_indices[i]],

--- a/src/mcfacts/physics/binary/merge/chieff.py
+++ b/src/mcfacts/physics/binary/merge/chieff.py
@@ -59,7 +59,7 @@ def chi_effective(masses_1, masses_2, spins_1, spins_2, spin_angles_1, spin_angl
 
     return chi_eff
 
-def chi_p(masses_1, masses_2, spins_1, spins_2, spin_angles_1, spin_angles_2, bin_ang_momenta, bin_incs_wrt_disk):
+def chi_p(masses_1, masses_2, spins_1, spins_2, spin_angles_1, spin_angles_2, bin_incs_wrt_disk):
     """Calculate the precessing spin component :math:`\chi_p` associated with a merger.
     
     chi_p = max[spin_1_perp, (q(4q+3)/(4+3q))* spin_2_perp]
@@ -87,10 +87,6 @@ def chi_p(masses_1, masses_2, spins_1, spins_2, spin_angles_1, spin_angles_2, bi
         Dimensionless spin angle of object 1.
     spin_angles_2 : float/ndarray
         Dimensionless spin angle of object 2.
-    bin_ang_momenta : int/ndarray
-        Direction of the binary's mutual angular momentum. If 1, the binary
-        is prograde (aligned with disk angular momentum). If -1, the binary
-        is retrograde (anti-aligned with disk angular momentum).
     bin_incs_wrt_disk : float/ndarray
         Angle of inclination of the binary with respect to the disk.
 

--- a/src/mcfacts/physics/binary/merge/tichy08.py
+++ b/src/mcfacts/physics/binary/merge/tichy08.py
@@ -46,7 +46,7 @@ def merged_mass(masses_1, masses_2, spins_1, spins_2):
     return merged_masses
 
 
-def merged_spin(masses_1, masses_2, spins_1, spins_2, bin_ang_mom):
+def merged_spin(masses_1, masses_2, spins_1, spins_2):
     """Calculate the spin magnitude of a merged binary.
 
     Only depends on M1,M2,a1,a2 and the binary ang mom around its center of mass.
@@ -64,8 +64,6 @@ def merged_spin(masses_1, masses_2, spins_1, spins_2, bin_ang_mom):
         Spin magnitudes of objects 1.
     spins_2 : float/ndarray
         Spin magnitudes of objects 2.
-    bin_ang_mom : float/ndarray
-        Angular momentum magnitudes of the binaries.
 
     Returns
     -------


### PR DESCRIPTION
Cleaned up unused function parameters

- `chieff.py`: function `chi_p()` called for the unused parameter `bin_ang_momenta`.
- `tichy08.py`: the function `merged_mass()` called for the unused parameter `bin_ang_mom`.