### PR TITLE
Fixed bug in eccentricity functions, red scare is real. More catches for orb_a > disk_radius_outer.

### DIFF
--- a/misc/retro_ecc.py
+++ b/misc/retro_ecc.py
@@ -1,7 +1,7 @@
 """ The module provides methods for calculating the eccentricity and semi major latus of retrograde orbiters."""
 import numpy as np
 import scipy
-import mcfacts.constants as mc_const
+import astropy.units as u
 
 
 def retro_semi_lat(smbh_mass, disk_bh_retro_orbs_a, disk_bh_retro_masses, disk_bh_retro_orbs_ecc,
@@ -45,9 +45,9 @@ def retro_semi_lat(smbh_mass, disk_bh_retro_orbs_a, disk_bh_retro_masses, disk_b
 
     # throw most things into SI units (that's right, ENGINEER UNITS!)
     #    or more locally convenient variable names
-    smbh_mass = smbh_mass * mc_const.KgPerMsun  # kg
+    smbh_mass = smbh_mass * u.Msun.to("kg")  # kg
     semi_maj_axis = disk_bh_retro_orbs_a * scipy.constants.G * smbh_mass / (scipy.constants.c) ** 2  # m
-    retro_mass = disk_bh_retro_masses * mc_const.KgPerMsun  # kg
+    retro_mass = disk_bh_retro_masses * u.Msun.to("kg")  # kg
     omega = disk_bh_retro_arg_periapse  # radians
     ecc = disk_bh_retro_orbs_ecc  # unitless
     inc = disk_bh_retro_orbs_inc  # radians

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -928,7 +928,7 @@ def main():
                 if bh_binary_id_num_ionization.size > 0:
                     # Append 2 new BH to arrays of single BH locations, masses, spins, spin angles & gens
                     # For now add 2 new orb ecc term of 0.01. inclination is 0.0 as well. TO DO: calculate v_kick and resulting perturbation to orb ecc.
-                    new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init)
+                    #new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init)
                     blackholes_pro.add_blackholes(
                         new_mass=np.concatenate([
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "mass_1"),
@@ -1038,9 +1038,9 @@ def main():
 
                         # TODO: calculate v_kick and resulting perturbation to orb ecc. For now set v_kick to 200 km/s
                         v_kick = 200.
-                        bh_orb_ecc_merged = merge.merged_orb_ecc(blackholes_binary.at_id_num(bh_binary_id_num_merger, "bin_orb_a"),
-                                                                 np.full(bh_binary_id_num_merger.size, v_kick),
-                                                                 opts.smbh_mass)
+                        #bh_orb_ecc_merged = merge.merged_orb_ecc(blackholes_binary.at_id_num(bh_binary_id_num_merger, "bin_orb_a"),
+                                                                 #np.full(bh_binary_id_num_merger.size, v_kick),
+                                                                 #opts.smbh_mass)
 
                         # Append new merged BH to arrays of single BH locations, masses, spins, spin angles & gens
                         blackholes_merged.add_blackholes(new_id_num=bh_binary_id_num_merger,

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -528,7 +528,6 @@ def main():
                 blackholes_pro.remove_id_num(bh_pro_id_num_unphysical_a)
                 filing_cabinet.remove_id_num(bh_pro_id_num_unphysical_a)
 
-
             # Accrete
             blackholes_pro.mass = accretion.change_bh_mass(
                 blackholes_pro.mass,

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -669,6 +669,7 @@ def main():
 
             # Perturb eccentricity via dynamical encounters
             if opts.flag_dynamic_enc > 0:
+
                 blackholes_pro.orb_a, blackholes_pro.orb_ecc = dynamics.circular_singles_encounters_prograde(
                     opts.smbh_mass,
                     blackholes_pro.orb_a,
@@ -727,6 +728,7 @@ def main():
                     # Harden/soften binaries via dynamical encounters
                     # Harden binaries due to encounters with circular singletons (e.g. Leigh et al. 2018)
                     # FIX THIS: RETURN perturbed circ singles (orb_a, orb_ecc)
+
                     blackholes_binary = dynamics.circular_binaries_encounters_circ_prograde(
                         opts.smbh_mass,
                         blackholes_pro.orb_a,
@@ -928,8 +930,7 @@ def main():
                 if bh_binary_id_num_ionization.size > 0:
                     # Append 2 new BH to arrays of single BH locations, masses, spins, spin angles & gens
                     # For now add 2 new orb ecc term of 0.01. inclination is 0.0 as well. TO DO: calculate v_kick and resulting perturbation to orb ecc.
-                    #new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init)
-                    new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, 0.7)
+                    new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init)
                     blackholes_pro.add_blackholes(
                         new_mass=np.concatenate([
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "mass_1"),
@@ -1119,7 +1120,8 @@ def main():
                     filing_cabinet.id_max,
                     opts.fraction_bin_retro,
                     opts.smbh_mass,
-                    agn_redshift
+                    agn_redshift,
+                    opts.disk_bh_pro_orb_ecc_crit
                 )
 
                 # Add new binaries to filing cabinet and delete prograde singleton black holes
@@ -1165,7 +1167,6 @@ def main():
                                               new_galaxy=np.full(len(bh_mass_captured),galaxy),
                                               new_time_passed=np.full(len(bh_mass_captured),time_passed),
                                               new_id_num=np.arange(filing_cabinet.id_max+1, len(bh_mass_captured) + filing_cabinet.id_max+1, 1))
-
                 # Update filing cabinet
                 filing_cabinet.add_objects(new_id_num=np.arange(filing_cabinet.id_max+1, len(bh_mass_captured) + filing_cabinet.id_max+1,1),
                                            new_category=np.array([0.0]),

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -928,7 +928,7 @@ def main():
                 if bh_binary_id_num_ionization.size > 0:
                     # Append 2 new BH to arrays of single BH locations, masses, spins, spin angles & gens
                     # For now add 2 new orb ecc term of 0.01. inclination is 0.0 as well. TO DO: calculate v_kick and resulting perturbation to orb ecc.
-
+                    new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init)
                     blackholes_pro.add_blackholes(
                         new_mass=np.concatenate([
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "mass_1"),
@@ -945,7 +945,8 @@ def main():
                         new_gen=np.concatenate([
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "gen_1"),
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "gen_2")]),
-                        new_orb_ecc=eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init),
+                        new_orb_ecc=np.full(bh_binary_id_num_ionization.size * 2, 0.01),
+                        #new_orb_ecc=new_orb_ecc,
                         new_orb_inc=np.full(bh_binary_id_num_ionization.size * 2, 0.0),
                         new_orb_ang_mom=np.ones(bh_binary_id_num_ionization.size * 2),
                         new_orb_arg_periapse=np.full(bh_binary_id_num_ionization.size * 2, -1.5),
@@ -1067,7 +1068,8 @@ def main():
                                                       new_spin_angle=np.zeros(bh_binary_id_num_merger.size),
                                                       new_orb_inc=np.zeros(bh_binary_id_num_merger.size),
                                                       new_orb_ang_mom=np.ones(bh_binary_id_num_merger.size),
-                                                      new_orb_ecc=bh_orb_ecc_merged,
+                                                      new_orb_ecc=np.full(bh_binary_id_num_merger.size, 0.01),
+                                                      #new_orb_ecc=bh_orb_ecc_merged,
                                                       new_gen=np.maximum(blackholes_merged.at_id_num(bh_binary_id_num_merger, "gen_1"),
                                                                          blackholes_merged.at_id_num(bh_binary_id_num_merger, "gen_2")) + 1.0,
                                                       new_orb_arg_periapse=np.full(bh_binary_id_num_merger.size, -1.5),

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -929,6 +929,7 @@ def main():
                     # Append 2 new BH to arrays of single BH locations, masses, spins, spin angles & gens
                     # For now add 2 new orb ecc term of 0.01. inclination is 0.0 as well. TO DO: calculate v_kick and resulting perturbation to orb ecc.
                     #new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init)
+                    new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, 0.1)
                     blackholes_pro.add_blackholes(
                         new_mass=np.concatenate([
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "mass_1"),
@@ -945,8 +946,8 @@ def main():
                         new_gen=np.concatenate([
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "gen_1"),
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "gen_2")]),
-                        new_orb_ecc=np.full(bh_binary_id_num_ionization.size * 2, 0.01),
-                        #new_orb_ecc=new_orb_ecc,
+                        #new_orb_ecc=np.full(bh_binary_id_num_ionization.size * 2, 0.01),
+                        new_orb_ecc=new_orb_ecc,
                         new_orb_inc=np.full(bh_binary_id_num_ionization.size * 2, 0.0),
                         new_orb_ang_mom=np.ones(bh_binary_id_num_ionization.size * 2),
                         new_orb_arg_periapse=np.full(bh_binary_id_num_ionization.size * 2, -1.5),
@@ -1038,9 +1039,9 @@ def main():
 
                         # TODO: calculate v_kick and resulting perturbation to orb ecc. For now set v_kick to 200 km/s
                         v_kick = 200.
-                        #bh_orb_ecc_merged = merge.merged_orb_ecc(blackholes_binary.at_id_num(bh_binary_id_num_merger, "bin_orb_a"),
-                                                                 #np.full(bh_binary_id_num_merger.size, v_kick),
-                                                                 #opts.smbh_mass)
+                        bh_orb_ecc_merged = merge.merged_orb_ecc(blackholes_binary.at_id_num(bh_binary_id_num_merger, "bin_orb_a"),
+                                                                 np.full(bh_binary_id_num_merger.size, v_kick),
+                                                                 opts.smbh_mass)
 
                         # Append new merged BH to arrays of single BH locations, masses, spins, spin angles & gens
                         blackholes_merged.add_blackholes(new_id_num=bh_binary_id_num_merger,
@@ -1068,8 +1069,8 @@ def main():
                                                       new_spin_angle=np.zeros(bh_binary_id_num_merger.size),
                                                       new_orb_inc=np.zeros(bh_binary_id_num_merger.size),
                                                       new_orb_ang_mom=np.ones(bh_binary_id_num_merger.size),
-                                                      new_orb_ecc=np.full(bh_binary_id_num_merger.size, 0.01),
-                                                      #new_orb_ecc=bh_orb_ecc_merged,
+                                                      #new_orb_ecc=np.full(bh_binary_id_num_merger.size, 0.01),
+                                                      new_orb_ecc=bh_orb_ecc_merged,
                                                       new_gen=np.maximum(blackholes_merged.at_id_num(bh_binary_id_num_merger, "gen_1"),
                                                                          blackholes_merged.at_id_num(bh_binary_id_num_merger, "gen_2")) + 1.0,
                                                       new_orb_arg_periapse=np.full(bh_binary_id_num_merger.size, -1.5),

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -945,7 +945,7 @@ def main():
                         new_gen=np.concatenate([
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "gen_1"),
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "gen_2")]),
-                        new_orb_ecc=setupdiskblackholes.setup_disk_blackholes_eccentricity_thermal(bh_binary_id_num_ionization.size * 2), #np.full(bh_binary_id_num_ionization.size * 2, 0.01), # BUG
+                        new_orb_ecc=eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init),
                         new_orb_inc=np.full(bh_binary_id_num_ionization.size * 2, 0.0),
                         new_orb_ang_mom=np.ones(bh_binary_id_num_ionization.size * 2),
                         new_orb_arg_periapse=np.full(bh_binary_id_num_ionization.size * 2, -1.5),
@@ -1035,6 +1035,13 @@ def main():
                                 blackholes_binary.at_id_num(bh_binary_id_num_merger, "bin_orb_inc")
                                 )
 
