### PR TITLE
fixed bug that always initialized BHs and stars with galaxy = 0

### DIFF
--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -319,7 +319,7 @@ def main():
                                   orb_ecc=bh_orb_ecc_initial,
                                   orb_arg_periapse=bh_orb_arg_periapse_initial,
                                   bh_num=disk_bh_num,
-                                  galaxy=np.zeros(disk_bh_num),
+                                  galaxy=np.full(disk_bh_num, galaxy),
                                   time_passed=np.zeros(disk_bh_num))
 
         # Initialize filing_cabinet
@@ -333,7 +333,7 @@ def main():
 
         # Initialize stars
         if opts.flag_add_stars:
-            stars, disk_star_num = initializediskstars.init_single_stars(opts, disk_aspect_ratio, id_start_val=filing_cabinet.id_max+1)
+            stars, disk_star_num = initializediskstars.init_single_stars(opts, disk_aspect_ratio, galaxy, id_start_val=filing_cabinet.id_max+1)
         else:
             stars, disk_star_num = AGNStar(), 0
 

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -121,14 +121,13 @@ def obj_to_binary_bh_array(obj):
 class AGNObject(object):
     """
     A superclass that holds parameters that apply to all objects in McFacts.
-    It is formatted as an object full of arrays.
+    It is formatted as an object full of arrays. Dimensions of arrays must
+    match the number of objects in the class.
     No instances of the AGNObject class should be created, it is a superclass
     to the AGNStar, AGNBlackHole, etc. classes.
     All orbital attributes to this class are with respect to the central SMBH.
     if the subclass is a Binary object, then attributes are for the total
     quantities (total mass, etc.), not the binary components.
-    No instances of the AGNObject class should be created, it is a superclass
-    to the AGNStar, AGNBlackHole, etc. classes.
     """
 
     def __init__(self,

--- a/src/mcfacts/setup/initializediskstars.py
+++ b/src/mcfacts/setup/initializediskstars.py
@@ -6,7 +6,7 @@ import numpy as np
 from mcfacts.mcfacts_random_state import rng
 
 
-def init_single_stars(opts, disk_aspect_ratio, id_start_val=None):
+def init_single_stars(opts, disk_aspect_ratio, galaxy, id_start_val=None):
 
     # Generate initial number of stars
     star_num_initial = setupdiskstars.setup_disk_stars_num(
@@ -75,7 +75,7 @@ def init_single_stars(opts, disk_aspect_ratio, id_start_val=None):
                     star_X=star_X,
                     star_Y=star_Y,
                     star_Z=star_Z,
-                    galaxy=np.zeros(star_num),
+                    galaxy=np.full(star_num, galaxy),
                     time_passed=np.zeros(star_num),
                     id_start_val=id_start_val,
                     star_num=star_num)


### PR DESCRIPTION
#### Summary

When initializing stars and BHs at the beginning of the time loop, `galaxy` was set with np.zeros, instead of set to the actual galaxy (iteration) we were on. This is now fixed.