### PR TITLE
dynamics updated, default run set to 0.5 Myr

### DIFF
--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -70,7 +70,7 @@ mass_pile_up = 35.
 #
 #
 #Star stuff
-flag_add_stars = 1
+flag_add_stars = 0
 # If 1: stars over disk_star_initial_mass_cutoff turn into BH. If 0: stars over disk_star_initial_mass_cutoff are held at the cutoff and are immortal. Default 1.
 flag_initial_stars_BH_immortal = 0
 # Maximum initial star mass before flag_initial_stars_BH_immortal behavior kicks in. Default 300.
@@ -94,7 +94,7 @@ nsc_star_metallicity_z_init = 0.02
 # timestep in years (float)
 timestep_duration_yr = 1.e4
 # For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
-timestep_num = 100
+timestep_num = 50
 
 # number of galaxies of code (1 for testing. 30 for a quick run.)
 galaxy_num = 1

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -766,7 +766,7 @@ def main():
                     # Harden binaries due to encounters with circular singletons (e.g. Leigh et al. 2018)
                     # FIX THIS: RETURN perturbed circ singles (orb_a, orb_ecc)
 
-                    blackholes_binary = dynamics.circular_binaries_encounters_circ_prograde(
+                    blackholes_binary, blackholes_pro.orb_a, blackholes_pro.orb_ecc = dynamics.circular_binaries_encounters_circ_prograde(
                         opts.smbh_mass,
                         blackholes_pro.orb_a,
                         blackholes_pro.mass,
@@ -785,7 +785,7 @@ def main():
 
                     # Soften/ ionize binaries due to encounters with eccentric singletons
                     # Return 3 things: perturbed biary_bh_array, disk_bh_pro_orbs_a, disk_bh_pro_orbs_ecc
-                    blackholes_binary = dynamics.circular_binaries_encounters_ecc_prograde(
+                    blackholes_binary, blackholes_pro.orb_a, blackholes_pro.orb_ecc = dynamics.circular_binaries_encounters_ecc_prograde(
                         opts.smbh_mass,
                         blackholes_pro.orb_a,
                         blackholes_pro.mass,

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -436,6 +436,8 @@ def circular_binaries_encounters_ecc_prograde(
                         blackholes_binary.bin_orb_ecc[i] = 1.0 - epsilon
 
     # TODO: ALSO return new array of singletons with changed params.
+    disk_bh_pro_orbs_a[ecc_prograde_population_indices] = ecc_prograde_population_locations
+    disk_bh_pro_orbs_ecc[ecc_prograde_population_indices] = ecc_prograde_population_eccentricities
 
     # Check finite
     assert np.isfinite(blackholes_binary.bin_sep).all(), \
@@ -446,7 +448,7 @@ def circular_binaries_encounters_ecc_prograde(
         "Finite check failure: bin_eccentricities"
     assert np.sum(blackholes_binary.bin_ecc > 1) == 0, "bin_ecc has values greater than 1"
 
-    return (blackholes_binary)
+    return (blackholes_binary, disk_bh_pro_orbs_a, disk_bh_pro_orbs_ecc)
 
 
 def circular_binaries_encounters_circ_prograde(
@@ -680,7 +682,11 @@ def circular_binaries_encounters_circ_prograde(
                         blackholes_binary.bin_ecc[i] = 1.0 - epsilon
                     if (blackholes_binary.bin_orb_ecc[i] >= 1):
                         blackholes_binary.bin_orb_ecc[i] = 1.0 - epsilon
-    return (blackholes_binary)
+
+    disk_bh_pro_orbs_a[circ_prograde_population_indices] = circ_prograde_population_locations
+    disk_bh_pro_orbs_ecc[circ_prograde_population_indices] = circ_prograde_population_eccentricities
+
+    return (blackholes_binary, disk_bh_pro_orbs_a, disk_bh_pro_orbs_ecc)
 
 
 def bin_spheroid_encounter(


### PR DESCRIPTION
#### Summary

Dynamics functions for binaries now return the altered single object orb_an and orb_ecc. Default run is set to 0.5Myr.
