### PR TITLE
Read log file capability

### DIFF
--- a/IOdocumentation.txt
+++ b/IOdocumentation.txt
@@ -12,18 +12,18 @@ star cluster variables second, and assorted other choices (time resolution etc.)
     smbh_mass : float
         supermassive black hole mass in units of solar masses
             default : 1.e8
-    flag_use_pagn : bool
-        Switch pAGN program on or off
+    flag_use_pagn : int
+        Switch pAGN program on (1) or off (0)
         Gangardt, Daria et al. 2024      
-            default : True  
+            default : 1  
     disk_model_name : string
         McFACTS comes with the following example options for disk models:
         sirko_goodman: from Sirko & Goodman 2003
         thompson_etal: from Thompson, Quataert & Murray 2005
 
-        If user sets pAGN to True, only sirko_goodman and thompson_etal are available to use   
+        If user sets pAGN to on (1), only sirko_goodman and thompson_etal are available to use   
             this variable sets the model used by pAGN Sirko & Goodman 2003 or Thompson, Quataert, and Murray 2005
-        If user sets pAGN to False, tabulated models will be used. Options included are sirko_goodman and thompson_etal
+        If user sets pAGN to off (0), tabulated models will be used. Options included are sirko_goodman and thompson_etal
             which will use the tablulated models within src/mcfacts/inputs/data/
             However, the intended use is for users that wish to input their own tabulated models 
         
@@ -187,7 +187,7 @@ star cluster variables second, and assorted other choices (time resolution etc.)
     nsc_spheroid_normalization : float
         Normalization factor determines the departures from sphericity of the initial distribution of perturbers
         default : 1.0
-    save_snapshots : bool
+    save_snapshots : int
         Saving the snapshots of each object being per time step. Deafult is 0 [off] 
         default : 0
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ mcfacts_sim: clean
 		python ../${MCFACTS_SIM_EXE} \
 		--galaxy_num 100 \
 		--fname-ini ../${FNAME_INI} \
-		--fname-log out.log \
+		--fname-log mcfacts.log \
 		--seed ${SEED}
 
 
@@ -144,7 +144,7 @@ kaila_stars_movie: clean
 		python ../${MCFACTS_SIM_EXE} \
 		--galaxy_num 100 \
 		--fname-ini ../${FNAME_INI} \
-		--fname-log out.log \
+		--fname-log mcfacts.log \
 		--seed ${SEED} \
 		--save-snapshots
 
@@ -213,7 +213,7 @@ clean:
 	rm -rf ${wd}/time_of_merger.png
 	rm -rf ${wd}/merger_remnant_mass.png
 	rm -rf ${wd}/gw_strain.png
-	rm -rf ${wd}/out.log
+	rm -rf ${wd}/mcfacts.log
 	rm -rf ${wd}/mergers_cdf*.png
 	rm -rf ${wd}/mergers_nal*.png
 	rm -rf ${wd}/r_chi_p.png
@@ -229,7 +229,7 @@ clean_win:
 	del /q .\time_of_merger.png
 	del /q .\merger_remnant_mass.png
 	del /q .\gw_strain.png
-	del /q .\out.log
+	del /q .\mcfacts.log
 	for /d %%i in (.\mergers_cdf*.png) do rd /s /q "%%i"
 	for /d %%i in (.\mergers_nal*.png) do rd /s /q "%%i"
 	del /q .\r_chi_p.png

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -69,8 +69,8 @@ def arg():
     parser.add_argument("--fname-output", default="output.dat",
                         help="output file (if any)", type=str)
     parser.add_argument("--fname-snapshots-bh",
-                        default="output_bh_[single|binary]_$(index).dat",
-                        help="output of BH index file ")
+                        default="output_bh_[single|binary]_pro_$(timestep_current_num).dat",
+                        help="output of BH snapshot file ")
     parser.add_argument("--save-snapshots", action='store_true')
     parser.add_argument("--verbose", action='store_true')
     parser.add_argument("-w", "--work-directory",
@@ -80,8 +80,8 @@ def arg():
                         )
     parser.add_argument("--seed", type=int, default=None,
                         help="Set the random seed. Randomly sets one if not passed. Default: None")
-    parser.add_argument("--fname-log", default="mcfacts_sim.log", type=str,
-                        help="Specify a file to save the arguments for mcfacts")
+    parser.add_argument("--fname-log", default="mcfacts.log", type=str,
+                        help="Specify a file in which to save the arguments and some runtime information. Default: mcfacts.log")
 
     # Add inifile arguments
     # Read default inifile

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -176,10 +176,15 @@ def arg():
     # Write parameters to log file
     with open(opts.work_directory / opts.fname_log, 'w') as F:
         for item in opts.__dict__:
-            line = "%s = %s\n" % (item, str(opts.__dict__[item]))
+            # Convert booleans to integers
+            if opts.__dict__[item] == False:
+                line = "%s = %s\n" % (item, 0)
+            elif opts.__dict__[item] == True:
+                line = "%s = %s\n" % (item, 1)
+            else: # everything else
+                line = "%s = %s\n" % (item, str(opts.__dict__[item]))
             F.write(line)
     return opts
