### PR TITLE
Fixing bugs in type1_migration and retro_bh_orb_disk_evolve

### DIFF
--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1220,7 +1220,6 @@ def main():
                     agn_redshift
                 )
 
-
             if blackholes_inner_disk.num > 0:
                 blackholes_emris.add_blackholes(new_mass=blackholes_inner_disk.mass,
                                                 new_spin=blackholes_inner_disk.spin,

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -711,7 +711,7 @@ def main():
 
                 # If there are binaries, evolve them
                 # Damp binary orbital eccentricity
-                eccentricity.orbital_bin_ecc_damping(
+                blackholes_binary = eccentricity.orbital_bin_ecc_damping(
                     opts.smbh_mass,
                     blackholes_binary,
                     disk_surface_density,

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -581,6 +581,7 @@ def main():
                 blackholes_retro.orb_ecc,
                 blackholes_retro.orb_inc,
                 blackholes_retro.orb_arg_periapse,
+                opts.disk_inner_stable_circ_orb,
                 disk_surface_density,
                 opts.timestep_duration_yr
             )

--- a/src/mcfacts/physics/accretion.py
+++ b/src/mcfacts/physics/accretion.py
@@ -120,18 +120,10 @@ def change_star_spin_magnitudes(disk_star_pro_spins,
     spin_iteration = (1.e-3*disk_bh_eddington_ratio_normalized*disk_star_torque_condition_normalized*timestep_duration_yr_normalized)
 
     disk_star_pro_spins_new = disk_star_pro_spins
-    # Singleton star with orb ecc > disk_star_pro_orbs_ecc_crit will spin down b/c accrete retrograde
-    #disk_star_pro_spin_down = np.ma.masked_where(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
-    # Singleton star with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
-    #disk_star_pro_spin_up = np.ma.masked_where(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
-    # Indices of singleton star with orb ecc > disk_star_pro_orbs_ecc_crit
-    #disk_star_pro_indices_spin_down = np.ma.nonzero(disk_star_pro_spin_down)
-    # Indices of singleton star with orb ecc < disk_star_pro_orbs_ecc_crit
-    #disk_star_pro_indices_spin_up = np.ma.nonzero(disk_star_pro_spin_up)
 
     # Singleton star with orb_ecc > orb_ecc_crit will spin down bc accrete retrograde
     disk_star_pro_indices_spin_down = np.asarray(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit).nonzero()[0]
-    # Singleton star with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
+    # Singleton star with orb ecc <= disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
     disk_star_pro_indices_spin_up = np.asarray(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit).nonzero()[0]
 
 
@@ -207,18 +199,10 @@ def change_star_spin_angles(prograde_stars_spin_angles,
 
     # Assume same angles as before to start
     disk_star_spin_angles_new = prograde_stars_spin_angles
-    # Singleton star with orb ecc > disk_star_pro_orbs_ecc_crit will spin down b/c accrete retrograde
-    #disk_star_pro_spin_down = np.ma.masked_where(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
-    # Singleton star with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
-    #disk_star_pro_spin_up = np.ma.masked_where(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
-    # Indices of singleton star with orb ecc > disk_star_pro_orbs_ecc_crit
-    #disk_star_pro_indices_spin_down = np.ma.nonzero(disk_star_pro_spin_down)
-    # Indices of singleton star with orb ecc < disk_star_pro_orbs_ecc_crit
-    #disk_star_pro_indices_spin_up = np.ma.nonzero(disk_star_pro_spin_up)
 
     # Singleton star with orb_ecc > orb_ecc_crit will spin down bc accrete retrograde
     disk_star_pro_indices_spin_down = np.asarray(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit).nonzero()[0]
-    # Singleton star with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
+    # Singleton star with orb ecc <= disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
     disk_star_pro_indices_spin_up = np.asarray(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit).nonzero()[0]
 
 
@@ -283,14 +267,6 @@ def change_bh_spin_magnitudes(disk_bh_pro_spins,
     spin_iteration = (1.e-3*normalized_Eddington_ratio*normalized_spin_torque_condition*normalized_timestep)
 
     disk_bh_pro_spins_new = disk_bh_pro_spins
-    # Singleton BH with orb ecc > disk_bh_pro_orbs_ecc_crit will spin down b/c accrete retrograde
-    #prograde_bh_spin_down = np.ma.masked_where(disk_bh_pro_orbs_ecc <= disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
-    # Singleton BH with orb ecc < disk_bh_pro_orbs_ecc_crit will spin up b/c accrete prograde
-    #prograde_bh_spin_up = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
-    # Indices of singleton BH with orb ecc > disk_bh_pro_orbs_ecc_crit
-    #indices_bh_spin_down = np.ma.nonzero(prograde_bh_spin_down)
-    # Indices of singleton BH with orb ecc < disk_bh_pro_orbs_ecc_crit
-    #indices_bh_spin_up = np.ma.nonzero(prograde_bh_spin_up)
 
     # Singleton BH with orb_ecc > orb_ecc_crit will spin down bc accrete retrograde
     indices_bh_spin_down = np.asarray(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit).nonzero()[0]
@@ -361,14 +337,6 @@ def change_bh_spin_angles(disk_bh_pro_spin_angles,
 
     # Assume same angles as before to start
     disk_bh_spin_angles_new = disk_bh_pro_spin_angles
-    # Singleton BH with orb ecc > disk_bh_pro_orbs_ecc_crit will spin down b/c accrete retrograde
-    #prograde_bh_spin_down = np.ma.masked_where(disk_bh_pro_orbs_ecc <= disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
-    # Singleton BH with orb ecc < disk_bh_pro_orbs_ecc_crit will spin up b/c accrete prograde
-    #prograde_bh_spin_up = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
-    # Indices of singleton BH with orb ecc > disk_bh_pro_orbs_ecc_crit
-    #indices_bh_spin_down = np.ma.nonzero(prograde_bh_spin_down)
-    # Indices of singleton BH with orb ecc < disk_bh_pro_orbs_ecc_crit
-    #indices_bh_spin_up = np.ma.nonzero(prograde_bh_spin_up)
 
     # Singleton BH with orb_ecc > orb_ecc_crit will spin down bc accrete retrograde
     indices_bh_spin_down = np.asarray(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit).nonzero()[0]

--- a/src/mcfacts/physics/accretion.py
+++ b/src/mcfacts/physics/accretion.py
@@ -121,13 +121,21 @@ def change_star_spin_magnitudes(disk_star_pro_spins,
 
     disk_star_pro_spins_new = disk_star_pro_spins
     # Singleton star with orb ecc > disk_star_pro_orbs_ecc_crit will spin down b/c accrete retrograde
-    disk_star_pro_spin_down = np.ma.masked_where(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
+    #disk_star_pro_spin_down = np.ma.masked_where(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
     # Singleton star with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
-    disk_star_pro_spin_up = np.ma.masked_where(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
+    #disk_star_pro_spin_up = np.ma.masked_where(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
     # Indices of singleton star with orb ecc > disk_star_pro_orbs_ecc_crit
-    disk_star_pro_indices_spin_down = np.ma.nonzero(disk_star_pro_spin_down)
+    #disk_star_pro_indices_spin_down = np.ma.nonzero(disk_star_pro_spin_down)
     # Indices of singleton star with orb ecc < disk_star_pro_orbs_ecc_crit
-    disk_star_pro_indices_spin_up = np.ma.nonzero(disk_star_pro_spin_up)
+    #disk_star_pro_indices_spin_up = np.ma.nonzero(disk_star_pro_spin_up)
+
+    # Singleton star with orb_ecc > orb_ecc_crit will spin down bc accrete retrograde
+    disk_star_pro_indices_spin_down = np.asarray(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit).nonzero()[0]
+    # Singleton star with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
+    disk_star_pro_indices_spin_up = np.asarray(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit).nonzero()[0]
+
+
+
     # disk_star_pro_spins_new[prograde_orb_ang_mom_indices]=disk_star_pro_spins_new[prograde_orb_ang_mom_indices]+(4.4e-3*disk_bh_eddington_ratio_normalized*disk_star_torque_condition_normalized*timestep_duration_yr_normalized)
     disk_star_pro_spins_new[disk_star_pro_indices_spin_up] = disk_star_pro_spins[disk_star_pro_indices_spin_up] + spin_iteration
     # Spin down stars with orb ecc > disk_star_pro_orbs_ecc_crit
@@ -200,13 +208,19 @@ def change_star_spin_angles(prograde_stars_spin_angles,
     # Assume same angles as before to start
     disk_star_spin_angles_new = prograde_stars_spin_angles
     # Singleton star with orb ecc > disk_star_pro_orbs_ecc_crit will spin down b/c accrete retrograde
-    disk_star_pro_spin_down = np.ma.masked_where(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
+    #disk_star_pro_spin_down = np.ma.masked_where(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
     # Singleton star with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
-    disk_star_pro_spin_up = np.ma.masked_where(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
+    #disk_star_pro_spin_up = np.ma.masked_where(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit, disk_star_pro_orbs_ecc)
     # Indices of singleton star with orb ecc > disk_star_pro_orbs_ecc_crit
-    disk_star_pro_indices_spin_down = np.ma.nonzero(disk_star_pro_spin_down)
+    #disk_star_pro_indices_spin_down = np.ma.nonzero(disk_star_pro_spin_down)
     # Indices of singleton star with orb ecc < disk_star_pro_orbs_ecc_crit
-    disk_star_pro_indices_spin_up = np.ma.nonzero(disk_star_pro_spin_up)
+    #disk_star_pro_indices_spin_up = np.ma.nonzero(disk_star_pro_spin_up)
+
+    # Singleton star with orb_ecc > orb_ecc_crit will spin down bc accrete retrograde
+    disk_star_pro_indices_spin_down = np.asarray(disk_star_pro_orbs_ecc > disk_star_pro_orbs_ecc_crit).nonzero()[0]
+    # Singleton star with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
+    disk_star_pro_indices_spin_up = np.asarray(disk_star_pro_orbs_ecc <= disk_star_pro_orbs_ecc_crit).nonzero()[0]
+
 
     # Spin up stars are torqued towards zero (ie alignment with disk,
     # so decrease mag of spin angle)
@@ -270,13 +284,19 @@ def change_bh_spin_magnitudes(disk_bh_pro_spins,
 
     disk_bh_pro_spins_new = disk_bh_pro_spins
     # Singleton BH with orb ecc > disk_bh_pro_orbs_ecc_crit will spin down b/c accrete retrograde
-    prograde_bh_spin_down = np.ma.masked_where(disk_bh_pro_orbs_ecc <= disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
+    #prograde_bh_spin_down = np.ma.masked_where(disk_bh_pro_orbs_ecc <= disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
     # Singleton BH with orb ecc < disk_bh_pro_orbs_ecc_crit will spin up b/c accrete prograde
-    prograde_bh_spin_up = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
+    #prograde_bh_spin_up = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
     # Indices of singleton BH with orb ecc > disk_bh_pro_orbs_ecc_crit
-    indices_bh_spin_down = np.ma.nonzero(prograde_bh_spin_down)
+    #indices_bh_spin_down = np.ma.nonzero(prograde_bh_spin_down)
     # Indices of singleton BH with orb ecc < disk_bh_pro_orbs_ecc_crit
-    indices_bh_spin_up = np.ma.nonzero(prograde_bh_spin_up)
+    #indices_bh_spin_up = np.ma.nonzero(prograde_bh_spin_up)
+
+    # Singleton BH with orb_ecc > orb_ecc_crit will spin down bc accrete retrograde
+    indices_bh_spin_down = np.asarray(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit).nonzero()[0]
+    # Singleton BH with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
+    indices_bh_spin_up = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orbs_ecc_crit).nonzero()[0]
+
     # disk_bh_pro_spins_new[prograde_orb_ang_mom_indices]=disk_bh_pro_spins_new[prograde_orb_ang_mom_indices]+(4.4e-3*normalized_Eddington_ratio*normalized_spin_torque_condition*normalized_timestep)
     disk_bh_pro_spins_new[indices_bh_spin_up] = disk_bh_pro_spins[indices_bh_spin_up] + spin_iteration
     # Spin down BH with orb ecc > disk_bh_pro_orbs_ecc_crit
@@ -342,13 +362,19 @@ def change_bh_spin_angles(disk_bh_pro_spin_angles,
     # Assume same angles as before to start
     disk_bh_spin_angles_new = disk_bh_pro_spin_angles
     # Singleton BH with orb ecc > disk_bh_pro_orbs_ecc_crit will spin down b/c accrete retrograde
-    prograde_bh_spin_down = np.ma.masked_where(disk_bh_pro_orbs_ecc <= disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
+    #prograde_bh_spin_down = np.ma.masked_where(disk_bh_pro_orbs_ecc <= disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
     # Singleton BH with orb ecc < disk_bh_pro_orbs_ecc_crit will spin up b/c accrete prograde
-    prograde_bh_spin_up = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
+    #prograde_bh_spin_up = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit, disk_bh_pro_orbs_ecc)
     # Indices of singleton BH with orb ecc > disk_bh_pro_orbs_ecc_crit
-    indices_bh_spin_down = np.ma.nonzero(prograde_bh_spin_down)
+    #indices_bh_spin_down = np.ma.nonzero(prograde_bh_spin_down)
     # Indices of singleton BH with orb ecc < disk_bh_pro_orbs_ecc_crit
-    indices_bh_spin_up = np.ma.nonzero(prograde_bh_spin_up)
+    #indices_bh_spin_up = np.ma.nonzero(prograde_bh_spin_up)
+
+    # Singleton BH with orb_ecc > orb_ecc_crit will spin down bc accrete retrograde
+    indices_bh_spin_down = np.asarray(disk_bh_pro_orbs_ecc > disk_bh_pro_orbs_ecc_crit).nonzero()[0]
+    # Singleton BH with orb ecc < disk_star_pro_orbs_ecc_crit will spin up b/c accrete prograde
+    indices_bh_spin_up = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orbs_ecc_crit).nonzero()[0]
+
 
     # Spin up BH are torqued towards zero (ie alignment with disk, so decrease mag of spin angle)
     disk_bh_spin_angles_new[indices_bh_spin_up] = disk_bh_pro_spin_angles[indices_bh_spin_up] - spin_torque_iteration

--- a/src/mcfacts/physics/binary/formation.py
+++ b/src/mcfacts/physics/binary/formation.py
@@ -59,10 +59,12 @@ def binary_check(
     # binaries.
 
     # Singleton BH with orb ecc < e_crit (candidates for binary formation)
-    prograde_bh_can_form_bins = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
-    indices_bh_can_form_bins = np.ma.nonzero(prograde_bh_can_form_bins)
+    #prograde_bh_can_form_bins = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
+    #indices_bh_can_form_bins = np.ma.nonzero(prograde_bh_can_form_bins)
+
+    indices_bh_can_form_bins = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
     # Indices of those candidates for binary formation
-    allowed_to_form_bins = np.array(indices_bh_can_form_bins[0])
+    allowed_to_form_bins = np.array(indices_bh_can_form_bins)
     # Sort the location of the candidates
     sorted_bh_locations = np.sort(disk_bh_pro_orbs_a[allowed_to_form_bins])
     # Sort the indices of all singleton BH (the superset)

--- a/src/mcfacts/physics/binary/formation.py
+++ b/src/mcfacts/physics/binary/formation.py
@@ -59,9 +59,6 @@ def binary_check(
     # binaries.
 
     # Singleton BH with orb ecc < e_crit (candidates for binary formation)
-    #prograde_bh_can_form_bins = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
-    #indices_bh_can_form_bins = np.ma.nonzero(prograde_bh_can_form_bins)
-
     indices_bh_can_form_bins = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
     # Indices of those candidates for binary formation
     allowed_to_form_bins = np.array(indices_bh_can_form_bins)

--- a/src/mcfacts/physics/disk_capture.py
+++ b/src/mcfacts/physics/disk_capture.py
@@ -101,7 +101,8 @@ def orb_inc_damping(smbh_mass, disk_bh_retro_orbs_a, disk_bh_retro_masses, disk_
 
 
 def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs_a, disk_bh_retro_orbs_ecc,
-                             disk_bh_retro_orbs_inc, disk_bh_retro_arg_periapse, disk_surf_density_func, timestep_duration_yr):
+                             disk_bh_retro_orbs_inc, disk_bh_retro_arg_periapse,
+                             disk_inner_stable_circ_orb, disk_surf_density_func, timestep_duration_yr):
     """Evolve the orbit of initially-embedded retrograde black hole orbiters due to disk interactions.
 
     This is a CRUDE version of evolution, future upgrades may couple to SpaceHub.
@@ -248,8 +249,8 @@ def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs
                 if disk_bh_retro_orbs_ecc_new[i] >= (1.0 - epsilon): disk_bh_retro_orbs_ecc_new[i] = (1.0 - epsilon)
                 disk_bh_retro_orbs_a_new[i] = disk_bh_retro_orbs_a[i] * (
                             1.0 - step1_delta_semimaj / disk_bh_retro_orbs_a[i] * (timestep_duration_yr / semimaj_scale_factor))
-                # catch overshooting semimaj axis, set to 0.0
-                if disk_bh_retro_orbs_a_new[i] <= 0.0: disk_bh_retro_orbs_a_new[i] = 0.0
+                # catch overshooting semimaj axis, set to disk_inner_stable_circ_orb
+                if disk_bh_retro_orbs_a_new[i] <= 0.0: disk_bh_retro_orbs_a_new[i] = disk_inner_stable_circ_orb
                 disk_bh_retro_orbs_inc_new[i] = disk_bh_retro_orbs_inc[i] * (
                             1.0 - step1_delta_inc / disk_bh_retro_orbs_inc[i] * (timestep_duration_yr / inc_scale_factor))
                 # catch overshooting inc, set to 0.0
@@ -278,8 +279,8 @@ def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs
                 if disk_bh_retro_orbs_ecc_new[i] >= (1.0 - epsilon): disk_bh_retro_orbs_ecc_new[i] = (1.0 - epsilon)
                 disk_bh_retro_orbs_a_new[i] = disk_bh_retro_orbs_a[i] * (
                             1.0 - step2_delta_semimaj / disk_bh_retro_orbs_a[i] * (timestep_duration_yr / semimaj_scale_factor))
-                # catch overshooting semimaj axis, set to 0.0
-                if disk_bh_retro_orbs_a_new[i] <= 0.0: disk_bh_retro_orbs_a_new[i] = 0.0
+                # catch overshooting semimaj axis, set to disk_inner_stable_circ_orb
+                if disk_bh_retro_orbs_a_new[i] <= 0.0: disk_bh_retro_orbs_a_new[i] = disk_inner_stable_circ_orb
                 disk_bh_retro_orbs_inc_new[i] = disk_bh_retro_orbs_inc[i] * (
                             1.0 - step2_delta_inc / disk_bh_retro_orbs_inc[i] * (timestep_duration_yr / inc_scale_factor))
                 # catch overshooting inc, set to 0.0
@@ -307,8 +308,8 @@ def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs
                 if disk_bh_retro_orbs_ecc_new[i] < 0.0: disk_bh_retro_orbs_ecc_new[i] = 0.0
                 disk_bh_retro_orbs_a_new[i] = disk_bh_retro_orbs_a[i] * (
                             1.0 - step3_delta_semimaj / disk_bh_retro_orbs_a[i] * (timestep_duration_yr / semimaj_scale_factor))
-                # catch overshooting semimaj axis, set to 0.0
-                if disk_bh_retro_orbs_a_new[i] <= 0.0: disk_bh_retro_orbs_a_new[i] = 0.0
+                # catch overshooting semimaj axis, set to disk_inner_stable_circ_orb
+                if disk_bh_retro_orbs_a_new[i] <= 0.0: disk_bh_retro_orbs_a_new[i] = disk_inner_stable_circ_orb
                 disk_bh_retro_orbs_inc_new[i] = disk_bh_retro_orbs_inc[i] * (
                             1.0 - step3_delta_inc / disk_bh_retro_orbs_inc[i] * (timestep_duration_yr / inc_scale_factor))
                 # catch overshooting inc, set to 0.0
@@ -342,8 +343,8 @@ def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs
             if disk_bh_retro_orbs_ecc_new[i] < 0.0: disk_bh_retro_orbs_ecc_new[i] = 0.0
             disk_bh_retro_orbs_a_new[i] = disk_bh_retro_orbs_a[i] * (
                         1.0 - stepw0_delta_semimaj / disk_bh_retro_orbs_a[i] * (timestep_duration_yr / stepw0_time))
-            # catch overshooting semimaj axis, set to 0.0
-            if disk_bh_retro_orbs_a_new[i] <= 0.0: disk_bh_retro_orbs_a_new[i] = 0.0
+            # catch overshooting semimaj axis, set to disk_inner_stable_circ_orb
+            if disk_bh_retro_orbs_a_new[i] <= 0.0: disk_bh_retro_orbs_a_new[i] = disk_inner_stable_circ_orb
             disk_bh_retro_orbs_inc_new[i] = disk_bh_retro_orbs_inc[i] * (1.0 - stepw0_delta_inc / disk_bh_retro_orbs_inc[i] * (timestep_duration_yr / stepw0_time))
             # catch overshooting inc, set to 0.0
             if disk_bh_retro_orbs_inc_new[i] <= (0.0): disk_bh_retro_orbs_inc_new[i] = (0.0)

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -150,19 +150,23 @@ def circular_singles_encounters_prograde(
     """
 
     # Set up new_disk_bh_pro_orbs_ecc
-    new_disk_bh_pro_orbs_ecc=np.empty_like(disk_bh_pro_orbs_ecc)
+    #new_disk_bh_pro_orbs_ecc=np.empty_like(disk_bh_pro_orbs_ecc)
 
     # Calculate & normalize all the parameters above in t_damp
     # E.g. normalize q=bh_mass/smbh_mass to 10^-7
-    mass_ratio = disk_bh_pro_masses/smbh_mass
+    #mass_ratio = disk_bh_pro_masses/smbh_mass
 
     # Find the e< crit_ecc. population. These are the (circularized) population that can form binaries.
-    circ_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
+    #circ_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
     # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
-    ecc_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc < disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
+    #ecc_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc < disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
     # Find the indices of the e<crit_ecc population
-    circ_prograde_population_indices = np.ma.nonzero(circ_prograde_population)
-    ecc_prograde_population_indices = np.ma.nonzero(ecc_prograde_population)
+    #circ_prograde_population_indices = np.ma.nonzero(circ_prograde_population)
+    #ecc_prograde_population_indices = np.ma.nonzero(ecc_prograde_population)
+
+    circ_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
+    ecc_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc >= disk_bh_pro_orb_ecc_crit).nonzero()[0]
+
     # Find their locations and masses
     circ_prograde_population_locations = disk_bh_pro_orbs_a[circ_prograde_population_indices]
     circ_prograde_population_masses = disk_bh_pro_masses[circ_prograde_population_indices]
@@ -193,7 +197,7 @@ def circular_singles_encounters_prograde(
                         prob_enc_per_timestep = 1
                     random_uniform_number = rng.uniform(size=1)
                     if random_uniform_number < prob_enc_per_timestep:
-                        indx_array = circ_prograde_population_indices[0]
+                        indx_array = circ_prograde_population_indices
                         num_encounters = num_encounters + 1
                         # if close encounter, pump ecc of circ orbiter to e=0.1 from near circular, and incr a_circ1 by 10%
                         # drop ecc of a_i by 10% and drop a_i by 10% (P.E. = -GMm/a)
@@ -363,9 +367,11 @@ def circular_binaries_encounters_ecc_prograde(
     bin_orbits_per_timestep = timestep_duration_yr/bin_orbital_times
 
     # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
-    ecc_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc < disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
+    #ecc_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc < disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
     # Find the indices of the e<crit_ecc population
-    ecc_prograde_population_indices = np.ma.nonzero(ecc_prograde_population)
+    #ecc_prograde_population_indices = np.ma.nonzero(ecc_prograde_population)
+
+    ecc_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc >= disk_bh_pro_orb_ecc_crit).nonzero()[0]
     # Find their locations and masses
     ecc_prograde_population_locations = disk_bh_pro_orbs_a[ecc_prograde_population_indices]
     ecc_prograde_population_masses = disk_bh_pro_masses[ecc_prograde_population_indices]
@@ -606,9 +612,11 @@ def circular_binaries_encounters_circ_prograde(
     bin_binding_energy = scipy.constants.G * (solar_mass ** 2.0) * blackholes_binary.mass_1 * blackholes_binary.mass_2 / (blackholes_binary.bin_sep * rg_in_meters)
 
     # Find the e< crit_ecc population. These are the interlopers w. low encounter vel that can harden the circularized population
-    circ_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
+    #circ_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
     # Find the indices of the e<crit_ecc population
-    circ_prograde_population_indices = np.ma.nonzero(circ_prograde_population)
+    #circ_prograde_population_indices = np.ma.nonzero(circ_prograde_population)
+
+    circ_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
     # Find their locations and masses
     circ_prograde_population_locations = disk_bh_pro_orbs_a[circ_prograde_population_indices]
     circ_prograde_population_masses = disk_bh_pro_masses[circ_prograde_population_indices]

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -149,22 +149,9 @@ def circular_singles_encounters_prograde(
             and remove da_bin worth of binary energy from eccentricity of m3.
     """
 
-    # Set up new_disk_bh_pro_orbs_ecc
-    #new_disk_bh_pro_orbs_ecc=np.empty_like(disk_bh_pro_orbs_ecc)
-
-    # Calculate & normalize all the parameters above in t_damp
-    # E.g. normalize q=bh_mass/smbh_mass to 10^-7
-    #mass_ratio = disk_bh_pro_masses/smbh_mass
-
     # Find the e< crit_ecc. population. These are the (circularized) population that can form binaries.
-    #circ_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
-    # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
-    #ecc_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc < disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
-    # Find the indices of the e<crit_ecc population
-    #circ_prograde_population_indices = np.ma.nonzero(circ_prograde_population)
-    #ecc_prograde_population_indices = np.ma.nonzero(ecc_prograde_population)
-
     circ_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
+    # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
     ecc_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc >= disk_bh_pro_orb_ecc_crit).nonzero()[0]
 
     # Find their locations and masses
@@ -184,7 +171,7 @@ def circular_singles_encounters_prograde(
     num_encounters = 0
     if len(circ_prograde_population_locations) > 0:
         for i in range(0, len(circ_prograde_population_locations)):
-            for j in range(0,len(ecc_prograde_population_locations)):
+            for j in range(0, len(ecc_prograde_population_locations)):
                 if circ_prograde_population_locations[i] < ecc_orb_max[j] and circ_prograde_population_locations[i] > ecc_orb_min[j]:
                     # prob_encounter/orbit =hill sphere size/circumference of circ orbit =2RH/2pi a_circ1
                     # r_h = a_circ1(temp_bin_mass/3smbh_mass)^1/3 so prob_enc/orb = mass_ratio^1/3/pi
@@ -367,10 +354,6 @@ def circular_binaries_encounters_ecc_prograde(
     bin_orbits_per_timestep = timestep_duration_yr/bin_orbital_times
 
     # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
-    #ecc_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc < disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
-    # Find the indices of the e<crit_ecc population
-    #ecc_prograde_population_indices = np.ma.nonzero(ecc_prograde_population)
-
     ecc_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc >= disk_bh_pro_orb_ecc_crit).nonzero()[0]
     # Find their locations and masses
     ecc_prograde_population_locations = disk_bh_pro_orbs_a[ecc_prograde_population_indices]
@@ -612,10 +595,6 @@ def circular_binaries_encounters_circ_prograde(
     bin_binding_energy = scipy.constants.G * (solar_mass ** 2.0) * blackholes_binary.mass_1 * blackholes_binary.mass_2 / (blackholes_binary.bin_sep * rg_in_meters)
 
     # Find the e< crit_ecc population. These are the interlopers w. low encounter vel that can harden the circularized population
-    #circ_prograde_population = np.ma.masked_where(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit, disk_bh_pro_orbs_ecc)
-    # Find the indices of the e<crit_ecc population
-    #circ_prograde_population_indices = np.ma.nonzero(circ_prograde_population)
-
     circ_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
     # Find their locations and masses
     circ_prograde_population_locations = disk_bh_pro_orbs_a[circ_prograde_population_indices]

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -100,20 +100,24 @@ def orbital_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, 
 
     # Modest orb eccentricities: e < 2h (experience simple exponential damping): mask entries > 2*aspect_ratio;
     # only show BH with e<2h
-    prograde_bh_modest_ecc = np.ma.masked_where(
-        prograde_disk_bh_pro_orbs_ecc > 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
-        prograde_disk_bh_pro_orbs_ecc)
+    #prograde_bh_modest_ecc = np.ma.masked_where(
+    #    prograde_disk_bh_pro_orbs_ecc > 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
+    #    prograde_disk_bh_pro_orbs_ecc)
 
     # Large orb eccentricities: e > 2h (experience more complicated damping)
-    prograde_bh_large_ecc = np.ma.masked_where(
-        prograde_disk_bh_pro_orbs_ecc < 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
-        prograde_disk_bh_pro_orbs_ecc)
+    #prograde_bh_large_ecc = np.ma.masked_where(
+    #    prograde_disk_bh_pro_orbs_ecc < 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
+    #    prograde_disk_bh_pro_orbs_ecc)
 
     # Indices of orb eccentricities where e<2h
-    modest_ecc_prograde_indices = np.ma.nonzero(prograde_bh_modest_ecc)
+    #modest_ecc_prograde_indices = np.ma.nonzero(prograde_bh_modest_ecc)
+
+    modest_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc <= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # Indices of orb eccentricities where e>2h
-    large_ecc_prograde_indices = np.ma.nonzero(prograde_bh_large_ecc)
+    #large_ecc_prograde_indices = np.ma.nonzero(prograde_bh_large_ecc)
+
+    large_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc >= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # print('modest ecc indices', modest_ecc_prograde_indices)
     # print('large ecc indices', large_ecc_prograde_indices)
@@ -360,20 +364,24 @@ def bin_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, disk
 
     # Modest orb eccentricities: e < 2h (experience simple exponential damping): mask entries > 2*aspect_ratio;
     # only show BH with e<2h
-    prograde_bh_modest_ecc = np.ma.masked_where(
-        prograde_disk_bh_pro_orbs_ecc > 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
-        prograde_disk_bh_pro_orbs_ecc)
+    #prograde_bh_modest_ecc = np.ma.masked_where(
+    #    prograde_disk_bh_pro_orbs_ecc > 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
+    #    prograde_disk_bh_pro_orbs_ecc)
 
     # Large orb eccentricities: e > 2h (experience more complicated damping)
-    prograde_bh_large_ecc = np.ma.masked_where(
-        prograde_disk_bh_pro_orbs_ecc < 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
-        prograde_disk_bh_pro_orbs_ecc)
+    #prograde_bh_large_ecc = np.ma.masked_where(
+    #    prograde_disk_bh_pro_orbs_ecc < 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
+    #    prograde_disk_bh_pro_orbs_ecc)
 
     # Indices of orb eccentricities where e<2h
-    modest_ecc_prograde_indices = np.ma.nonzero(prograde_bh_modest_ecc)
+    #modest_ecc_prograde_indices = np.ma.nonzero(prograde_bh_modest_ecc)
+
+    modest_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc <= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # Indices of orb eccentricities where e>2h
-    large_ecc_prograde_indices = np.ma.nonzero(prograde_bh_large_ecc)
+    #large_ecc_prograde_indices = np.ma.nonzero(prograde_bh_large_ecc)
+
+    large_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc >= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # print('modest ecc indices', modest_ecc_prograde_indices)
     # print('large ecc indices', large_ecc_prograde_indices)

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -243,9 +243,7 @@ def orbital_bin_ecc_damping(smbh_mass, blackholes_binary, disk_surf_density_func
 
     blackholes_binary.bin_orb_ecc = new_bin_orb_ecc
 
-    #return (blackholes_binary)
-    #BUG 
-    return
+    return (blackholes_binary)
 
 
 def bin_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, disk_surf_density_func,

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -100,23 +100,9 @@ def orbital_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, 
 
     # Modest orb eccentricities: e < 2h (experience simple exponential damping): mask entries > 2*aspect_ratio;
     # only show BH with e<2h
-    #prograde_bh_modest_ecc = np.ma.masked_where(
-    #    prograde_disk_bh_pro_orbs_ecc > 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
-    #    prograde_disk_bh_pro_orbs_ecc)
-
-    # Large orb eccentricities: e > 2h (experience more complicated damping)
-    #prograde_bh_large_ecc = np.ma.masked_where(
-    #    prograde_disk_bh_pro_orbs_ecc < 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
-    #    prograde_disk_bh_pro_orbs_ecc)
-
-    # Indices of orb eccentricities where e<2h
-    #modest_ecc_prograde_indices = np.ma.nonzero(prograde_bh_modest_ecc)
-
     modest_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc <= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
-    # Indices of orb eccentricities where e>2h
-    #large_ecc_prograde_indices = np.ma.nonzero(prograde_bh_large_ecc)
-
+    # Large orb eccentricities: e > 2h (experience more complicated damping)
     large_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc >= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # print('modest ecc indices', modest_ecc_prograde_indices)
@@ -153,7 +139,7 @@ def orbital_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, 
 def orbital_bin_ecc_damping(smbh_mass, blackholes_binary, disk_surf_density_func, disk_aspect_ratio_func, timestep_duration_yr,
                             disk_bh_pro_orb_ecc_crit):
     """Calculates damping of BBH orbital eccentricities according to a prescription.
-    
+
     Use same mechanisms as for prograde singleton BH.
 
     E.g. Tanaka & Ward (2004)  t_damp = M^3/2 h^4 / (2^1/2 m Sigma a^1/2 G )
@@ -364,23 +350,9 @@ def bin_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, disk
 
     # Modest orb eccentricities: e < 2h (experience simple exponential damping): mask entries > 2*aspect_ratio;
     # only show BH with e<2h
-    #prograde_bh_modest_ecc = np.ma.masked_where(
-    #    prograde_disk_bh_pro_orbs_ecc > 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
-    #    prograde_disk_bh_pro_orbs_ecc)
-
-    # Large orb eccentricities: e > 2h (experience more complicated damping)
-    #prograde_bh_large_ecc = np.ma.masked_where(
-    #    prograde_disk_bh_pro_orbs_ecc < 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a),
-    #    prograde_disk_bh_pro_orbs_ecc)
-
-    # Indices of orb eccentricities where e<2h
-    #modest_ecc_prograde_indices = np.ma.nonzero(prograde_bh_modest_ecc)
-
     modest_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc <= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
-    # Indices of orb eccentricities where e>2h
-    #large_ecc_prograde_indices = np.ma.nonzero(prograde_bh_large_ecc)
-
+    # Large orb eccentricities: e > 2h (experience more complicated damping)
     large_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc >= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # print('modest ecc indices', modest_ecc_prograde_indices)


### PR DESCRIPTION
If an object tried to migrate out of the disk, we set its `orb_a  = disk_outer_radius`, which caused problems later on if two BH at `disk_outer_radius` formed a binary (`orb_a_1 = orb_a_2` so `bin_sep = orb_a_1 - orb_a_2 = 0`). Now a BH migrating out of the disk has its `orb_a = disk_outer_radius - epsilon` where epsilon is the Hill sphere of the BH at `disk_outer_radius` times a random number between 0 and 1.

When evolving retros, objects that had their `orb_a <= 0` in the calculations were caught and were set to `orb_a = 0.0` This has been changed so that they are set to `disk_inner_stable_circ_orb` instead.