+                        # TODO: calculate v_kick and resulting perturbation to orb ecc. For now set v_kick to 200 km/s
+                        v_kick = 200.
+                        bh_orb_ecc_merged = merge.merged_orb_ecc(blackholes_binary.at_id_num(bh_binary_id_num_merger, "bin_orb_a"),
+                                                                 np.full(bh_binary_id_num_merger.size, v_kick),
+                                                                 opts.smbh_mass)
+
+                        # Append new merged BH to arrays of single BH locations, masses, spins, spin angles & gens
                         blackholes_merged.add_blackholes(new_id_num=bh_binary_id_num_merger,
                                                          new_galaxy=np.full(bh_binary_id_num_merger.size, galaxy),
                                                          new_bin_orb_a=blackholes_binary.at_id_num(bh_binary_id_num_merger, "bin_orb_a"),
@@ -1060,25 +1067,23 @@ def main():
                                                       new_spin_angle=np.zeros(bh_binary_id_num_merger.size),
                                                       new_orb_inc=np.zeros(bh_binary_id_num_merger.size),
                                                       new_orb_ang_mom=np.ones(bh_binary_id_num_merger.size),
-                                                      new_orb_ecc=setupdiskblackholes.setup_disk_blackholes_eccentricity_thermal(bh_binary_id_num_merger.size),#np.full(bh_binary_id_num_merger.size, 0.01),
+                                                      new_orb_ecc=bh_orb_ecc_merged,
                                                       new_gen=np.maximum(blackholes_merged.at_id_num(bh_binary_id_num_merger, "gen_1"),
                                                                          blackholes_merged.at_id_num(bh_binary_id_num_merger, "gen_2")) + 1.0,
                                                       new_orb_arg_periapse=np.full(bh_binary_id_num_merger.size, -1.5),
                                                       new_galaxy=np.full(bh_binary_id_num_merger.size, galaxy),
                                                       new_time_passed=np.full(bh_binary_id_num_merger.size, time_passed),
                                                       new_id_num=bh_binary_id_num_merger)
-                        
+
                         # Update filing cabinet
                         filing_cabinet.update(id_num=bh_binary_id_num_merger,
-                                            attr="category",
-                                            new_info=np.full(bh_binary_id_num_merger.size, 0))
+                                              attr="category",
+                                              new_info=np.full(bh_binary_id_num_merger.size, 0))
                         filing_cabinet.update(id_num=bh_binary_id_num_merger,
-                                            attr="size",
-                                            new_info=np.full(bh_binary_id_num_merger.size, -1))
+                                              attr="size",
+                                              new_info=np.full(bh_binary_id_num_merger.size, -1))
                         blackholes_binary.remove_id_num(bh_binary_id_num_merger)
 
-                    # Append new merged BH to arrays of single BH locations, masses, spins, spin angles & gens
-                    # For now add 1 new orb ecc term of 0.01. TO DO: calculate v_kick and resulting perturbation to orb ecc.
                     if opts.verbose:
                         print("New BH locations", blackholes_pro.orb_a)
                 else:

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -929,7 +929,7 @@ def main():
                     # Append 2 new BH to arrays of single BH locations, masses, spins, spin angles & gens
                     # For now add 2 new orb ecc term of 0.01. inclination is 0.0 as well. TO DO: calculate v_kick and resulting perturbation to orb ecc.
                     #new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, opts.disk_bh_orb_ecc_max_init)