-
 
 def main():
     """

--- a/scripts/population_plots.py
+++ b/scripts/population_plots.py
@@ -14,6 +14,7 @@ from importlib import resources as impresources
 from mcfacts.vis import data
 from mcfacts.vis import plotting
 from mcfacts.vis import styles
+from mcfacts.outputs.ReadOutputs import ReadLog
 
 # Use the McFACTS plot style
 plt.style.use("mcfacts.vis.mcfacts_figures")
@@ -37,6 +38,9 @@ def arg():
     parser.add_argument("--fname-lvk",
                         default="output_mergers_lvk.dat",
                         type=str, help="output_lvk file")
+    parser.add_argument("--fname-log",
+                        default="mcfacts.log",
+                        type=str, help="log file")
     opts = parser.parse_args()
     print(opts.fname_mergers)
     assert os.path.isfile(opts.fname_mergers)
@@ -144,9 +148,11 @@ def main():
     # Merger Mass vs Radius
     # ========================================
 
-    # TQM has a trap at 500r_g, SG has a trap radius at 700r_g.
-    # trap_radius = 500
-    trap_radius = 700
+    # Read the log file
+    log_data = ReadLog(opts.fname_log)
+
+    # Retrieve the migration trap radius used in run
+    trap_radius = log_data["disk_radius_trap"]
 
     # plt.title('Migration Trap influence')
     for i in range(len(mergers[:, 1])):
@@ -190,7 +196,7 @@ def main():
                 )
 
     plt.axvline(trap_radius, color='k', linestyle='--', zorder=0,
-                label=f'Trap Radius = {trap_radius} ' + r'$R_g$')
+                label=f'Trap Radius = {trap_radius:.0f} ' + r'$R_g$')
 
     # plt.text(650, 602, 'Migration Trap', rotation='vertical', size=18, fontweight='bold')
     plt.ylabel(r'Remnant Mass [$M_\odot$]')
@@ -373,6 +379,9 @@ def main():
                 facecolor='none',
                 alpha=styles.markeralpha_genX,
                 label=r'$\geq$3g-Ng')
+    
+    plt.axvline(np.log10(trap_radius), color='k', linestyle='--', zorder=0,
+                label=f'Trap Radius = {trap_radius:.0f} ' + r'$R_g$')
 
     # plt.title("In-plane effective Spin vs. Merger radius")
     ax1.set(

--- a/src/mcfacts/external/DiskModelsPAGN.py
+++ b/src/mcfacts/external/DiskModelsPAGN.py
@@ -48,7 +48,7 @@ class AGNGasDiskModel(object):
         else:
             np.savetxt(filename, np.vstack((R/ct.pc, Omega, T, rho, h, cs, tauV, Q)).T)
 
-    def return_disk_surf_model(self, flag_truncate_disk=False):
+    def return_disk_surf_model(self, flag_truncate_disk=0):
         """Generate disk surface model functions
 
         Interpolate and return disk surface model functions as a function of the disk radius.
@@ -60,9 +60,9 @@ class AGNGasDiskModel(object):
 
         Parameters
         ----------
-        flag_truncate_disk : bool, optional
-            If `True`, truncate these functions at the radius where star formation starts
-            in the gas disk. If `False`, do not truncate. By default `False`.
+        flag_truncate_disk : int, optional
+            If 1, truncate these functions at the radius where star formation starts
+            in the gas disk. If 0, do not truncate. By default 0.
 
         Returns
         -------

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -123,6 +123,12 @@ Inifile
         Innermost Stable Circular Orbit around SMBH
     "mass_pile_up"                  : float
         Pile-up of masses caused by cutoff (M_sun)
