### PR TITLE
new default snapshot saving, disk truncation, and dir name behavior

### DIFF
--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -63,7 +63,7 @@ def arg():
     parser.add_argument("--fname-snapshots-bh",
                         default="output_bh_[single|binary]_$(index).dat",
                         help="output of BH index file ")
-    parser.add_argument("--no-snapshots", action='store_true')
+    parser.add_argument("--save-snapshots", action='store_true')
     parser.add_argument("--verbose", action='store_true')
     parser.add_argument("-w", "--work-directory",
                         default=Path().parent.resolve(),
@@ -450,16 +450,14 @@ def main():
         timestep_current_num = 0
 
         while time_passed < time_final:
-            # Record
-            if not (opts.no_snapshots):
+            # Record snapshots if user wishes
+            if opts.save_snapshots:
 
-                if (opts.verbose):
-                    blackholes_pro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_single_pro_{timestep_current_num}.dat"))
-                    blackholes_retro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_single_retro_{timestep_current_num}.dat"))
-                    stars_pro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_stars_single_pro{timestep_current_num}.dat"))
-                    stars_retro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_stars_single_retro_{timestep_current_num}.dat"))
-
-                    blackholes_binary.to_txt(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_binary_{timestep_current_num}.dat"),
+                blackholes_pro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_single_pro_{timestep_current_num}.dat"))
+                blackholes_retro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_single_retro_{timestep_current_num}.dat"))
+                stars_pro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_stars_single_pro{timestep_current_num}.dat"))
+                stars_retro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_stars_single_retro_{timestep_current_num}.dat"))
+                blackholes_binary.to_txt(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_binary_{timestep_current_num}.dat"),
                                              cols=binary_cols)
                 timestep_current_num += 1
 

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -202,9 +202,9 @@ def main():
         # Fills run number with leading zeros to stay sequential
         galaxy_zfilled_str = f"{galaxy:>0{int(np.log10(opts.galaxy_num))+1}}"
         try:  # Make subdir, exit if it exists to avoid clobbering.
-            os.makedirs(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}"), exist_ok=False)
+            os.makedirs(os.path.join(opts.work_directory, f"gal{galaxy_zfilled_str}"), exist_ok=False)
         except FileExistsError:
-            raise FileExistsError(f"Directory \'run{galaxy_zfilled_str}\' exists. Exiting so I don't delete your data.")
+            raise FileExistsError(f"Directory \'gal{galaxy_zfilled_str}\' exists. Exiting so I don't delete your data.")
 
         # Housekeeping for array initialization
         blackholes_binary = AGNBinaryBlackHole()
@@ -303,8 +303,8 @@ def main():
                                    new_disk_inner_outer=np.zeros(stars.num))
 
         # Writing initial parameters to file
-        stars.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/initial_params_star.dat"))
-        blackholes.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/initial_params_bh.dat"))
+        stars.to_file(os.path.join(opts.work_directory, f"gal{galaxy_zfilled_str}/initial_params_star.dat"))
+        blackholes.to_file(os.path.join(opts.work_directory, f"gal{galaxy_zfilled_str}/initial_params_bh.dat"))
 
         # Generate initial inner disk arrays for objects that end up in the inner disk. 
         # This is to track possible EMRIs--we're tossing things in these arrays
@@ -453,11 +453,11 @@ def main():
             # Record snapshots if user wishes
             if opts.save_snapshots:
 
-                blackholes_pro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_single_pro_{timestep_current_num}.dat"))
-                blackholes_retro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_single_retro_{timestep_current_num}.dat"))
-                stars_pro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_stars_single_pro{timestep_current_num}.dat"))
-                stars_retro.to_file(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_stars_single_retro_{timestep_current_num}.dat"))
-                blackholes_binary.to_txt(os.path.join(opts.work_directory, f"run{galaxy_zfilled_str}/output_bh_binary_{timestep_current_num}.dat"),
+                blackholes_pro.to_file(os.path.join(opts.work_directory, f"gal{galaxy_zfilled_str}/output_bh_single_pro_{timestep_current_num}.dat"))
+                blackholes_retro.to_file(os.path.join(opts.work_directory, f"gal{galaxy_zfilled_str}/output_bh_single_retro_{timestep_current_num}.dat"))
+                stars_pro.to_file(os.path.join(opts.work_directory, f"gal{galaxy_zfilled_str}/output_stars_single_pro{timestep_current_num}.dat"))
+                stars_retro.to_file(os.path.join(opts.work_directory, f"gal{galaxy_zfilled_str}/output_stars_single_retro_{timestep_current_num}.dat"))
+                blackholes_binary.to_txt(os.path.join(opts.work_directory, f"gal{galaxy_zfilled_str}/output_bh_binary_{timestep_current_num}.dat"),
                                              cols=binary_cols)
                 timestep_current_num += 1
 
@@ -1311,7 +1311,7 @@ def main():
                                               new_galaxy=blackholes_binary_gw.galaxy)
 
         # Save the mergers
-        galaxy_save_name = f"run{galaxy_zfilled_str}/{opts.fname_output_mergers}"
+        galaxy_save_name = f"gal{galaxy_zfilled_str}/{opts.fname_output_mergers}"
         blackholes_merged.to_txt(os.path.join(opts.work_directory, galaxy_save_name), cols=merger_cols)
 
         # Append each galaxy result to outputs

--- a/src/mcfacts/external/DiskModelsPAGN.py
+++ b/src/mcfacts/external/DiskModelsPAGN.py
@@ -42,7 +42,7 @@ class AGNGasDiskModel(object):
         else:
             np.savetxt(filename, np.vstack((R/ct.pc, Omega, T, rho, h, cs, tauV, Q)).T)
 
-    def return_disk_surf_model(self, no_truncate=True):
+    def return_disk_surf_model(self, flag_truncate_disk=True):
         """Generate disk surface model functions
 
         Interpolate and return disk surface model functions as a function of the disk radius.
@@ -54,9 +54,9 @@ class AGNGasDiskModel(object):
         
         Parameters
         ----------
-        no_truncate : bool, optional
-            If `False`, truncate these functions to the extent of the where starformation starts
-            in the gas disk. If `True`, do not truncate, by default True.
+        flag_truncate_disk : bool, optional
+            If `True`, truncate these functions at the radius where star formation starts
+            in the gas disk. If `False`, do not truncate, by default `True`.
 
         Returns
         -------
@@ -77,7 +77,7 @@ class AGNGasDiskModel(object):
         R_agn = self.disk_model.R_AGN / (self.disk_model.Rs / 2)
         Sigma = 2 * self.disk_model.h * self.disk_model.rho  # SI density
         kappa = 2 * self.disk_model.tauV / Sigma # Opacity = 2*tau/Sigma
-        if not(no_truncate): # truncate to gas part of disk (no SFR)
+        if flag_truncate_disk: # truncate to gas part of disk (no SFR)
             R=R[:self.disk_model.isf]
             Sigma = Sigma[:self.disk_model.isf]
             kappa = kappa[:self.disk_model.isf]
@@ -93,7 +93,7 @@ class AGNGasDiskModel(object):
 
         # Generate aspect ratio (h/r) interpolator function
         ln_aspect_ratio = np.log(self.disk_model.h/self.disk_model.R)
-        if not(no_truncate): # truncate to gas part of disk (no SFR)
+        if flag_truncate_disk: # truncate to gas part of disk (no SFR)
             ln_aspect_ratio = ln_aspect_ratio[:self.disk_model.isf]
         aspect_func_log = scipy.interpolate.CubicSpline(
                                                         np.log(R),

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -623,7 +623,7 @@ def ReadInputs_prior_mergers(fname='recipes/sg1Myrx2_survivors.dat', verbose=Fal
         (wasn't involved in merger in previous episode; but accretion=mass/spin changed)
     )
     """
-    with open(fname) as filedata:
+    with open(fname, 'r') as filedata:
         prior_mergers_file = np.genfromtxt(filedata, unpack = True)
 
 

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -482,7 +482,7 @@ def construct_disk_pAGN(
 
     # Run pAGN
     pagn_model =dm_pagn.AGNGasDiskModel(disk_type=pagn_name,**base_args)
-    disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, bonus_structures  = \
+    disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, bonus_structures = \
         pagn_model.return_disk_surf_model()
 
     # Define properties we want to return

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -623,8 +623,8 @@ def ReadInputs_prior_mergers(fname='recipes/sg1Myrx2_survivors.dat', verbose=Fal
         (wasn't involved in merger in previous episode; but accretion=mass/spin changed)
     )
     """
-    with open('../recipes/sg1Myrx2_survivors.dat') as filedata:
-        prior_mergers_file = np.genfromtxt('../recipes/sg1Myrx2_survivors.dat', unpack = True)
+    with open(fname) as filedata:
+        prior_mergers_file = np.genfromtxt(filedata, unpack = True)
 
 
     #Clean the file of galaxy lines (of form 3.0 3.0 3.0 3.0 3.0 etc for it=3.0, same value across each column)


### PR DESCRIPTION
1. only write galaxy snapshot `*.dat` files if user passes `--save-snapshots` flag
2. make logic behind truncating disks more straight forward. Also, truncated by-default.
3. fix prior merger file name hard coding
4. new name for sub-directories to match galaxy conventions to `runs/gal*/`