-                    new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, 0.1)
+                    new_orb_ecc = eccentricity.ionized_orb_ecc(bh_binary_id_num_ionization.size * 2, 0.7)
                     blackholes_pro.add_blackholes(
                         new_mass=np.concatenate([
                             blackholes_binary.at_id_num(bh_binary_id_num_ionization, "mass_1"),

--- a/src/mcfacts/constants.py
+++ b/src/mcfacts/constants.py
@@ -10,10 +10,3 @@ Global Variables:
 from astropy import constants as const
 
 # mass_per_msun = 1.99e30
-
-
-def rg_in_meters(smbh_mass):
-    smbh_mass_units = smbh_mass * const.M_sun
-    rg = (const.G * (smbh_mass_units) / (const.c ** 2.0)).to("meter")
-
-    return (rg.value)

--- a/src/mcfacts/constants.py
+++ b/src/mcfacts/constants.py
@@ -7,4 +7,13 @@ Global Variables:
 
 """
 
-mass_per_msun = 1.99e30
+from astropy import constants as const
+
+# mass_per_msun = 1.99e30
+
+
+def rg_in_meters(smbh_mass):
+    smbh_mass_units = smbh_mass * const.M_sun
+    rg = (const.G * (smbh_mass_units) / (const.c ** 2.0)).to("meter")
+
+    return (rg.value)

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -731,8 +731,8 @@ class AGNBlackHole(AGNObject):
             self.orb_ang_mom = setupdiskblackholes.setup_disk_blackholes_orb_ang_mom(bh_num)
 
             if ((gw_freq is empty_arr) and (gw_strain is empty_arr)):
-                self.gw_freq = np.full(bh_num, -1) #BUG np.full(bh_num, -1.5)
-                self.gw_strain =np.full(bh_num, -1) # BUG np.full(bh_num, -1.5)
+                self.gw_freq = np.full(bh_num, -1.5)
+                self.gw_strain =np.full(bh_num, -1.5)
 
             elif ((gw_freq is not empty_arr) and (gw_strain is not empty_arr)):
                 self.gw_freq = gw_freq
@@ -777,12 +777,12 @@ class AGNBlackHole(AGNObject):
         assert new_mass.shape == (bh_num,),"bh_num must match the number of objects"
 
         if new_gw_freq is empty_arr:
-            self.gw_freq = np.concatenate([self.gw_freq, np.full(bh_num, -1)]) # BUG np.concatenate([self.gw_freq, np.full(bh_num, -1.5)])
+            self.gw_freq = np.concatenate([self.gw_freq, np.full(bh_num, -1.5)])
         else:
             self.gw_freq = np.concatenate([self.gw_freq, new_gw_freq])
         
         if new_gw_strain is empty_arr:
-            self.gw_strain = np.concatenate([self.gw_strain, np.full(bh_num, -1)])#BUG np.concatenate([self.gw_strain, np.full(bh_num, -1.5)])
+            self.gw_strain = np.concatenate([self.gw_strain, np.full(bh_num, -1.5)])
         else:
             self.gw_strain = np.concatenate([self.gw_strain, new_gw_strain])
 

--- a/src/mcfacts/physics/accretion.py
+++ b/src/mcfacts/physics/accretion.py
@@ -117,7 +117,7 @@ def change_star_spin_magnitudes(disk_star_pro_spins,
     timestep_duration_yr_normalized = timestep_duration_yr/1.e4
     disk_star_torque_condition_normalized = disk_star_torque_condition/0.1
 
-    spin_iteration = (1.e-3*disk_bh_eddington_ratio_normalized*disk_star_torque_condition_normalized*timestep_duration_yr_normalized)
+    spin_iteration = ((1.e-3)*disk_bh_eddington_ratio_normalized*disk_star_torque_condition_normalized*timestep_duration_yr_normalized)
 
     disk_star_pro_spins_new = disk_star_pro_spins
 

--- a/src/mcfacts/physics/binary/evolve.py
+++ b/src/mcfacts/physics/binary/evolve.py
@@ -158,8 +158,8 @@ def change_bin_spin_angles(blackholes_binary, disk_bh_eddington_ratio,
     spin_angle_1_after = spin_angle_1_before - spin_angle_change_factor
     spin_angle_2_after = spin_angle_2_before - spin_angle_change_factor
 
-    spin_angle_1_after[spin_angle_1_after < spin_minimum_resolution] = np.zeros(np.sum(spin_angle_1_after < spin_minimum_resolution))
-    spin_angle_2_after[spin_angle_2_after < spin_minimum_resolution] = np.zeros(np.sum(spin_angle_2_after < spin_minimum_resolution))
+    spin_angle_1_after[spin_angle_1_after < spin_minimum_resolution] = 0.0
+    spin_angle_2_after[spin_angle_2_after < spin_minimum_resolution] = 0.0
 
     blackholes_binary.spin_angle_1[idx_non_mergers] = spin_angle_1_after
     blackholes_binary.spin_angle_2[idx_non_mergers] = spin_angle_2_after
@@ -226,12 +226,12 @@ def bin_com_feedback_hankla(blackholes_binary, disk_surface_density, disk_opacit
     else:
         raise AttributeError("disk_surface_density is a float")
 
-    # Define kappa (or set up a function to call). 
+    # Define kappa (or set up a function to call).
     disk_opacity = disk_opacity_func(blackholes_binary.bin_orb_a)
 
     ratio_heat_mig_torques_bin_com = 0.07 * (1 / disk_opacity) * (disk_alpha_viscosity ** -1.5) * disk_bh_eddington_ratio * np.sqrt(blackholes_binary.bin_orb_a) / disk_surface_density_at_location
 
-    ratio_heat_mig_torques_bin_com[blackholes_binary.bin_orb_a > disk_radius_outer] = np.ones(np.sum(blackholes_binary.bin_orb_a > disk_radius_outer))
+    ratio_heat_mig_torques_bin_com[blackholes_binary.bin_orb_a > disk_radius_outer] = 1.0
 
     return (ratio_heat_mig_torques_bin_com)
 

--- a/src/mcfacts/physics/binary/evolve.py
+++ b/src/mcfacts/physics/binary/evolve.py
@@ -99,8 +99,8 @@ def change_bin_spin_magnitudes(blackholes_binary, disk_bh_eddington_ratio,
     spin_1_after = spin_1_before + spin_change_factor
     spin_2_after = spin_2_before + spin_change_factor
 
-    spin_1_after[spin_1_after > max_allowed_spin] = np.full(np.sum(spin_1_after > max_allowed_spin), max_allowed_spin)
-    spin_2_after[spin_2_after > max_allowed_spin] = np.full(np.sum(spin_2_after > max_allowed_spin), max_allowed_spin)
+    spin_1_after[spin_1_after > max_allowed_spin] = max_allowed_spin
+    spin_2_after[spin_2_after > max_allowed_spin] = max_allowed_spin
 
     blackholes_binary.spin_1[idx_non_mergers] = spin_1_after
     blackholes_binary.spin_2[idx_non_mergers] = spin_2_after
@@ -320,7 +320,7 @@ def bin_contact_check(blackholes_binary, smbh_mass):
 
     # If binary separation <= contact condition, set binary separation to contact condition
     blackholes_binary.bin_sep[mask_condition] = contact_condition[mask_condition]
-    blackholes_binary.flag_merging[mask_condition] = np.full(np.sum(mask_condition), -2)
+    blackholes_binary.flag_merging[mask_condition] = -2
 
     return (blackholes_binary)
 
@@ -391,7 +391,6 @@ def bin_harden_baruteau(blackholes_binary, smbh_mass, timestep_duration_yr,
     # 2. Find number of binary orbits around its center of mass within the timestep
     # 3. For every 10^3 orbits, halve the binary separation.
 
-
     # Only interested in BH that have not merged
     idx_non_mergers = np.where(blackholes_binary.flag_merging >= 0)[0]
 
@@ -438,8 +437,8 @@ def bin_harden_baruteau(blackholes_binary, smbh_mass, timestep_duration_yr,
 
     # Otherwise binary will merge in this timestep
     # Update flag_merging to -2 and time_merged to current time
-    blackholes_binary.flag_merging[idx_non_mergers[time_to_merger_gw <= timestep_duration_yr]] = np.full(np.sum(time_to_merger_gw <= timestep_duration_yr), -2)
-    blackholes_binary.time_merged[idx_non_mergers[time_to_merger_gw <= timestep_duration_yr]] = np.full(np.sum(time_to_merger_gw <= timestep_duration_yr), time_passed)
+    blackholes_binary.flag_merging[idx_non_mergers[time_to_merger_gw <= timestep_duration_yr]] = -2
+    blackholes_binary.time_merged[idx_non_mergers[time_to_merger_gw <= timestep_duration_yr]] = time_passed
     # Finite check
     assert np.isfinite(blackholes_binary.flag_merging).all(),\
         "Finite check failure: blackholes_binary.flag_merging"

--- a/src/mcfacts/physics/binary/evolve.py
+++ b/src/mcfacts/physics/binary/evolve.py
@@ -347,9 +347,10 @@ def bin_reality_check(blackholes_binary):
     mass_2_id_num = blackholes_binary.id_num[blackholes_binary.mass_2 == 0]
     orb_a_1_id_num = blackholes_binary.id_num[blackholes_binary.orb_a_1 == 0]
     orb_a_2_id_num = blackholes_binary.id_num[blackholes_binary.orb_a_2 == 0]
+    bin_ecc_id_num = blackholes_binary.id_num[blackholes_binary.bin_ecc > 1]
 
     id_nums = np.concatenate([mass_1_id_num, mass_2_id_num,
-                             orb_a_1_id_num, orb_a_2_id_num])
+                             orb_a_1_id_num, orb_a_2_id_num, bin_ecc_id_num])
 
     if id_nums.size > 0:
         return (id_nums)

--- a/src/mcfacts/physics/binary/evolve.py
+++ b/src/mcfacts/physics/binary/evolve.py
@@ -347,7 +347,7 @@ def bin_reality_check(blackholes_binary):
     mass_2_id_num = blackholes_binary.id_num[blackholes_binary.mass_2 == 0]
     orb_a_1_id_num = blackholes_binary.id_num[blackholes_binary.orb_a_1 == 0]
     orb_a_2_id_num = blackholes_binary.id_num[blackholes_binary.orb_a_2 == 0]
-    bin_ecc_id_num = blackholes_binary.id_num[blackholes_binary.bin_ecc > 1]
+    bin_ecc_id_num = blackholes_binary.id_num[blackholes_binary.bin_ecc >= 1]
 
     id_nums = np.concatenate([mass_1_id_num, mass_2_id_num,
                              orb_a_1_id_num, orb_a_2_id_num, bin_ecc_id_num])

--- a/src/mcfacts/physics/binary/formation.py
+++ b/src/mcfacts/physics/binary/formation.py
@@ -144,7 +144,7 @@ def binary_check(
     return disk_bin_bhbh_pro_indices
 
 
-def add_to_binary_obj(blackholes_binary, blackholes_pro, bh_pro_id_num_binary, id_start_val, fraction_bin_retro, smbh_mass, agn_redshift):
+def add_to_binary_obj(blackholes_binary, blackholes_pro, bh_pro_id_num_binary, id_start_val, fraction_bin_retro, smbh_mass, agn_redshift, disk_bh_pro_orb_ecc_crit):
     """Create new BH binaries with appropriate parameters.
 
     We take the semi-maj axis, masses, spins, spin angles and generations
@@ -209,8 +209,8 @@ def add_to_binary_obj(blackholes_binary, blackholes_pro, bh_pro_id_num_binary, i
     # to be pi radians if retrograde.
     bin_orb_inc = np.zeros(bin_num)
     # Set up binary orbital eccentricity of com around SMBH.
-    # Assume initially v.small (e~0.01)
-    bin_orb_ecc = np.full(bin_num, 0.01)
+    # Assume initially v.small (e~0.01 = disk_bh_pro_orb_ecc_crit)
+    bin_orb_ecc = np.full(bin_num, disk_bh_pro_orb_ecc_crit)
     galaxy = np.zeros(bin_num)
 
     for i in range(bin_num):

--- a/src/mcfacts/physics/binary/merge.py
+++ b/src/mcfacts/physics/binary/merge.py
@@ -4,6 +4,7 @@ Module for calculating the final variables of a merging binary.
 import numpy as np
 from astropy import units as u
 from astropy import constants as const
+from mcfacts.mcfacts_random_state import rng
 
 from mcfacts.physics.point_masses import time_of_orbital_shrinkage, si_from_r_g
 
@@ -282,6 +283,8 @@ def merged_orb_ecc(bin_orbs_a, v_kicks, smbh_mass):
     v_kep = ((np.sqrt(const.G * smbh_mass_units / orbs_a_units)).to("km/s")).value
 
     merged_ecc = v_kicks/v_kep
+
+    merged_ecc = rng.uniform(low=0.0, high=v_kicks/v_kep, size=v_kicks.size)
 
     #print("merged_ecc",merged_ecc)
 

--- a/src/mcfacts/physics/binary/merge.py
+++ b/src/mcfacts/physics/binary/merge.py
@@ -3,6 +3,7 @@ Module for calculating the final variables of a merging binary.
 """
 import numpy as np
 from astropy import units as u
+from astropy import constants as const
 
 from mcfacts.physics.point_masses import time_of_orbital_shrinkage, si_from_r_g
 
@@ -256,3 +257,33 @@ def merged_spin(masses_1, masses_2, spins_1, spins_2):
     merged_spins = 0.686 * ((5.04 * nu) - (4.16 * nu_squared)) + (0.4 * ((spins_1 / spin_factors_1) + (spins_2 / spin_factors_2)))
 
     return (merged_spins)
+
+
+def merged_orb_ecc(bin_orbs_a, v_kicks, smbh_mass):
+    """Calculates orbital eccentricity of a merged binary.
+
+    Parameters
+    ----------
+    bin_orbs_a : numpy.ndarray
+        Location of binary [r_{g,SMBH}] wrt to the SMBH with :obj:`float` type
+    v_kicks : numpy.ndarray
+        Kick velocity [km/s] with :obj:`float` type
+    smbh_mass : float
+        Mass [Msun] of the SMBH
+
+    Returns
+    -------
+    merged_ecc : numpy.ndarray
+        Orbital eccentricity of merged binary with :obj:`float` type
+    """
+    smbh_mass_units = smbh_mass * u.solMass
+    rg_in_meters = (const.G * (smbh_mass_units) / (const.c ** 2.0)).to("meter")
+    orbs_a_units = bin_orbs_a * rg_in_meters
+
+    v_kep = ((np.sqrt(const.G * smbh_mass_units / orbs_a_units)).to("km/s")).value
+
+    merged_ecc = v_kicks/v_kep
+
+    #print("merged_ecc",merged_ecc)
+
+    return (merged_ecc)

--- a/src/mcfacts/physics/binary/merge.py
+++ b/src/mcfacts/physics/binary/merge.py
@@ -282,10 +282,6 @@ def merged_orb_ecc(bin_orbs_a, v_kicks, smbh_mass):
 
     v_kep = ((np.sqrt(const.G * smbh_mass_units / orbs_a_units)).to("km/s")).value
 
-    #merged_ecc = v_kicks/v_kep
-
-    merged_ecc = rng.uniform(low=0.0, high=v_kicks/v_kep, size=v_kicks.size)
-
-    #print("merged_ecc",merged_ecc)
+    merged_ecc = v_kicks/v_kep
 
     return (merged_ecc)

--- a/src/mcfacts/physics/binary/merge.py
+++ b/src/mcfacts/physics/binary/merge.py
@@ -277,8 +277,7 @@ def merged_orb_ecc(bin_orbs_a, v_kicks, smbh_mass):
         Orbital eccentricity of merged binary with :obj:`float` type
     """
     smbh_mass_units = smbh_mass * u.solMass
-    rg_in_meters = (const.G * (smbh_mass_units) / (const.c ** 2.0)).to("meter")
-    orbs_a_units = bin_orbs_a * rg_in_meters
+    orbs_a_units = si_from_r_g(smbh_mass * u.solMass, bin_orbs_a).to("meter")
 
     v_kep = ((np.sqrt(const.G * smbh_mass_units / orbs_a_units)).to("km/s")).value
 

--- a/src/mcfacts/physics/binary/merge.py
+++ b/src/mcfacts/physics/binary/merge.py
@@ -284,7 +284,7 @@ def merged_orb_ecc(bin_orbs_a, v_kicks, smbh_mass):
 
     merged_ecc = v_kicks/v_kep
 
-    merged_ecc = rng.uniform(low=0.0, high=v_kicks/v_kep, size=v_kicks.size)
+    #merged_ecc = rng.uniform(low=0.0, high=v_kicks/v_kep, size=v_kicks.size)
 
     #print("merged_ecc",merged_ecc)
 

--- a/src/mcfacts/physics/binary/merge.py
+++ b/src/mcfacts/physics/binary/merge.py
@@ -282,9 +282,9 @@ def merged_orb_ecc(bin_orbs_a, v_kicks, smbh_mass):
 
     v_kep = ((np.sqrt(const.G * smbh_mass_units / orbs_a_units)).to("km/s")).value
 
-    merged_ecc = v_kicks/v_kep
+    #merged_ecc = v_kicks/v_kep
 
-    #merged_ecc = rng.uniform(low=0.0, high=v_kicks/v_kep, size=v_kicks.size)
+    merged_ecc = rng.uniform(low=0.0, high=v_kicks/v_kep, size=v_kicks.size)
 
     #print("merged_ecc",merged_ecc)
 

--- a/src/mcfacts/physics/disk_capture.py
+++ b/src/mcfacts/physics/disk_capture.py
@@ -378,8 +378,8 @@ def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs
 
     # Anything outside the disk is brought back in
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    #epsilon_orb_a = disk_radius_outer * ((disk_bh_retro_masses / (3 * (disk_bh_retro_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(disk_bh_retro_masses))
-    disk_bh_retro_orbs_a_new[disk_bh_retro_orbs_a_new > disk_radius_outer] = disk_radius_outer #- epsilon_orb_a[disk_bh_retro_orbs_a_new > disk_radius_outer]
+    epsilon_orb_a = disk_radius_outer * ((disk_bh_retro_masses / (3 * (disk_bh_retro_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(disk_bh_retro_masses))
+    disk_bh_retro_orbs_a_new[disk_bh_retro_orbs_a_new > disk_radius_outer] = disk_radius_outer - epsilon_orb_a[disk_bh_retro_orbs_a_new > disk_radius_outer]
 
     return disk_bh_retro_orbs_ecc_new, disk_bh_retro_orbs_a_new, disk_bh_retro_orbs_inc_new
 

--- a/src/mcfacts/physics/disk_capture.py
+++ b/src/mcfacts/physics/disk_capture.py
@@ -3,6 +3,7 @@ Module for computing disk-orbiter interactions, which may lead to capture.
 """
 import numpy as np
 import scipy
+from mcfacts.mcfacts_random_state import rng
 
 from mcfacts import constants as mc_const
 
@@ -102,7 +103,7 @@ def orb_inc_damping(smbh_mass, disk_bh_retro_orbs_a, disk_bh_retro_masses, disk_
 
 def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs_a, disk_bh_retro_orbs_ecc,
                              disk_bh_retro_orbs_inc, disk_bh_retro_arg_periapse,
-                             disk_inner_stable_circ_orb, disk_surf_density_func, timestep_duration_yr):
+                             disk_inner_stable_circ_orb, disk_surf_density_func, timestep_duration_yr, disk_radius_outer):
     """Evolve the orbit of initially-embedded retrograde black hole orbiters due to disk interactions.
 
     This is a CRUDE version of evolution, future upgrades may couple to SpaceHub.
@@ -373,6 +374,11 @@ def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs
     # Check Finite
     assert np.isfinite(disk_bh_retro_orbs_inc_new).all(), \
         "Finite check failed for disk_bh_retro_orbs_inc_new"
+
+    # Anything outside the disk is brought back in
+    # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
+    epsilon_orb_a = disk_radius_outer * ((disk_bh_retro_masses / (3 * (disk_bh_retro_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(disk_bh_retro_masses))
+    disk_bh_retro_orbs_a_new[disk_bh_retro_orbs_a_new > disk_radius_outer] = disk_radius_outer - epsilon_orb_a[disk_bh_retro_orbs_a_new > disk_radius_outer]
 
     return disk_bh_retro_orbs_ecc_new, disk_bh_retro_orbs_a_new, disk_bh_retro_orbs_inc_new
 

--- a/src/mcfacts/physics/disk_capture.py
+++ b/src/mcfacts/physics/disk_capture.py
@@ -378,8 +378,8 @@ def retro_bh_orb_disk_evolve(smbh_mass, disk_bh_retro_masses, disk_bh_retro_orbs
 
     # Anything outside the disk is brought back in
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    epsilon_orb_a = disk_radius_outer * ((disk_bh_retro_masses / (3 * (disk_bh_retro_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(disk_bh_retro_masses))
-    disk_bh_retro_orbs_a_new[disk_bh_retro_orbs_a_new > disk_radius_outer] = disk_radius_outer - epsilon_orb_a[disk_bh_retro_orbs_a_new > disk_radius_outer]
+    #epsilon_orb_a = disk_radius_outer * ((disk_bh_retro_masses / (3 * (disk_bh_retro_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(disk_bh_retro_masses))
+    disk_bh_retro_orbs_a_new[disk_bh_retro_orbs_a_new > disk_radius_outer] = disk_radius_outer #- epsilon_orb_a[disk_bh_retro_orbs_a_new > disk_radius_outer]
 
     return disk_bh_retro_orbs_ecc_new, disk_bh_retro_orbs_a_new, disk_bh_retro_orbs_inc_new
 

--- a/src/mcfacts/physics/disk_capture.py
+++ b/src/mcfacts/physics/disk_capture.py
@@ -6,6 +6,7 @@ import scipy
 from mcfacts.mcfacts_random_state import rng
 
 from mcfacts import constants as mc_const
+import astropy.units as u
 
 
 def orb_inc_damping(smbh_mass, disk_bh_retro_orbs_a, disk_bh_retro_masses, disk_bh_retro_orbs_ecc,
@@ -57,10 +58,10 @@ def orb_inc_damping(smbh_mass, disk_bh_retro_orbs_a, disk_bh_retro_masses, disk_
 
     # throw most things into SI units (that's right, ENGINEER UNITS!)
     #    or more locally convenient variable names
-    smbh_mass = smbh_mass * mc_const.mass_per_msun  # kg
+    smbh_mass = smbh_mass * u.Msun.to("kg")  # kg
     semi_maj_axis = disk_bh_retro_orbs_a * scipy.constants.G * smbh_mass \
                     / (scipy.constants.c ** 2)  # m
-    retro_mass = disk_bh_retro_masses * mc_const.mass_per_msun  # kg
+    retro_mass = disk_bh_retro_masses * u.Msun.to("kg")  # kg
     omega = disk_bh_retro_arg_periapse  # radians
     ecc = disk_bh_retro_orbs_ecc  # unitless
     inc = disk_bh_retro_orbs_inc  # radians
@@ -412,10 +413,10 @@ def tau_inc_dyn(smbh_mass, disk_bh_retro_orbs_a, disk_bh_retro_masses, disk_bh_r
     """
     # throw most things into SI units (that's right, ENGINEER UNITS!)
     #    or more locally convenient variable names
-    SI_smbh_mass = smbh_mass * mc_const.mass_per_msun  # kg
+    SI_smbh_mass = smbh_mass * u.Msun.to("kg")  # kg
     SI_semi_maj_axis = disk_bh_retro_orbs_a * scipy.constants.G * smbh_mass \
                        / (scipy.constants.c ** 2)  # m
-    SI_orbiter_mass = disk_bh_retro_masses * mc_const.mass_per_msun  # kg
+    SI_orbiter_mass = disk_bh_retro_masses * u.Msun.to("kg")  # kg
     omega = disk_bh_retro_arg_periapse  # radians
     ecc = disk_bh_retro_orbs_ecc  # unitless
     inc = disk_bh_retro_orbs_inc  # radians
@@ -487,10 +488,10 @@ def tau_semi_lat(smbh_mass, retrograde_bh_locations, retrograde_bh_masses, retro
     """
     # throw most things into SI units (that's right, ENGINEER UNITS!)
     #    or more locally convenient variable names
-    smbh_mass = smbh_mass * mc_const.mass_per_msun  # kg
+    smbh_mass = smbh_mass * u.Msun.to("kg")  # kg
     semi_maj_axis = retrograde_bh_locations * scipy.constants.G * smbh_mass \
                     / (scipy.constants.c ** 2)  # m
-    retro_mass = retrograde_bh_masses * mc_const.mass_per_msun  # kg
+    retro_mass = retrograde_bh_masses * u.Msun.to("kg")  # kg
     omega = retro_arg_periapse  # radians
     ecc = retrograde_bh_orb_ecc  # unitless
     inc = retrograde_bh_orb_inc  # radians

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -66,7 +66,7 @@ def circular_singles_encounters_prograde(
 
     2, calculate orbital timescales for a_circ1 and a_i and N_orbits/timestep. 
         For example, since
-        :math:`T_orb =2\pi \sqrt(a^3/GM_{smbh})`
+        :math:`T_orb =2\\pi \sqrt(a^3/GM_{smbh})`
         and
         .. math::
         a^3/GM_{smbh} = (10^3r_g)^3/GM_{smbh} = 10^9 (a/10^3r_g)^3 (GM_{smbh}/c^2)^3/GM_{smbh} \\
@@ -74,10 +74,10 @@ def circular_singles_encounters_prograde(
 
         So
         .. math::
-            T_orb   = 2\pi 10^{4.5} (a/10^3r_g)^{3/2} GM_{smbh}/c^3 \\
-                    = 2\pi 10^{4.5} (a/10^3r_g)^{3/2} (6.7e-11*2e38/(3e8)^3) \\
-                    = 2\pi 10^{4.5} (a/10^3r_g)^{3/2} (13.6e27/27e24) \\
-                    = \pi 10^{7.5}  (a/10^3r_g)^{3/2} \\
+            T_orb   = 2\\pi 10^{4.5} (a/10^3r_g)^{3/2} GM_{smbh}/c^3 \\
+                    = 2\\pi 10^{4.5} (a/10^3r_g)^{3/2} (6.7e-11*2e38/(3e8)^3) \\
+                    = 2\\pi 10^{4.5} (a/10^3r_g)^{3/2} (13.6e27/27e24) \\
+                    = \\pi 10^{7.5}  (a/10^3r_g)^{3/2} \\
                     ~ 3yr (a/10^3r_g)^3/2 (M_{smbh}/10^8M_{sun}) \\
         i.e. Orbit~3yr at 10^3r_g around a 10^8M_{sun} SMBH.
         Therefore in a timestep=1.e4yr, a BH at 10^3r_g orbits the SMBH N_orbit/timestep =3,000 times.

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -408,8 +408,8 @@ def circular_binaries_encounters_ecc_prograde(
                     if hard > 0:
                         # Binary is hard w.r.t interloper
                         # Change binary parameters; decr separation, incr ecc around bin_orb_a and orb_ecc
-                        blackholes_binary.bin_sep[i] = blackholes_binary.bin_sep[i] * (1 - delta_energy_strong)  # BUG check if should be de_strong
-                        blackholes_binary.bin_ecc[i] = blackholes_binary.bin_ecc[i] * (1 + delta_energy_strong)  # BUG should be de_strong
+                        blackholes_binary.bin_sep[i] = blackholes_binary.bin_sep[i] * (1 - delta_energy_strong)
+                        blackholes_binary.bin_ecc[i] = blackholes_binary.bin_ecc[i] * (1 + delta_energy_strong)
                         blackholes_binary.bin_orb_ecc[i] = blackholes_binary.bin_orb_ecc[i] * (1 + delta_energy_strong)
                         # Change interloper parameters; increase a_ecc, increase e_ecc
                         ecc_prograde_population_locations[j] = ecc_prograde_population_locations[j] * (1 + delta_energy_strong)
@@ -422,8 +422,8 @@ def circular_binaries_encounters_ecc_prograde(
                         # Binary is soft w.r.t. interloper
                         # Check to see if binary is ionized
                         # Change binary parameters; incr bin separation, decr ecc around com, incr orb_ecc
-                        blackholes_binary.bin_sep[i] = blackholes_binary.bin_sep[i] * (1 + delta_energy_strong)  # BUG check if should be de_strong
-                        blackholes_binary.bin_ecc[i] = blackholes_binary.bin_ecc[i] * (1 - delta_energy_strong)  # BUG check if should be de_strong
+                        blackholes_binary.bin_sep[i] = blackholes_binary.bin_sep[i] * (1 + delta_energy_strong)
+                        blackholes_binary.bin_ecc[i] = blackholes_binary.bin_ecc[i] * (1 - delta_energy_strong)
                         blackholes_binary.bin_orb_ecc[i] = blackholes_binary.bin_orb_ecc[i] * (1 + delta_energy_strong)
                         # Change interloper parameters; decrease a_ecc, decrease e_ecc
                         ecc_prograde_population_locations[j] = ecc_prograde_population_locations[j] * (1 - delta_energy_strong)
@@ -666,8 +666,8 @@ def circular_binaries_encounters_circ_prograde(
                         # Binary is soft w.r.t. interloper
                         # Check to see if binary is ionized
                         # Change binary parameters; incr bin separation, decr ecc around com, incr orb_ecc
-                        blackholes_binary.bin_sep[i] = blackholes_binary.bin_sep[i] * (1 + delta_energy_strong)  # BUG should this be de_strong?
-                        blackholes_binary.bin_ecc[i] = blackholes_binary.bin_ecc[i] * (1 - delta_energy_strong)  # BUG should this be de_strong?
+                        blackholes_binary.bin_sep[i] = blackholes_binary.bin_sep[i] * (1 + delta_energy_strong)
+                        blackholes_binary.bin_ecc[i] = blackholes_binary.bin_ecc[i] * (1 - delta_energy_strong)
                         blackholes_binary.bin_orb_ecc[i] = blackholes_binary.bin_orb_ecc[i] * (1 + delta_energy_strong)
                         # Change interloper parameters; decrease a_ecc, decrease e_ecc
                         circ_prograde_population_locations[j] = circ_prograde_population_locations[j] * (1 - delta_energy_strong)
@@ -950,8 +950,8 @@ def bin_spheroid_encounter(
 
         # If hard < 0 binary is soft wrt interloper
         # Change binary parameters: increase separation, decrease ecc around bin_orb_a, increase orb_ecc
-        bin_sep[mask_soft] = bin_sep[mask_soft] * (1 + delta_energy_strong)  # BUG this should be de_strong
-        bin_ecc[mask_soft] = bin_ecc[mask_soft] * (1 - delta_energy_strong)  # BUG this should be de_strong
+        bin_sep[mask_soft] = bin_sep[mask_soft] * (1 + delta_energy_strong)
+        bin_ecc[mask_soft] = bin_ecc[mask_soft] * (1 - delta_energy_strong)
         bin_orb_ecc[mask_soft] = bin_orb_ecc[mask_soft] * (1 + delta_energy_strong)
 
         # Catch if bin_ecc or bin_orb_ecc >= 1

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -347,14 +347,13 @@ def circular_binaries_encounters_ecc_prograde(
 
     # Set up constants
     solar_mass = astropy_units.solMass.to("kg")
-    rg_in_meters = scipy.constants.G * (solar_mass*smbh_mass) / (scipy.constants.c ** 2.0)
     # eccentricity correction--do not let ecc>=1, catch and reset to 1-epsilon
     epsilon = 1e-8
 
     # Set up other values we need
     bin_masses = blackholes_binary.mass_1 + blackholes_binary.mass_2
     bin_velocities = scipy.constants.c / np.sqrt(blackholes_binary.bin_orb_a)
-    bin_binding_energy = scipy.constants.G * (solar_mass ** 2) * blackholes_binary.mass_1 * blackholes_binary.mass_2 / (blackholes_binary.bin_sep * rg_in_meters)
+    bin_binding_energy = scipy.constants.G * (solar_mass ** 2) * blackholes_binary.mass_1 * blackholes_binary.mass_2 / (si_from_r_g(smbh_mass, blackholes_binary.bin_sep).to("meter")).value
     bin_orbital_times = 3.15 * (smbh_mass / 1.e8) * ((blackholes_binary.bin_orb_a / 1.e3) ** 1.5)
     bin_orbits_per_timestep = timestep_duration_yr/bin_orbital_times
 
@@ -592,7 +591,6 @@ def circular_binaries_encounters_circ_prograde(
 
     # Housekeeping
     solar_mass = astropy_units.solMass.to("kg")
-    rg_in_meters = scipy.constants.G * (solar_mass * smbh_mass) / (scipy.constants.c ** 2.0)
 
     # Magnitude of energy change to drive binary to merger in ~2 interactions in a strong encounter. Say de_strong=0.9
     # de_strong here refers to the perturbation of the binary around its center of mass
@@ -607,7 +605,7 @@ def circular_binaries_encounters_circ_prograde(
     bin_velocities = scipy.constants.c/np.sqrt(blackholes_binary.bin_orb_a)
     bin_orbital_times = 3.15 * (smbh_mass / 1.e8) * ((blackholes_binary.bin_orb_a / 1.e3) ** 1.5)
     bin_orbits_per_timestep = timestep_duration_yr / bin_orbital_times
-    bin_binding_energy = scipy.constants.G * (solar_mass ** 2.0) * blackholes_binary.mass_1 * blackholes_binary.mass_2 / (blackholes_binary.bin_sep * rg_in_meters)
+    bin_binding_energy = scipy.constants.G * (solar_mass ** 2.0) * blackholes_binary.mass_1 * blackholes_binary.mass_2 /  (si_from_r_g(smbh_mass, blackholes_binary.bin_sep).to("meter")).value
 
     # Find the e< crit_ecc population. These are the interlopers w. low encounter vel that can harden the circularized population
     circ_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
@@ -852,12 +850,11 @@ def bin_spheroid_encounter(
     # eccentricity correction--do not let ecc>=1, catch and reset to 1-epsilon
     epsilon = 1e-8
     # Spheroid normalization to allow for non-ideal NSC (cored/previous AGN episodes/disky population concentration/whatever)
-    rg_in_meters = scipy.constants.G * (solar_mass * smbh_mass) / (scipy.constants.c ** 2.0)
 
     # Set up binary properties we need for later
     bin_mass = blackholes_binary.mass_1 + blackholes_binary.mass_2
     bin_velocities = scipy.constants.c / np.sqrt(blackholes_binary.bin_orb_a)
-    bin_binding_energy = scipy.constants.G * (solar_mass ** 2) * blackholes_binary.mass_1 * blackholes_binary.mass_2 / (blackholes_binary.bin_sep * rg_in_meters)
+    bin_binding_energy = scipy.constants.G * (solar_mass ** 2) * blackholes_binary.mass_1 * blackholes_binary.mass_2 / (si_from_r_g(smbh_mass, blackholes_binary.bin_sep).to("meter")).value
 
     # Calculate encounter rate for each binary based on bin_orb_a, binary size, and time_passed
     # Set up array of encounter rates filled with -1

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -158,7 +158,7 @@ def circular_singles_encounters_prograde(
     circ_prograde_population_locations = disk_bh_pro_orbs_a[circ_prograde_population_indices]
 
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    epsilon = disk_radius_outer * ((disk_bh_pro_masses / (3 * (disk_bh_pro_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(disk_bh_pro_masses))
+    #epsilon = disk_radius_outer * ((disk_bh_pro_masses / (3 * (disk_bh_pro_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(disk_bh_pro_masses))
 
     # T_orb = pi (R/r_g)^1.5 (GM_smbh/c^2) = pi (R/r_g)^1.5 (GM_smbh*2e30/c^2)
     #      = pi (R/r_g)^1.5 (6.7e-11 2e38/27e24)= pi (R/r_g)^1.5 (1.3e11)s =(R/r_g)^1/5 (1.3e4)
@@ -192,12 +192,12 @@ def circular_singles_encounters_prograde(
                             disk_bh_pro_orbs_a[circ_idx] = disk_bh_pro_orbs_a[circ_idx]*(1.0 + delta_energy_strong)
                             # Catch for if orb_a > disk_radius_outer
                             if (disk_bh_pro_orbs_a[circ_idx] > disk_radius_outer):
-                                disk_bh_pro_orbs_a[circ_idx] = disk_radius_outer - epsilon[circ_idx]
+                                disk_bh_pro_orbs_a[circ_idx] = disk_radius_outer #- epsilon[circ_idx]
                             disk_bh_pro_orbs_ecc[ecc_idx] = disk_bh_pro_orbs_ecc[ecc_idx]*(1 - delta_energy_strong)
                             disk_bh_pro_orbs_a[ecc_idx] = disk_bh_pro_orbs_a[ecc_idx]*(1 - delta_energy_strong)
                             # Catch for if orb_a > disk_radius_outer
                             if (disk_bh_pro_orbs_a[ecc_idx] > disk_radius_outer):
-                                disk_bh_pro_orbs_a[ecc_idx] = disk_radius_outer - epsilon[ecc_idx]
+                                disk_bh_pro_orbs_a[ecc_idx] = disk_radius_outer #- epsilon[ecc_idx]
                     num_poss_ints = num_poss_ints + 1
             num_poss_ints = 0
             num_encounters = 0
@@ -370,7 +370,7 @@ def circular_binaries_encounters_ecc_prograde(
     ecc_velocities = scipy.constants.c/np.sqrt(ecc_prograde_population_locations)
 
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    epsilon_orb_a = disk_radius_outer * ((ecc_prograde_population_masses / (3 * (ecc_prograde_population_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(ecc_prograde_population_masses))
+    #epsilon_orb_a = disk_radius_outer * ((ecc_prograde_population_masses / (3 * (ecc_prograde_population_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(ecc_prograde_population_masses))
 
     if blackholes_binary.num == 0:
         return (blackholes_binary)
@@ -417,7 +417,7 @@ def circular_binaries_encounters_ecc_prograde(
                         ecc_prograde_population_locations[j] = ecc_prograde_population_locations[j] * (1 + delta_energy_strong)
                         # Catch for if location > disk_radius_outer #
                         if (ecc_prograde_population_locations[j] > disk_radius_outer):
-                            ecc_prograde_population_locations[j] = disk_radius_outer - epsilon_orb_a[j]
+                            ecc_prograde_population_locations[j] = disk_radius_outer #- epsilon_orb_a[j]
                         ecc_prograde_population_eccentricities[j] = ecc_prograde_population_eccentricities[j] * (1 + delta_energy_strong)
 
                     if hard < 0:
@@ -430,8 +430,8 @@ def circular_binaries_encounters_ecc_prograde(
                         # Change interloper parameters; decrease a_ecc, decrease e_ecc
                         ecc_prograde_population_locations[j] = ecc_prograde_population_locations[j] * (1 - delta_energy_strong)
                         # Catch for if location > disk_radius_outer
-                        if (ecc_prograde_population_locations[j] > disk_radius_outer): 
-                            ecc_prograde_population_locations[j] = disk_radius_outer - epsilon_orb_a
+                        if (ecc_prograde_population_locations[j] > disk_radius_outer):
+                            ecc_prograde_population_locations[j] = disk_radius_outer #- epsilon_orb_a[j]
                         ecc_prograde_population_eccentricities[j] = ecc_prograde_population_eccentricities[j] * (1 - delta_energy_strong)
 
                     # Catch if bin_ecc or bin_orb_ecc >= 1
@@ -620,7 +620,7 @@ def circular_binaries_encounters_circ_prograde(
     circ_velocities = scipy.constants.c/np.sqrt(circ_prograde_population_locations)
 
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    epsilon_orb_a = disk_radius_outer * ((circ_prograde_population_masses / (3 * (circ_prograde_population_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(circ_prograde_population_masses))
+    #epsilon_orb_a = disk_radius_outer * ((circ_prograde_population_masses / (3 * (circ_prograde_population_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(circ_prograde_population_masses))
 
     if (blackholes_binary.num == 0):
         return (blackholes_binary)
@@ -664,7 +664,7 @@ def circular_binaries_encounters_circ_prograde(
                         # Change interloper parameters; increase a_ecc, increase e_ecc
                         circ_prograde_population_locations[j] = circ_prograde_population_locations[j] * (1 + delta_energy_strong)
                         if (circ_prograde_population_locations[j] > disk_radius_outer):
-                            circ_prograde_population_locations[j] = disk_radius_outer - epsilon_orb_a[j]
+                            circ_prograde_population_locations[j] = disk_radius_outer #- epsilon_orb_a[j]
                         circ_prograde_population_eccentricities[j] = circ_prograde_population_eccentricities[j] * (1 + delta_energy_strong)
 
                     if hard < 0:
@@ -677,7 +677,7 @@ def circular_binaries_encounters_circ_prograde(
                         # Change interloper parameters; decrease a_ecc, decrease e_ecc
                         circ_prograde_population_locations[j] = circ_prograde_population_locations[j] * (1 - delta_energy_strong)
                         if (circ_prograde_population_locations[j] > disk_radius_outer):
-                            circ_prograde_population_locations[j] = disk_radius_outer - epsilon_orb_a[j]
+                            circ_prograde_population_locations[j] = disk_radius_outer #- epsilon_orb_a[j]
                         circ_prograde_population_eccentricities[j] = circ_prograde_population_eccentricities[j] * (1 - delta_energy_strong)
 
                     # Catch where bin_orb_ecc and bin_ecc >= 1

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -158,7 +158,7 @@ def circular_singles_encounters_prograde(
     circ_prograde_population_locations = disk_bh_pro_orbs_a[circ_prograde_population_indices]
 
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    #epsilon = disk_radius_outer * ((disk_bh_pro_masses / (3 * (disk_bh_pro_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(disk_bh_pro_masses))
+    epsilon = disk_radius_outer * ((disk_bh_pro_masses[circ_prograde_population_indices] / (3 * (disk_bh_pro_masses[circ_prograde_population_indices] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=circ_prograde_population_indices.size)
 
     # T_orb = pi (R/r_g)^1.5 (GM_smbh/c^2) = pi (R/r_g)^1.5 (GM_smbh*2e30/c^2)
     #      = pi (R/r_g)^1.5 (6.7e-11 2e38/27e24)= pi (R/r_g)^1.5 (1.3e11)s =(R/r_g)^1/5 (1.3e4)
@@ -192,12 +192,9 @@ def circular_singles_encounters_prograde(
                             disk_bh_pro_orbs_a[circ_idx] = disk_bh_pro_orbs_a[circ_idx]*(1.0 + delta_energy_strong)
                             # Catch for if orb_a > disk_radius_outer
                             if (disk_bh_pro_orbs_a[circ_idx] > disk_radius_outer):
-                                disk_bh_pro_orbs_a[circ_idx] = disk_radius_outer #- epsilon[circ_idx]
+                                disk_bh_pro_orbs_a[circ_idx] = disk_radius_outer - epsilon[i]
                             disk_bh_pro_orbs_ecc[ecc_idx] = disk_bh_pro_orbs_ecc[ecc_idx]*(1 - delta_energy_strong)
                             disk_bh_pro_orbs_a[ecc_idx] = disk_bh_pro_orbs_a[ecc_idx]*(1 - delta_energy_strong)
-                            # Catch for if orb_a > disk_radius_outer
-                            if (disk_bh_pro_orbs_a[ecc_idx] > disk_radius_outer):
-                                disk_bh_pro_orbs_a[ecc_idx] = disk_radius_outer #- epsilon[ecc_idx]
                     num_poss_ints = num_poss_ints + 1
             num_poss_ints = 0
             num_encounters = 0

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -152,7 +152,7 @@ def circular_singles_encounters_prograde(
     # Find the e< crit_ecc. population. These are the (circularized) population that can form binaries.
     circ_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
     # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
-    ecc_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc >= disk_bh_pro_orb_ecc_crit).nonzero()[0]
+    ecc_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit).nonzero()[0]
 
     # Get locations for circ population
     circ_prograde_population_locations = disk_bh_pro_orbs_a[circ_prograde_population_indices]

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -152,7 +152,7 @@ def circular_singles_encounters_prograde(
     # Find the e< crit_ecc. population. These are the (circularized) population that can form binaries.
     circ_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
     # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
-    ecc_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit).nonzero()[0]
+    ecc_prograde_population_indices = np.asarray(disk_bh_pro_orbs_ecc >= disk_bh_pro_orb_ecc_crit).nonzero()[0]
 
     # Get locations for circ population
     circ_prograde_population_locations = disk_bh_pro_orbs_a[circ_prograde_population_indices]
@@ -684,7 +684,7 @@ def circular_binaries_encounters_circ_prograde(
                     if (blackholes_binary.bin_ecc[i] >= 1):
                         blackholes_binary.bin_ecc[i] = 1.0 - epsilon
                     if (blackholes_binary.bin_orb_ecc[i] >= 1):
-                        blackholes_binary.bin_orb_ecc = 1.0 - epsilon
+                        blackholes_binary.bin_orb_ecc[i] = 1.0 - epsilon
     return (blackholes_binary)
 
 

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -368,7 +368,7 @@ def circular_binaries_encounters_ecc_prograde(
     ecc_velocities = scipy.constants.c / np.sqrt(ecc_prograde_population_locations)
 
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    #epsilon_orb_a = disk_radius_outer * ((ecc_prograde_population_masses / (3 * (ecc_prograde_population_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(ecc_prograde_population_masses))
+    epsilon_orb_a = disk_radius_outer * ((ecc_prograde_population_masses / (3 * (ecc_prograde_population_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(ecc_prograde_population_masses))
 
     if blackholes_binary.num == 0:
         return (blackholes_binary)
@@ -415,7 +415,7 @@ def circular_binaries_encounters_ecc_prograde(
                         ecc_prograde_population_locations[j] = ecc_prograde_population_locations[j] * (1 + delta_energy_strong)
                         # Catch for if location > disk_radius_outer #
                         if (ecc_prograde_population_locations[j] > disk_radius_outer):
-                            ecc_prograde_population_locations[j] = disk_radius_outer #- epsilon_orb_a[j]
+                            ecc_prograde_population_locations[j] = disk_radius_outer - epsilon_orb_a[j]
                         ecc_prograde_population_eccentricities[j] = ecc_prograde_population_eccentricities[j] * (1 + delta_energy_strong)
 
                     if hard < 0:
@@ -615,7 +615,7 @@ def circular_binaries_encounters_circ_prograde(
     circ_velocities = scipy.constants.c/np.sqrt(circ_prograde_population_locations)
 
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    #epsilon_orb_a = disk_radius_outer * ((circ_prograde_population_masses / (3 * (circ_prograde_population_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(circ_prograde_population_masses))
+    epsilon_orb_a = disk_radius_outer * ((circ_prograde_population_masses / (3 * (circ_prograde_population_masses + smbh_mass)))**(1. / 3.)) * rng.uniform(size=len(circ_prograde_population_masses))
 
     if (blackholes_binary.num == 0):
         return (blackholes_binary)
@@ -659,7 +659,7 @@ def circular_binaries_encounters_circ_prograde(
                         # Change interloper parameters; increase a_ecc, increase e_ecc
                         circ_prograde_population_locations[j] = circ_prograde_population_locations[j] * (1 + delta_energy_strong)
                         if (circ_prograde_population_locations[j] > disk_radius_outer):
-                            circ_prograde_population_locations[j] = disk_radius_outer #- epsilon_orb_a[j]
+                            circ_prograde_population_locations[j] = disk_radius_outer - epsilon_orb_a[j]
                         circ_prograde_population_eccentricities[j] = circ_prograde_population_eccentricities[j] * (1 + delta_energy_strong)
 
                     if hard < 0:
@@ -672,7 +672,7 @@ def circular_binaries_encounters_circ_prograde(
                         # Change interloper parameters; decrease a_ecc, decrease e_ecc
                         circ_prograde_population_locations[j] = circ_prograde_population_locations[j] * (1 - delta_energy_strong)
                         if (circ_prograde_population_locations[j] > disk_radius_outer):
-                            circ_prograde_population_locations[j] = disk_radius_outer #- epsilon_orb_a[j]
+                            circ_prograde_population_locations[j] = disk_radius_outer - epsilon_orb_a[j]
                         circ_prograde_population_eccentricities[j] = circ_prograde_population_eccentricities[j] * (1 - delta_energy_strong)
 
                     # Catch where bin_orb_ecc and bin_ecc >= 1

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -236,7 +236,7 @@ def orbital_bin_ecc_damping(smbh_mass, blackholes_binary, disk_surf_density_func
     mask3 = (blackholes_binary.bin_orb_ecc > disk_bh_pro_orb_ecc_crit) & (blackholes_binary.bin_orb_ecc > (2 * disk_aspect_ratio))
     new_bin_orb_ecc[mask3] = blackholes_binary.bin_orb_ecc[mask3] * np.exp(-large_timescale_ratio[mask3])
 
-    new_bin_orb_ecc[new_bin_orb_ecc < disk_bh_pro_orb_ecc_crit] = np.full(np.sum(new_bin_orb_ecc < disk_bh_pro_orb_ecc_crit), disk_bh_pro_orb_ecc_crit)
+    new_bin_orb_ecc[new_bin_orb_ecc < disk_bh_pro_orb_ecc_crit] = disk_bh_pro_orb_ecc_crit
     # Check output
     assert np.isfinite(new_bin_orb_ecc).all(), \
         "Finite check failed for new_bin_orb_ecc"

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -352,7 +352,7 @@ def bin_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, disk
     modest_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc <= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # Large orb eccentricities: e > 2h (experience more complicated damping)
-    large_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc >= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
+    large_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc > 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # print('modest ecc indices', modest_ecc_prograde_indices)
     # print('large ecc indices', large_ecc_prograde_indices)

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -3,6 +3,7 @@ Module for calculating the orbital and binary eccentricity damping.
 """
 
 import numpy as np
+from mcfacts.mcfacts_random_state import rng
 
 
 def orbital_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, disk_surf_density_func,
@@ -63,7 +64,7 @@ def orbital_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, 
     For eccentricity e>2h eqn. 9 in McKernan & Ford (2023), based on Horn et al. (2012) the scaling time is now t_ecc.
     :math:`t_{ecc} = (t_{damp}/0.78)*[1 - (0.14*(e/h)^2) + (0.06*(e/h)^3)]` ......(2)
     which in the limit of e>0.1 for most disk models becomes
-    :math:`t_{ecc} \propto (t_{damp}/0.78)*[1 + (0.06*(e/h)^3)]`
+    :math:`t_{ecc} \\propto (t_{damp}/0.78)*[1 + (0.06*(e/h)^3)]`
     """
     # Check incoming eccentricities for nans
     assert np.isfinite(disk_bh_pro_orbs_ecc).all(), \
@@ -382,3 +383,20 @@ def bin_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, disk
     assert np.isfinite(new_disk_bh_pro_orbs_ecc).all(),\
         "Finite check failed for new_disk_bh_pro_orbs_ecc"
     return new_disk_bh_pro_orbs_ecc
+
+
+def ionized_orb_ecc(num_bh, orb_ecc_max):
+    """Calculate new eccentricity for each component of an ionized binary.
+
+    Parameters
+    ----------
+    num_bh : int
+        Number of BHs (num of ionized binaries * 2)
+    orb_ecc_max : float
+        Maximum allowed orb_ecc
+    """
+    orb_eccs = rng.uniform(low=0.0, high=orb_ecc_max, size=num_bh)
+
+    #print("orb_eccs",orb_eccs)
+
+    return (orb_eccs)

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -397,6 +397,6 @@ def ionized_orb_ecc(num_bh, orb_ecc_max):
     """
     orb_eccs = rng.uniform(low=0.0, high=orb_ecc_max, size=num_bh)
 
-    #print("orb_eccs",orb_eccs)
+    #print("ionized ecc",orb_eccs)
 
     return (orb_eccs)

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -395,8 +395,9 @@ def ionized_orb_ecc(num_bh, orb_ecc_max):
     orb_ecc_max : float
         Maximum allowed orb_ecc
     """
-    orb_eccs = rng.uniform(low=0.0, high=orb_ecc_max, size=num_bh)
+    #orb_eccs = rng.uniform(low=0.0, high=orb_ecc_max, size=num_bh)
 
+    orb_eccs = np.full(num_bh, orb_ecc_max)
     #print("ionized ecc",orb_eccs)
 
     return (orb_eccs)

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -104,7 +104,7 @@ def orbital_ecc_damping(smbh_mass, disk_bh_pro_orbs_a, disk_bh_pro_orbs_masses, 
     modest_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc <= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # Large orb eccentricities: e > 2h (experience more complicated damping)
-    large_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc >= 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
+    large_ecc_prograde_indices = np.asarray(prograde_disk_bh_pro_orbs_ecc > 2.0 * disk_aspect_ratio_func(disk_bh_pro_orbs_a)).nonzero()[0]
 
     # print('modest ecc indices', modest_ecc_prograde_indices)
     # print('large ecc indices', large_ecc_prograde_indices)

--- a/src/mcfacts/physics/eccentricity.py
+++ b/src/mcfacts/physics/eccentricity.py
@@ -395,9 +395,6 @@ def ionized_orb_ecc(num_bh, orb_ecc_max):
     orb_ecc_max : float
         Maximum allowed orb_ecc
     """
-    #orb_eccs = rng.uniform(low=0.0, high=orb_ecc_max, size=num_bh)
-
-    orb_eccs = np.full(num_bh, orb_ecc_max)
-    #print("ionized ecc",orb_eccs)
+    orb_eccs = rng.uniform(low=0.0, high=orb_ecc_max, size=num_bh)
 
     return (orb_eccs)

--- a/src/mcfacts/physics/gw.py
+++ b/src/mcfacts/physics/gw.py
@@ -95,7 +95,7 @@ def gw_strain_freq(mass_1, mass_2, obj_sep, timestep_duration_yr, old_gw_freq, s
         strain_factor[nu_gw > (1e-6) * u.Hz] = np.sqrt((nu_squared[nu_gw > (1e-6) * u.Hz] / delta_nu_delta_timestep[nu_gw > (1e-6) * u.Hz]) / 8.)
     # Condition from evolve_gw
     elif (flag_include_old_gw_freq == 0):
-        strain_factor[nu_gw > (1e-6) * u.Hz] = np.full(np.sum(nu_gw > (1e-6) * u.Hz), 4.e3)
+        strain_factor[nu_gw > (1e-6) * u.Hz] = 4.e3
     char_strain = strain_factor*strain
 
     return (char_strain.value, nu_gw.value)

--- a/src/mcfacts/physics/migration.py
+++ b/src/mcfacts/physics/migration.py
@@ -55,12 +55,9 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
     # Otherwise no change in semi-major axis (orb_a).
     # Get indices of objects with orb_ecc <= ecc_crit so we can only update orb_a for those.
     migration_indices = np.asarray(orbs_ecc <= orb_ecc_crit).nonzero()[0]
+
     # If nothing will migrate then end the function
     if migration_indices.shape == (0,):
-        # BUG it shouldn't work like this
-        # epsilon is disk_radius_outer * Hill sphere of BH at outer edge of disk * random number
-        epsilon = disk_radius_outer * ((masses[orbs_a > disk_radius_outer] / (3 * (masses[orbs_a > disk_radius_outer] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=np.sum(orbs_a > disk_radius_outer))
-        orbs_a[orbs_a > disk_radius_outer] = disk_radius_outer - epsilon
         return (orbs_a)
 
     # If things will migrate then copy over the orb_a of objects that will migrate
@@ -137,9 +134,6 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
 
     # Update orbs_a
     orbs_a[migration_indices] = new_orbs_a
-    # BUG should not work like this, check should only be for orbs_a set in this function
-    epsilon = disk_radius_outer * ((masses[orbs_a > disk_radius_outer] / (3 * (masses[orbs_a > disk_radius_outer] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=np.sum(orbs_a > disk_radius_outer))
-    orbs_a[orbs_a > disk_radius_outer] = disk_radius_outer - epsilon
     return (orbs_a)
 
 

--- a/src/mcfacts/physics/migration.py
+++ b/src/mcfacts/physics/migration.py
@@ -90,7 +90,7 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
     migration_distance = new_orbs_a.copy() * dt
 
     # Calculate epsilon --amount to adjust from disk_radius_trap for objects that will be set to disk_radius_trap
-    epsilon_trap_radius = disk_radius_trap * ((masses[migration_indices] / (3 * (masses[migration_indices] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=migration_indices.size)
+    #epsilon_trap_radius = disk_radius_trap * ((masses[migration_indices] / (3 * (masses[migration_indices] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=migration_indices.size)
 
     # Get masks for if objects are inside or outside the trap radius
     mask_out_trap = new_orbs_a > disk_radius_trap
@@ -102,13 +102,13 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
         # If outside trap migrate inwards
         temp_orbs_a = new_orbs_a[mask_mig_in & mask_out_trap] - migration_distance[mask_mig_in & mask_out_trap] * (1 - disk_feedback_ratio[mask_mig_in & mask_out_trap])
         # If migration takes object inside trap, fix at trap #BUG 
-        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_mig_in & mask_out_trap][temp_orbs_a <= disk_radius_trap]
+        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap #- epsilon_trap_radius[mask_mig_in & mask_out_trap][temp_orbs_a <= disk_radius_trap]
         new_orbs_a[mask_mig_in & mask_out_trap] = temp_orbs_a
 
         # If inside trap, migrate outwards
         temp_orbs_a = new_orbs_a[mask_mig_in & mask_in_trap] + migration_distance[mask_mig_in & mask_in_trap] * (1 - disk_feedback_ratio[mask_mig_in & mask_in_trap])
         # If migration takes object outside trap, fix at trap
-        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap + epsilon_trap_radius[mask_mig_in & mask_in_trap][temp_orbs_a >= disk_radius_trap]
+        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap #+ epsilon_trap_radius[mask_mig_in & mask_in_trap][temp_orbs_a >= disk_radius_trap]
         new_orbs_a[mask_mig_in & mask_in_trap] = temp_orbs_a
 
     # Get mask for objects where feedback_ratio > 1: these migrate outwards
@@ -122,13 +122,13 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
         # If outside trap migrate inwards
         temp_orbs_a = new_orbs_a[mask_mig_stay & mask_out_trap] - migration_distance[mask_mig_stay & mask_out_trap]
         # If migration takes object inside trap, fix at trap
-        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_mig_stay & mask_out_trap][temp_orbs_a <= disk_radius_trap]
+        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap #- epsilon_trap_radius[mask_mig_stay & mask_out_trap][temp_orbs_a <= disk_radius_trap]
         new_orbs_a[mask_mig_stay & mask_out_trap] = temp_orbs_a
 
         # If inside trap migrate outwards
         temp_orbs_a = new_orbs_a[mask_mig_stay & mask_in_trap] + migration_distance[mask_mig_stay & mask_in_trap]
         # If migration takes object outside trap, fix at trap
-        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap + epsilon_trap_radius[mask_mig_stay & mask_in_trap][temp_orbs_a >= disk_radius_trap]
+        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap #+ epsilon_trap_radius[mask_mig_stay & mask_in_trap][temp_orbs_a >= disk_radius_trap]
         new_orbs_a[mask_mig_stay & mask_in_trap] = temp_orbs_a
 
     # Assert that things cannot migrate out of the disk

--- a/src/mcfacts/physics/migration.py
+++ b/src/mcfacts/physics/migration.py
@@ -101,7 +101,7 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
     if (np.sum(mask_mig_in) > 0):
         # If outside trap migrate inwards
         temp_orbs_a = new_orbs_a[mask_mig_in & mask_out_trap] - migration_distance[mask_mig_in & mask_out_trap] * (1 - disk_feedback_ratio[mask_mig_in & mask_out_trap])
-        # If migration takes object inside trap, fix at trap
+        # If migration takes object inside trap, fix at trap #BUG 
         temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_mig_in & mask_out_trap][temp_orbs_a <= disk_radius_trap]
         new_orbs_a[mask_mig_in & mask_out_trap] = temp_orbs_a
 

--- a/src/mcfacts/physics/migration.py
+++ b/src/mcfacts/physics/migration.py
@@ -90,7 +90,7 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
     migration_distance = new_orbs_a.copy() * dt
 
     # Calculate epsilon --amount to adjust from disk_radius_trap for objects that will be set to disk_radius_trap
-    #epsilon_trap_radius = disk_radius_trap * ((masses[migration_indices] / (3 * (masses[migration_indices] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=migration_indices.size)
+    epsilon_trap_radius = disk_radius_trap * ((masses[migration_indices] / (3 * (masses[migration_indices] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=migration_indices.size)
 
     # Get masks for if objects are inside or outside the trap radius
     mask_out_trap = new_orbs_a > disk_radius_trap
@@ -102,13 +102,13 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
         # If outside trap migrate inwards
         temp_orbs_a = new_orbs_a[mask_mig_in & mask_out_trap] - migration_distance[mask_mig_in & mask_out_trap] * (1 - disk_feedback_ratio[mask_mig_in & mask_out_trap])
         # If migration takes object inside trap, fix at trap #BUG 
-        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap #- epsilon_trap_radius[mask_mig_in & mask_out_trap][temp_orbs_a <= disk_radius_trap]
+        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_mig_in & mask_out_trap][temp_orbs_a <= disk_radius_trap]
         new_orbs_a[mask_mig_in & mask_out_trap] = temp_orbs_a
 
         # If inside trap, migrate outwards
         temp_orbs_a = new_orbs_a[mask_mig_in & mask_in_trap] + migration_distance[mask_mig_in & mask_in_trap] * (1 - disk_feedback_ratio[mask_mig_in & mask_in_trap])
         # If migration takes object outside trap, fix at trap
-        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap #+ epsilon_trap_radius[mask_mig_in & mask_in_trap][temp_orbs_a >= disk_radius_trap]
+        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap + epsilon_trap_radius[mask_mig_in & mask_in_trap][temp_orbs_a >= disk_radius_trap]
         new_orbs_a[mask_mig_in & mask_in_trap] = temp_orbs_a
 
     # Get mask for objects where feedback_ratio > 1: these migrate outwards
@@ -122,13 +122,13 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
         # If outside trap migrate inwards
         temp_orbs_a = new_orbs_a[mask_mig_stay & mask_out_trap] - migration_distance[mask_mig_stay & mask_out_trap]
         # If migration takes object inside trap, fix at trap
-        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap #- epsilon_trap_radius[mask_mig_stay & mask_out_trap][temp_orbs_a <= disk_radius_trap]
+        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_mig_stay & mask_out_trap][temp_orbs_a <= disk_radius_trap]
         new_orbs_a[mask_mig_stay & mask_out_trap] = temp_orbs_a
 
         # If inside trap migrate outwards
         temp_orbs_a = new_orbs_a[mask_mig_stay & mask_in_trap] + migration_distance[mask_mig_stay & mask_in_trap]
         # If migration takes object outside trap, fix at trap
-        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap #+ epsilon_trap_radius[mask_mig_stay & mask_in_trap][temp_orbs_a >= disk_radius_trap]
+        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap + epsilon_trap_radius[mask_mig_stay & mask_in_trap][temp_orbs_a >= disk_radius_trap]
         new_orbs_a[mask_mig_stay & mask_in_trap] = temp_orbs_a
 
     # Assert that things cannot migrate out of the disk

--- a/src/mcfacts/physics/migration.py
+++ b/src/mcfacts/physics/migration.py
@@ -89,6 +89,9 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
     # migration distance is original locations times fraction of tau_mig elapsed
     migration_distance = new_orbs_a.copy() * dt
 
+    # Calculate epsilon --amount to adjust from disk_radius_trap for objects that will be set to disk_radius_trap
+    epsilon_trap_radius = disk_radius_trap * ((masses[migration_indices] / (3 * (masses[migration_indices] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=migration_indices.size)
+
     # Get masks for if objects are inside or outside the trap radius
     mask_out_trap = new_orbs_a > disk_radius_trap
     mask_in_trap = new_orbs_a < disk_radius_trap
@@ -99,13 +102,13 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
         # If outside trap migrate inwards
         temp_orbs_a = new_orbs_a[mask_mig_in & mask_out_trap] - migration_distance[mask_mig_in & mask_out_trap] * (1 - disk_feedback_ratio[mask_mig_in & mask_out_trap])
         # If migration takes object inside trap, fix at trap
-        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap
+        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_mig_in & mask_out_trap][temp_orbs_a <= disk_radius_trap]
         new_orbs_a[mask_mig_in & mask_out_trap] = temp_orbs_a
 
         # If inside trap, migrate outwards
         temp_orbs_a = new_orbs_a[mask_mig_in & mask_in_trap] + migration_distance[mask_mig_in & mask_in_trap] * (1 - disk_feedback_ratio[mask_mig_in & mask_in_trap])
         # If migration takes object outside trap, fix at trap
-        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap
+        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap + epsilon_trap_radius[mask_mig_in & mask_in_trap][temp_orbs_a >= disk_radius_trap]
         new_orbs_a[mask_mig_in & mask_in_trap] = temp_orbs_a
 
     # Get mask for objects where feedback_ratio > 1: these migrate outwards
@@ -119,13 +122,13 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
         # If outside trap migrate inwards
         temp_orbs_a = new_orbs_a[mask_mig_stay & mask_out_trap] - migration_distance[mask_mig_stay & mask_out_trap]
         # If migration takes object inside trap, fix at trap
-        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap
+        temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_mig_stay & mask_out_trap][temp_orbs_a <= disk_radius_trap]
         new_orbs_a[mask_mig_stay & mask_out_trap] = temp_orbs_a
 
         # If inside trap migrate outwards
         temp_orbs_a = new_orbs_a[mask_mig_stay & mask_in_trap] + migration_distance[mask_mig_stay & mask_in_trap]
         # If migration takes object outside trap, fix at trap
-        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap
+        temp_orbs_a[temp_orbs_a >= disk_radius_trap] = disk_radius_trap + epsilon_trap_radius[mask_mig_stay & mask_in_trap][temp_orbs_a >= disk_radius_trap]
         new_orbs_a[mask_mig_stay & mask_in_trap] = temp_orbs_a
 
     # Assert that things cannot migrate out of the disk

--- a/src/mcfacts/physics/point_masses.py
+++ b/src/mcfacts/physics/point_masses.py
@@ -163,7 +163,7 @@ def si_from_r_g(smbh_mass, distance_rg):
     # Calculate r_g in SI
     r_g = G*smbh_mass/(c ** 2)
     # Calculate distance
-    distance = distance_rg * r_g
+    distance = (distance_rg * r_g).to("meter")
     return distance
 
 
@@ -195,5 +195,9 @@ def r_g_from_units(smbh_mass, distance):
     # Calculate r_g in SI
     r_g = G*smbh_mass/(c ** 2)
     # Calculate distance
-    distance_rg = distance / r_g
+    distance_rg = distance.to("meter") / r_g
+
+    # Check to make sure units are okay.
+    assert astropy_units.dimensionless_unscaled == distance_rg.unit, "distance_rg is not dimensionless. Check your input is a astropy Quantity, not an astropy Unit."
+
     return distance_rg


### PR DESCRIPTION
Fixed a bug in `dynamics.circular_singles_encounters_prograde` where circular BHs were defined as `orb_ecc <= ecc_crit`, but eccentric BHs were defined as `orb_ecc >= ecc_crit`, leading to overlap. Eccentric BHs are now defined as `orb_ecc > ecc_crit`. This created the red scare.

Also fixed a similar bug in `eccentricity.orbital_ecc_damping` and `eccentricity.bin_ecc_damping` where `modest_ecc_prograde_indices` were defined as `orb_ecc <= 2 * disk_aspect_ratio` and `large_ecc_prograde_indices` were defined as `orb_ecc >= 2 * disk_aspect_ratio`. We now define `large_ecc_prograde_indices as orb_ecc > 2 * disk_aspect_ratio`.

If a binary is ionized (broken apart) the two new single BHs have their `orb_ecc` set as a random number between `0` and `orb_ecc_max` (set in ini file). This function is `eccentricity.ionized_orb_ecc`.

If a binary merges, the new single BH has its `orb_ecc` set as `v_kick/v_kepler`, with `v_kick` currently hardcoded to 200 km/s for all BHs. This function is `merge.merged_orb_ecc`.

If a binary forms from two single BHs, it's bin_orb_ecc is set to ecc_crit (set in ini file). This function is `formation.add_to_binary_obj`.

Added catches for objects trying to move out of the disk in `dynamics.circular_binaries_encounters_ecc_prograde` and `dynamics.circular_binaries_encounters_circ_prograde`. Added catch for objects set to the `disk_radius_trap` in `migration.type1_migration`. In all cases, object's `orb_a` is set to `disk_radius_outer - epsilon` or `disk_radius_trap - epsilon`, where `epsilon` is defined as the Hill radius at `disk_radius_outer` or `disk_radius_trap` multiplied by a random number between 0 and 1. This ensures that two objects do not have exactly the same `orb_a`, preventing them from forming a binary with a separation of zero.