+    "save_snapshots"
+        Save snapshots of the disk and NSC at each timestep
+    "mean_harden_energy_delta"
+        The Gaussian mean value for the energy change during a strong interaction
+    "var_harden_energy_delta"
+        The Gaussian variance value for the energy change during a strong interaction
 """
 # Things everyone needs
 import configparser as ConfigParser

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -8,7 +8,7 @@ Inifile
         Use pAGN to generate disk model?
     "flag_add_stars"                : int
         Add stars to the disk
-    "flag_initial_stars_BH_immortal": float
+    "flag_initial_stars_BH_immortal": int
         If stars over disk_star_initial_mass_cutoff turn into BH (0) or hold at cutoff (1, immortal)
     "smbh_mass"                     : float
         Mass of the supermassive black hole (solMass)

--- a/src/mcfacts/outputs/ReadOutputs.py
+++ b/src/mcfacts/outputs/ReadOutputs.py
@@ -1,0 +1,285 @@
+"""Define output handling functions for McFACTS
+
+Logfile
+-------
+    "bin_num_max"                   : int
+        Maximum allowable number of binaries at a given time. Sets array size.
+    "fname_ini"                     : str
+        Name of the ini file used for this run.
+    "fname_output_mergers"          : str
+        Name of the output file for mergers.
+    "fname_output"                  : str
+        Name of the output file for the run.
+    "fname_snapshots_bh"            : str
+        Name of the output file recording BH info at each snapshot.
+    "saves_snapshots"               : bool
+        True: save snapshots, False: don't save snapshots
+    "verbose"                       : bool
+        True: print extra info, False: don't print extra info
+    "work_directory"                : str
+        The working directory used for the run.
+    "seed"                          : int
+        Random seed used for the run.
+    "fname_log"                     : str
+        Name of the log file storing details of the run.
+    "runtime_directory"             : str
+        The runtime directory used for the run.
+    "disk_model_name"               : str
+        'sirko_goodman' or 'thompson_etal'
+    "flag_use_pagn"                 : bool
+        Use pAGN to generate disk model?
+    "flag_add_stars"                : bool
+        Add stars to the disk
+    "flag_initial_stars_BH_immortal": float
+        If stars over disk_star_initial_mass_cutoff turn into BH (0) or hold at cutoff (1, immortal)
+    "smbh_mass"                     : float
+        Mass of the supermassive black hole (solMass)
+    "disk_radius_trap"              : float
+        Radius of migration trap in gravitational radii (r_g = G*`smbh_mass`/c^2)
+        Should be set to zero if disk model has no trap
+    "disk_radius_outer"             : float
+        final element of disk_model_radius_array (units of r_g)
+    "disk_radius_max_pc"            : float
+        Maximum disk size in parsecs (0. for off)
+    "disk_alpha_viscosity"          : float
+        disk viscosity 'alpha'
+    "nsc_radius_outer"              : float
+        Radius of NSC (units of pc)
+    "nsc_mass"                      : float
+        Mass of NSC (units of M_sun)
+    "nsc_radius_crit"               : float
+        Radius where NSC density profile flattens (transition to Bahcall-Wolf) (units of pc)
+    "nsc_ratio_bh_num_star_num"     : float
+        Ratio of number of BH to stars in NSC (typically spans 3x10^-4 to 10^-2 in Generozov+18)
+    "nsc_ratio_bh_mass_star_mass"   : float
+        Ratio of mass of typical BH to typical star in NSC (typically 10:1 in Generozov+18)
+    "nsc_density_index_inner"       : float
+        Index of radial density profile of NSC inside r_nsc_crit (usually Bahcall-Wolf, 1.75)
+    "nsc_density_index_outer"       : float
+        Index of radial density profile of NSC outside r_nsc_crit
+        (e.g. 2.5 in Generozov+18 or 2.25 if Peebles)
+    "disk_aspect_ratio_avg"    : float
+        Average disk scale height (e.g. about 3% in Sirko & Goodman 2003 out to ~0.3pc)
+    "nsc_spheroid_normalization"    : float
+        Spheroid normalization
+    "nsc_imf_bh_mode"               : float
+        Initial mass distribution for stellar bh is assumed to be Pareto
+        with high mass cutoff--mode of initial mass dist (M_sun)
+    "nsc_imf_bh_powerlaw_index"     : float
+        Initial mass distribution for stellar bh is assumed to be Pareto
+        with high mass cutoff--powerlaw index for Pareto dist
+    "nsc_imf_bh_mass_max"           : float
+        Initial mass distribution for stellar bh is assumed to be Pareto
+        with high mass cutoff--mass of cutoff (M_sun)
+    "nsc_bh_spin_dist_mu"           : float
+        Initial spin distribution for stellar bh is assumed to be Gaussian
+        --mean of spin dist
+    "nsc_bh_spin_dist_sigma"        : float
+        Initial spin distribution for stellar bh is assumed to be Gaussian
+        --standard deviation of spin dist
+    "disk_bh_torque_condition"      : float
+        fraction of initial mass required to be accreted before BH spin is torqued
+        fully into alignment with the AGN disk. We don't know for sure but
+        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
+    "disk_bh_eddington_ratio"       : float
+        Eddington ratio for disk bh
+    "disk_bh_orb_ecc_max_init"      : float
+        assumed accretion rate onto stellar bh from disk gas, in units of Eddington
+        accretion rate
+    "disk_star_mass_max_init"       : float
+        Initial mass distribution for stars is assumed Salpeter
+    "disk_star_mass_min_init"       : float
+        Initial mass distribution for stars is assumed Salpeter
+    "nsc_imf_star_powerlaw_index"   : float
+        Initial mass distribution for stars is assumed Salpeter, disk_alpha_viscosity = 2.35
+    "disk_star_scale_factor"        : float
+        Scale factor to go from number of BH to number of stars.
+    "disk_star_initial_mass_cutoff" : float
+        Cutoff for initial star behavior
+    "nsc_imf_star_mass_mode"       : float
+        Mass mode for star IMF
+    "disk_star_torque_condition"    : float
+        fraction of initial mass required to be accreted before star spin is torqued
+        fully into alignment with the AGN disk. We don't know for sure but
+        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
+    "disk_star_eddington_ratio"     : float
+        assumed accretion rate onto stars from disk gas, in units of Eddington
+        accretion rate
+    "disk_star_orb_ecc_max_init"    : float
+        assuming initially flat eccentricity distribution among single orbiters around SMBH
+        out to max_initial_eccentricity. Eventually this will become smarter.
+    "nsc_star_metallicity_x_init"   : float
+        Stellar initial hydrogen mass fraction
+    "nsc_star_metallicity_y_init"   : float
+        Stellar initial helium mass fraction
+    "nsc_star_metallicity_z_init"   : float
+        Stellar initial metallicity mass fraction
+    "timestep_duration_yr"          : float
+        How long is your timestep in years?
+    "timestep_num"                  : int
+        How many timesteps are you taking (timestep*number_of_timesteps = disk_lifetime)
+    "galaxy_num"                    : int
+        Number of galaxies of code run (e.g. 1 for testing, 30 for a quick run)
+    "fraction_bin_retro"            : float
+        Fraction of BBH that form retrograde to test (q,X_eff) relation. Default retro=0.1
+    "flag_thermal_feedback"         : int
+        Switch (1) turns feedback from embedded BH on.
+    "flag_orb_ecc_damping"          : int
+        Switch (1) turns orb. ecc damping on.
+        If switch = 0, assumes all bh are circularized (at e=e_crit)
+    "capture_time_yr"              : float
+        Capture time in years Secunda et al. (2021) assume capture rate 1/0.1 Myr
+    "disk_radius_capture_outer"     : float
+        Disk capture outer radius (units of r_g)
+        Secunda et al. (2001) assume <2000r_g from Fabj et al. (2020)
+    "disk_bh_pro_orb_ecc_crit"      : float
+        Critical eccentricity (limiting eccentricity, below which assumed circular orbit)
+    "flag_dynamic_enc"              : int
+        Switch (1) turns dynamical encounters between embedded BH on.
+    "delta_energy_strong"           : float
+        Average energy change per strong interaction.
+        de can be 20% in cluster interactions. May be 10% on average (with gas)
+    "inner_disk_outer_radius"       : float
+        Outer radius of the inner disk (Rg)
+    "disk_inner_stable_circ_orb"    : float
+        Innermost Stable Circular Orbit around SMBH
+    "mass_pile_up"                  : float
+        Pile-up of masses caused by cutoff (M_sun)
+
+"""
+
+# Things everyone needs
+import configparser as ConfigParser
+from io import StringIO
+from importlib import resources as impresources
+# Third party
+import numpy as np
+import scipy.interpolate
+# pAGN imports 
+import pagn.constants as pagn_ct
+# Local imports 
+import mcfacts.external.DiskModelsPAGN as dm_pagn
+from mcfacts.inputs import data as mcfacts_input_data
+from astropy import constants as ct
+
+# Dictionary of types
+OUTPUT_TYPES = {
+    "bin_num_max"                   : int,
+    "fname_ini"                     : str,
+    "fname_output_mergers"          : str,
+    "fname_output"                  : str,
+    "fname_snapshots_bh"            : str,
+    "saves_snapshots"               : bool,
+    "verbose"                       : bool,
+    "work_directory"                : str,
+    "seed"                          : int,
+    "fname_log"                     : str,
+    "runtime_directory"             : str,
+    "disk_model_name"               : str,
+    "flag_use_pagn"                 : bool,
+    "flag_add_stars"                : bool,
+    "flag_initial_stars_BH_immortal": bool,
+    "smbh_mass"                     : float,
+    "disk_radius_trap"              : float,
+    "disk_radius_outer"             : float,
+    "disk_radius_max_pc"            : float,
+    "disk_alpha_viscosity"          : float,
+    "nsc_radius_outer"              : float,
+    "nsc_mass"                      : float,
+    "nsc_radius_crit"               : float,
+    "nsc_ratio_bh_num_star_num"     : float,
+    "nsc_ratio_bh_mass_star_mass"   : float,
+    "nsc_density_index_inner"       : float,
+    "nsc_density_index_outer"       : float,
+    "disk_aspect_ratio_avg"         : float,
+    "nsc_spheroid_normalization"    : float,
+    "nsc_imf_bh_mode"               : float,
+    "nsc_imf_bh_powerlaw_index"     : float,
+    "nsc_imf_bh_mass_max"           : float,
+    "nsc_bh_spin_dist_mu"           : float,
+    "nsc_bh_spin_dist_sigma"        : float,
+    "disk_bh_torque_condition"      : float,
+    "disk_bh_eddington_ratio"       : float,
+    "disk_bh_orb_ecc_max_init"      : float,
+    "disk_star_mass_max_init"       : float,
+    "disk_star_mass_min_init"       : float,
+    "nsc_imf_star_powerlaw_index"   : float,
+    "disk_star_scale_factor"        : float,
+    "disk_star_initial_mass_cutoff" : float,
+    "nsc_imf_star_mass_mode"        : float,
+    "disk_star_torque_condition"    : float,
+    "disk_star_eddington_ratio"     : float,
+    "disk_star_orb_ecc_max_init"    : float,
+    "nsc_star_metallicity_x_init"   : float,
+    "nsc_star_metallicity_y_init"   : float,
+    "nsc_star_metallicity_z_init"   : float,
+    "timestep_duration_yr"          : float,
+    "timestep_num"                  : int,
+    "galaxy_num"                    : int,
+    "fraction_bin_retro"            : float,
+    "flag_thermal_feedback"         : int,
+    "flag_orb_ecc_damping"          : int,
+    "capture_time_yr"               : float,
+    "disk_radius_capture_outer"     : float,
+    "disk_bh_pro_orb_ecc_crit"      : float,
+    "flag_dynamic_enc"              : int,
+    "delta_energy_strong"           : float,
+    "inner_disk_outer_radius"       : float,
+    "disk_inner_stable_circ_orb"    : float,
+    "mass_pile_up"                  : float,
+    "save_snapshots"                : bool,
+    "mean_harden_energy_delta"      : float,
+    "var_harden_energy_delta"       : float
+}
+
+def ReadLog(fname_log, verbose=False):
+    """Output log parser
+
+    Parameters
+    ----------
+    fname_log : str
+        Path and name to the log file from a McFACTS run
+    verbose : bool, optional
+        Print extra info, by default False
+    """
+
+    # Read in the file
+    with open(fname_log, 'r') as f:
+        lines = f.readlines()
+
+    # Initialize the dictionary
+    log_dict = {}
+    extra_values = {}
+
+    # Loop through the lines
+    for line in lines:
+        # Split the line
+        key, value = line.split('=')
+        # Strip the values of any whitespace
+        key = key.strip()
+        value = value.strip()
+        # Convert the values
+        if key in OUTPUT_TYPES:
+            log_dict[key] = OUTPUT_TYPES[key](value)
+        else:
+            log_dict[key] = value
+            extra_values[key] = value
+        
+    # Print the dictionary
+    if verbose:
+        for key, value in log_dict.items():
+            print(f"{key}: {value}")
+
+    if len(extra_values) > 0:
+        print(f"~~~~~~~~~~~~~~~~~~~~~~\n",
+               "[ReadLog] Warning!: The log file you're using contains additional\n",
+               "entries not found in OUTPUT_TYPES. They have been added to the log\n",
+               "dictionary as a STRING type. Please verify their types before you\n",
+               "use them in your analysis or add them to the OUTPUT_TYPES dictionary.")
+        for key, value in extra_values.items():
+            print(f"  {key}: {value}")
+        print(f"~~~~~~~~~~~~~~~~~~~~~~")
+        
+
+    return log_dict
+    

--- a/src/mcfacts/outputs/ReadOutputs.py
+++ b/src/mcfacts/outputs/ReadOutputs.py
@@ -12,10 +12,10 @@ Logfile
         Name of the output file for the run.
     "fname_snapshots_bh"            : str
         Name of the output file recording BH info at each snapshot.
-    "saves_snapshots"               : bool
-        True: save snapshots, False: don't save snapshots
-    "verbose"                       : bool
-        True: print extra info, False: don't print extra info
+    "saves_snapshots"               : int
+        1: save snapshots, 0: don't save snapshots
+    "verbose"                       : int
+        1: print extra info, 0: don't print extra info
     "work_directory"                : str
         The working directory used for the run.
     "seed"                          : int
@@ -24,143 +24,13 @@ Logfile
         Name of the log file storing details of the run.
     "runtime_directory"             : str
         The runtime directory used for the run.
-    "disk_model_name"               : str
-        'sirko_goodman' or 'thompson_etal'
-    "flag_use_pagn"                 : bool
-        Use pAGN to generate disk model?
-    "flag_add_stars"                : bool
-        Add stars to the disk
-    "flag_initial_stars_BH_immortal": float
-        If stars over disk_star_initial_mass_cutoff turn into BH (0) or hold at cutoff (1, immortal)
-    "smbh_mass"                     : float
-        Mass of the supermassive black hole (solMass)
-    "disk_radius_trap"              : float
-        Radius of migration trap in gravitational radii (r_g = G*`smbh_mass`/c^2)
-        Should be set to zero if disk model has no trap
-    "disk_radius_outer"             : float
-        final element of disk_model_radius_array (units of r_g)
-    "disk_radius_max_pc"            : float
-        Maximum disk size in parsecs (0. for off)
-    "disk_alpha_viscosity"          : float
-        disk viscosity 'alpha'
-    "nsc_radius_outer"              : float
-        Radius of NSC (units of pc)
-    "nsc_mass"                      : float
-        Mass of NSC (units of M_sun)
-    "nsc_radius_crit"               : float
-        Radius where NSC density profile flattens (transition to Bahcall-Wolf) (units of pc)
-    "nsc_ratio_bh_num_star_num"     : float
-        Ratio of number of BH to stars in NSC (typically spans 3x10^-4 to 10^-2 in Generozov+18)
-    "nsc_ratio_bh_mass_star_mass"   : float
-        Ratio of mass of typical BH to typical star in NSC (typically 10:1 in Generozov+18)
-    "nsc_density_index_inner"       : float
-        Index of radial density profile of NSC inside r_nsc_crit (usually Bahcall-Wolf, 1.75)
-    "nsc_density_index_outer"       : float
-        Index of radial density profile of NSC outside r_nsc_crit
-        (e.g. 2.5 in Generozov+18 or 2.25 if Peebles)
-    "disk_aspect_ratio_avg"    : float
-        Average disk scale height (e.g. about 3% in Sirko & Goodman 2003 out to ~0.3pc)
-    "nsc_spheroid_normalization"    : float
-        Spheroid normalization
-    "nsc_imf_bh_mode"               : float
-        Initial mass distribution for stellar bh is assumed to be Pareto
-        with high mass cutoff--mode of initial mass dist (M_sun)
-    "nsc_imf_bh_powerlaw_index"     : float
-        Initial mass distribution for stellar bh is assumed to be Pareto
-        with high mass cutoff--powerlaw index for Pareto dist
-    "nsc_imf_bh_mass_max"           : float
-        Initial mass distribution for stellar bh is assumed to be Pareto
-        with high mass cutoff--mass of cutoff (M_sun)
-    "nsc_bh_spin_dist_mu"           : float
-        Initial spin distribution for stellar bh is assumed to be Gaussian
-        --mean of spin dist
-    "nsc_bh_spin_dist_sigma"        : float
-        Initial spin distribution for stellar bh is assumed to be Gaussian
-        --standard deviation of spin dist
-    "disk_bh_torque_condition"      : float
-        fraction of initial mass required to be accreted before BH spin is torqued
-        fully into alignment with the AGN disk. We don't know for sure but
-        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
-    "disk_bh_eddington_ratio"       : float
-        Eddington ratio for disk bh
-    "disk_bh_orb_ecc_max_init"      : float
-        assumed accretion rate onto stellar bh from disk gas, in units of Eddington
-        accretion rate
-    "disk_star_mass_max_init"       : float
-        Initial mass distribution for stars is assumed Salpeter
-    "disk_star_mass_min_init"       : float
-        Initial mass distribution for stars is assumed Salpeter
-    "nsc_imf_star_powerlaw_index"   : float
-        Initial mass distribution for stars is assumed Salpeter, disk_alpha_viscosity = 2.35
-    "disk_star_scale_factor"        : float
-        Scale factor to go from number of BH to number of stars.
-    "disk_star_initial_mass_cutoff" : float
-        Cutoff for initial star behavior
-    "nsc_imf_star_mass_mode"       : float
-        Mass mode for star IMF
-    "disk_star_torque_condition"    : float
-        fraction of initial mass required to be accreted before star spin is torqued
-        fully into alignment with the AGN disk. We don't know for sure but
-        Bogdanovic et al. says between 0.01=1% and 0.1=10% is what is required.
-    "disk_star_eddington_ratio"     : float
-        assumed accretion rate onto stars from disk gas, in units of Eddington
-        accretion rate
-    "disk_star_orb_ecc_max_init"    : float
-        assuming initially flat eccentricity distribution among single orbiters around SMBH
-        out to max_initial_eccentricity. Eventually this will become smarter.
-    "nsc_star_metallicity_x_init"   : float
-        Stellar initial hydrogen mass fraction
-    "nsc_star_metallicity_y_init"   : float
-        Stellar initial helium mass fraction
-    "nsc_star_metallicity_z_init"   : float
-        Stellar initial metallicity mass fraction
-    "timestep_duration_yr"          : float
-        How long is your timestep in years?
-    "timestep_num"                  : int
-        How many timesteps are you taking (timestep*number_of_timesteps = disk_lifetime)
-    "galaxy_num"                    : int
-        Number of galaxies of code run (e.g. 1 for testing, 30 for a quick run)
-    "fraction_bin_retro"            : float
-        Fraction of BBH that form retrograde to test (q,X_eff) relation. Default retro=0.1
-    "flag_thermal_feedback"         : int
-        Switch (1) turns feedback from embedded BH on.
-    "flag_orb_ecc_damping"          : int
-        Switch (1) turns orb. ecc damping on.
-        If switch = 0, assumes all bh are circularized (at e=e_crit)
-    "capture_time_yr"              : float
-        Capture time in years Secunda et al. (2021) assume capture rate 1/0.1 Myr
-    "disk_radius_capture_outer"     : float
-        Disk capture outer radius (units of r_g)
-        Secunda et al. (2001) assume <2000r_g from Fabj et al. (2020)
-    "disk_bh_pro_orb_ecc_crit"      : float
-        Critical eccentricity (limiting eccentricity, below which assumed circular orbit)
-    "flag_dynamic_enc"              : int
-        Switch (1) turns dynamical encounters between embedded BH on.
-    "delta_energy_strong"           : float
-        Average energy change per strong interaction.
-        de can be 20% in cluster interactions. May be 10% on average (with gas)
-    "inner_disk_outer_radius"       : float
-        Outer radius of the inner disk (Rg)
-    "disk_inner_stable_circ_orb"    : float
-        Innermost Stable Circular Orbit around SMBH
-    "mass_pile_up"                  : float
-        Pile-up of masses caused by cutoff (M_sun)
 
 """
 
