### PR TITLE
Bug fixes in bin_contact_check, bin_harden_baruteau

### DIFF
--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -976,7 +976,7 @@ def main():
                     blackholes_binary.remove_id_num(bh_binary_id_num_ionization)
                     filing_cabinet.remove_id_num(bh_binary_id_num_ionization)
 
-                bh_binary_id_num_merger = blackholes_binary.id_num[np.nonzero(blackholes_binary.flag_merging)]
+                bh_binary_id_num_merger = blackholes_binary.id_num[blackholes_binary.flag_merging < 0]
 
                 if opts.verbose:
                     print("Merger ID numbers")

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -28,7 +28,7 @@ attr_binary_bh = ["id_num", "orb_a_1", "orb_a_2", "mass_1", "mass_2", #"mass_tot
 attr_merged_bh = ["id_num", "galaxy", "bin_orb_a", "mass_final",
                   "spin_final", "spin_angle_final",
                   "mass_1", "mass_2",
-                  "spin_1", "spin_2",
+                  "spin_1", "spin_2",   
                   "spin_angle_1", "spin_angle_2",
                   "gen_1", "gen_2",
                   "chi_eff", "chi_p", "time_merged"]

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -28,7 +28,7 @@ attr_binary_bh = ["id_num", "orb_a_1", "orb_a_2", "mass_1", "mass_2", #"mass_tot
 attr_merged_bh = ["id_num", "galaxy", "bin_orb_a", "mass_final",
                   "spin_final", "spin_angle_final",
                   "mass_1", "mass_2",
-                  "spin_1", "spin_2",   
+                  "spin_1", "spin_2",
                   "spin_angle_1", "spin_angle_2",
                   "gen_1", "gen_2",
                   "chi_eff", "chi_p", "time_merged"]

--- a/src/mcfacts/physics/binary/evolve.py
+++ b/src/mcfacts/physics/binary/evolve.py
@@ -316,8 +316,8 @@ def bin_contact_check(blackholes_binary, smbh_mass):
     """
 
     # We assume bh are not spinning when in contact. TODO: Consider spin in future.
-    contact_condition = point_masses.r_schwarzschild_of_m(blackholes_binary.mass_1) + \
-                        point_masses.r_schwarzschild_of_m(blackholes_binary.mass_2)
+    contact_condition = (point_masses.r_schwarzschild_of_m(blackholes_binary.mass_1) +
+                         point_masses.r_schwarzschild_of_m(blackholes_binary.mass_2))
     contact_condition = point_masses.r_g_from_units(smbh_mass, contact_condition)
     mask_condition = (blackholes_binary.bin_sep <= contact_condition)
 
@@ -397,7 +397,6 @@ def bin_harden_baruteau(blackholes_binary, smbh_mass, timestep_duration_yr,
 
     # Only interested in BH that have not merged
     idx_non_mergers = np.where(blackholes_binary.flag_merging >= 0)[0]
-    print("idx_non_mergers",idx_non_mergers)
 
     # If all binaries have merged then nothing to do
     if (idx_non_mergers.shape[0] == 0):
@@ -425,8 +424,8 @@ def bin_harden_baruteau(blackholes_binary, smbh_mass, timestep_duration_yr,
     scaled_num_orbits = num_orbits_in_timestep / 1000.0
 
     # Timescale for binary merger via GW emission alone, scaled to bin parameters
-    sep_crit = point_masses.r_schwarzschild_of_m(blackholes_binary.mass_1[idx_non_mergers]) + \
-               point_masses.r_schwarzschild_of_m(blackholes_binary.mass_2[idx_non_mergers])
+    sep_crit = (point_masses.r_schwarzschild_of_m(blackholes_binary.mass_1[idx_non_mergers]) +
+                point_masses.r_schwarzschild_of_m(blackholes_binary.mass_2[idx_non_mergers]))
     time_to_merger_gw = (point_masses.time_of_orbital_shrinkage(
         blackholes_binary.mass_1[idx_non_mergers] * astropy_units.Msun,
         blackholes_binary.mass_2[idx_non_mergers] * astropy_units.Msun,

--- a/src/mcfacts/physics/point_masses.py
+++ b/src/mcfacts/physics/point_masses.py
@@ -201,3 +201,28 @@ def r_g_from_units(smbh_mass, distance):
     assert astropy_units.dimensionless_unscaled == distance_rg.unit, "distance_rg is not dimensionless. Check your input is a astropy Quantity, not an astropy Unit."
 
     return distance_rg
+
+
+def r_schwarzschild_of_m(mass):
+    """Calculate the Schwarzschild radius from the mass of the object.
+
+    Parameters
+    ----------
+    mass : numpy.ndarray or float
+        Mass [Msun] of the object(s)
+
+    Returns
+    -------
+    r_sch : numpy.ndarray
+        Schwarzschild radius [m] with `astropy.units.quantity.Quantity`
+    """
+
+    # Assign units to mass
+    if hasattr(mass, 'unit'):
+        mass = mass.to('solMass')
+    else:
+        mass = mass * astropy_units.solMass
+
+    r_sch = (2. * astropy_constants.G * mass / (astropy_constants.c ** 2)).to("meter")
+
+    return (r_sch)


### PR DESCRIPTION
#### Summary

We were comparing `time_to_merger_gw` (in seconds) to `timestep_duration_yr` (in years) in `bin_harden_baruteau`. This is now fixed.

Updated the calculation for `time_to_merger_gw` to use the `point_masses.time_of_orbital_shrinkage` function, with `sep_final` set to `R_sch_1 + R_sch_2` with `R_sch` as the Schwarzschild radius.

Updated the calculation in `bin_contact_check` to use the actual Schwarzschild radius of each BH.

Added `r_schwarzschild_of_m` function in `point_masses.py` to calculate the Schwarzschild radius ($R_\text{sch} = 2G M/c^2$).