-# Things everyone needs
-import configparser as ConfigParser
-from io import StringIO
-from importlib import resources as impresources
 # Third party
-import numpy as np
-import scipy.interpolate
-# pAGN imports 
-import pagn.constants as pagn_ct
-# Local imports 
-import mcfacts.external.DiskModelsPAGN as dm_pagn
-from mcfacts.inputs import data as mcfacts_input_data
 from astropy import constants as ct
+# Local imports 
+from mcfacts.inputs.ReadInputs import INPUT_TYPES
 
 # Dictionary of types
 OUTPUT_TYPES = {
@@ -169,78 +39,32 @@ OUTPUT_TYPES = {
     "fname_output_mergers"          : str,
     "fname_output"                  : str,
     "fname_snapshots_bh"            : str,
-    "saves_snapshots"               : bool,
-    "verbose"                       : bool,
+    "verbose"                       : int,
     "work_directory"                : str,
     "seed"                          : int,
     "fname_log"                     : str,
     "runtime_directory"             : str,
-    "disk_model_name"               : str,
-    "flag_use_pagn"                 : bool,
-    "flag_add_stars"                : bool,
-    "flag_initial_stars_BH_immortal": bool,
-    "smbh_mass"                     : float,
-    "disk_radius_trap"              : float,
-    "disk_radius_outer"             : float,
-    "disk_radius_max_pc"            : float,
-    "disk_alpha_viscosity"          : float,
-    "nsc_radius_outer"              : float,
-    "nsc_mass"                      : float,
-    "nsc_radius_crit"               : float,
-    "nsc_ratio_bh_num_star_num"     : float,
-    "nsc_ratio_bh_mass_star_mass"   : float,
-    "nsc_density_index_inner"       : float,
-    "nsc_density_index_outer"       : float,
-    "disk_aspect_ratio_avg"         : float,
-    "nsc_spheroid_normalization"    : float,
-    "nsc_imf_bh_mode"               : float,
-    "nsc_imf_bh_powerlaw_index"     : float,
-    "nsc_imf_bh_mass_max"           : float,
-    "nsc_bh_spin_dist_mu"           : float,
-    "nsc_bh_spin_dist_sigma"        : float,
-    "disk_bh_torque_condition"      : float,
-    "disk_bh_eddington_ratio"       : float,
-    "disk_bh_orb_ecc_max_init"      : float,
-    "disk_star_mass_max_init"       : float,
-    "disk_star_mass_min_init"       : float,
-    "nsc_imf_star_powerlaw_index"   : float,
-    "disk_star_scale_factor"        : float,
-    "disk_star_initial_mass_cutoff" : float,
-    "nsc_imf_star_mass_mode"        : float,
-    "disk_star_torque_condition"    : float,
-    "disk_star_eddington_ratio"     : float,
-    "disk_star_orb_ecc_max_init"    : float,
-    "nsc_star_metallicity_x_init"   : float,
-    "nsc_star_metallicity_y_init"   : float,
-    "nsc_star_metallicity_z_init"   : float,
-    "timestep_duration_yr"          : float,
-    "timestep_num"                  : int,
-    "galaxy_num"                    : int,
-    "fraction_bin_retro"            : float,
-    "flag_thermal_feedback"         : int,
-    "flag_orb_ecc_damping"          : int,
-    "capture_time_yr"               : float,
-    "disk_radius_capture_outer"     : float,
-    "disk_bh_pro_orb_ecc_crit"      : float,
-    "flag_dynamic_enc"              : int,
-    "delta_energy_strong"           : float,
-    "inner_disk_outer_radius"       : float,
-    "disk_inner_stable_circ_orb"    : float,
-    "mass_pile_up"                  : float,
-    "save_snapshots"                : bool,
-    "mean_harden_energy_delta"      : float,
-    "var_harden_energy_delta"       : float
 }
+# Ensure none of the data types are bool to avoid issues casting ascii to boolean
+if bool in OUTPUT_TYPES.values():
+    raise ValueError("[ReadOutputs.py] Boolean data types are not allowed in"
+                     "the OUTPUT_TYPES dictionary. Please use int instead.")
 
-def ReadLog(fname_log, verbose=False):
+# Add the INPUT_TYPES to the OUTPUT_TYPES dictionary
+for key, value in INPUT_TYPES.items():
+    OUTPUT_TYPES[key] = value
+
+
+
+def ReadLog(fname_log, verbose=0):
     """Output log parser
 
     Parameters
     ----------
     fname_log : str
         Path and name to the log file from a McFACTS run
-    verbose : bool, optional
-        Print extra info, by default False
+    verbose : int, optional
+        Print extra info, by default 0
     """
 
     # Read in the file
@@ -258,10 +82,9 @@ def ReadLog(fname_log, verbose=False):
         # Strip the values of any whitespace
         key = key.strip()
         value = value.strip()
+        print(key, value)
         # Convert the values
         if key in OUTPUT_TYPES:
-            log_dict[key] = OUTPUT_TYPES[key](value)
-        else:
             log_dict[key] = value
             extra_values[key] = value
         
@@ -270,6 +93,7 @@ def ReadLog(fname_log, verbose=False):
         for key, value in log_dict.items():
             print(f"{key}: {value}")
 
+    # Warning if extra values are found
     if len(extra_values) > 0:
         print(f"~~~~~~~~~~~~~~~~~~~~~~\n",
                "[ReadLog] Warning!: The log file you're using contains additional\n",

--- a/src/mcfacts/outputs/ReadOutputs.py
+++ b/src/mcfacts/outputs/ReadOutputs.py
@@ -82,7 +82,6 @@ def ReadLog(fname_log, verbose=0):
         # Strip the values of any whitespace
         key = key.strip()
         value = value.strip()
-        print(key, value)
         # Convert the values
         if key in OUTPUT_TYPES:
             log_dict[key] = value
@@ -96,7 +95,7 @@ def ReadLog(fname_log, verbose=0):
     # Warning if extra values are found
     if len(extra_values) > 0:
         print(f"~~~~~~~~~~~~~~~~~~~~~~\n",
-               "[ReadLog] Warning!: The log file you're using contains additional\n",
+               "[ReadOutputs.py] Warning!: The log file you're using contains additional\n",
                "entries not found in OUTPUT_TYPES. They have been added to the log\n",
                "dictionary as a STRING type. Please verify their types before you\n",
                "use them in your analysis or add them to the OUTPUT_TYPES dictionary.")

--- a/src/mcfacts/outputs/ReadOutputs.py
+++ b/src/mcfacts/outputs/ReadOutputs.py
@@ -84,7 +84,10 @@ def ReadLog(fname_log, verbose=0):
         value = value.strip()
         # Convert the values
         if key in OUTPUT_TYPES:
-            log_dict[key] = value
+            log_dict[key] = OUTPUT_TYPES[key](value)
+        # Store unexpected lines to report below
+        if not (key in OUTPUT_TYPES):
+            log_dict[key] = OUTPUT_TYPES[key](value)
             extra_values[key] = value
         
     # Print the dictionary
@@ -95,9 +98,9 @@ def ReadLog(fname_log, verbose=0):
     # Warning if extra values are found
     if len(extra_values) > 0:
         print(f"~~~~~~~~~~~~~~~~~~~~~~\n",
-               "[ReadOutputs.py] Warning!: The log file you're using contains additional\n",
-               "entries not found in OUTPUT_TYPES. They have been added to the log\n",
-               "dictionary as a STRING type. Please verify their types before you\n",
+               f"[ReadOutputs.py] Warning!: The log file you're using contains {len(extra_values)} additional"
+               "entries not found in OUTPUT_TYPES. They have been added to the log"
+               "dictionary as a STRING type. Please verify their types before you"
                "use them in your analysis or add them to the OUTPUT_TYPES dictionary.")
         for key, value in extra_values.items():
             print(f"  {key}: {value}")

--- a/src/mcfacts/physics/gw.py
+++ b/src/mcfacts/physics/gw.py
@@ -28,7 +28,7 @@ def gw_strain_freq(mass_1, mass_2, obj_sep, timestep_duration_yr, old_gw_freq, s
         Mass [M_sun] of the SMBH
     agn_redshift : float
         Redshift [unitless] of the SMBH
-    flag_include_old_gw_freq : boolean
+    flag_include_old_gw_freq : int
         Flag indicating if old_gw_freq should be included in calculations
         if not, we use the hardcoded value (see note below)
         0 if no, 1 if yes


### PR DESCRIPTION
#### Summary
I made a new module to read output files. For now, it contains one function to read the McFACTS log file and is currently used in `/scripts/population_plots.py`.

##### Details
1. Create a new module file `src/mcfacts/outputs/ReadOutputs.py` containing the `ReadLog` function.
2. Log file name is now consistent across McFACTS. Previously we had cases of `out.log` and `mcfacts_sim.log`. I implemented `mcfacts.log` as the standard. Users still have the option to customize this.
3. The `scripts/population_plots.py` plotting routine uses the new log dictionary, and all radial distributions now include a vertical line at the trap radius. 

##### Possible Tests for Reviewer
The `ReadLog` function generates a dictionary using pre-defined types since the log file contains multiple types. If the log file contains extra keys that are not known to the code, they will still be added but as a string type with a warning communicating this to the user. Test this by adding these lines to a default McFACTS run log file, importing the function into a python environment, and passing the file to the function.
```
flag_bh_are_cool: True
love_factor: 1.4
num_aliens: 10000
```