### PR TITLE
Fixed CubicSpline bug in torque coefficient calculations

### DIFF
--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -5,7 +5,7 @@
 # See IOdocumentation.txt for details.
 #
 # SMBH mass in units of M_sun:
-smbh_mass = 1.e7
+smbh_mass = 1.e8
 #
 # SMBH accretion disk:
 #

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -613,13 +613,10 @@ def main():
                     opts.disk_radius_outer,
                     opts.timestep_duration_yr
                 )
-
             # Alternatively, calculate actual torques from disk profiles.
             # Paardekooper torque coeff (default)
             if opts.torque_prescription == 'paardekooper':
                 paardekooper_torque_coeff = migration.paardekooper10_torque(
-                    opts.smbh_mass,
-                    disk_surface_density_log,
                     disk_surface_density,
                     temp_func,
                     blackholes_pro.orb_a,
@@ -1337,12 +1334,8 @@ def main():
                 #Paardekooper torque coeff (default)
                 if opts.torque_prescription == 'paardekooper':
                     paardekooper_torque_coeff = migration.paardekooper10_torque_binary(
-                        opts.smbh_mass,
-                        disk_surface_density_log,
                         disk_surface_density,
                         temp_func,
-                        blackholes_pro.orb_a,
-                        blackholes_pro.orb_ecc,
                         opts.disk_bh_pro_orb_ecc_crit,
                         blackholes_binary,
                         opts.disk_radius_outer,
@@ -1420,8 +1413,6 @@ def main():
                                 disk_trap_radius = opts.disk_radius_trap * (opts.smbh_mass/1.e8)**(-0.97)
                                 disk_anti_trap_radius = opts.disk_radius_trap * (opts.smbh_mass/1.e8)**(0.099)
 
-
-
                         torque_mig_timescales = migration.torque_mig_timescale(
                             opts.smbh_mass,
                             blackholes_binary.bin_orb_a,
@@ -1449,7 +1440,6 @@ def main():
                             opts.nsc_imf_bh_mode,
                             opts.torque_prescription
                         )
-
 
                 # Update filing cabinet
                 filing_cabinet.update(id_num=blackholes_binary.id_num,

--- a/src/mcfacts/physics/migration.py
+++ b/src/mcfacts/physics/migration.py
@@ -6,146 +6,108 @@ import numpy as np
 import astropy.constants as const
 import astropy.units as u
 from mcfacts.mcfacts_random_state import rng
+from mcfacts.physics.point_masses import si_from_r_g
 import scipy
 
 
-def paardekooper10_torque(smbh_mass, disk_surf_density_func_log, disc_surf_density, temp_func, orbs_a, orbs_ecc, orb_ecc_crit, disk_radius_outer, disk_inner_stable_circ_orb):
+def paardekooper10_torque(disc_surf_density, temp_func, orbs_a, orbs_ecc, orb_ecc_crit, disk_radius_outer, disk_inner_stable_circ_orb):
     """Return the Paardekooper (2010) torque coefficient for Type 1 migration
         Paardekooper_Coeff = [-0.85+0.9dTdR +dSigmadR]
     """
 
-    #Need to have at least 2 elements in sorted_log_orbs_a below.
-    # If insufficient elements, generate a new sorted range of default 100 pts across [disk_inner_radius,disk_outer_radius]
-    if np.size(orbs_a) < 100:
-        orbs_a = np.linspace(10*disk_inner_stable_circ_orb,disk_radius_outer,num=100)
-        #sorted_log_orbs_a = np.log10(sorted_orbs_a)
-    #Sort the radii of BH and get their log (radii)
-    sorted_orbs_a = np.sort(orbs_a)
-    #Prevent accidental zeros or Nans!
-    log_orbs_a = np.log10(orbs_a)
-    sorted_log_orbs_a = np.sort(log_orbs_a)
+    # generate a new sorted range of default 100 pts across [disk_inner_radius,disk_outer_radius]
+    disk_radius_arr = np.linspace(3*disk_inner_stable_circ_orb, disk_radius_outer, num=100)
+    # Prevent accidental zeros or Nans!
+    log_disk_radius_arr = np.log10(disk_radius_arr)
 
-    #sorted_log_orbs_a = np.nan_to_num(sorted_log_orbs_a)
     # Migration only occurs for sufficiently damped orbital ecc. If orb_ecc <= ecc_crit, then migrate.
     # Otherwise no change in semi-major axis (orb_a).
     # Get indices of objects with orb_ecc <= ecc_crit so we can only update orb_a for those.
     migration_indices = np.asarray(orbs_ecc <= orb_ecc_crit).nonzero()[0]
 
-
     # If nothing will migrate then end the function
     if migration_indices.shape == (0,):
-    #    return (orbs_a)
         return ()
     # If things will migrate then copy over the orb_a of objects that will migrate
     new_orbs_a = orbs_a[migration_indices].copy()
 
-
     log_new_orbs_a = np.log10(new_orbs_a)
-    #Evaluate disc surf density at locations of all BH
-    #disc_surf_d = disc_surf_density(orbs_a)
-    disc_surf_d = disc_surf_density(sorted_orbs_a)
-    disc_temp=np.nan_to_num(temp_func(sorted_orbs_a))
-    disc_temp=np.abs(disc_temp)
-    #Evaluate disc surf density at only migrating BH
-    disc_surf_d_mig = disc_surf_density(new_orbs_a)
-    #Get log of disc surf density
+    # Evaluate disc surf density at locations of all BH
+    disc_surf_d = disc_surf_density(disk_radius_arr)
+    disc_temp = np.nan_to_num(temp_func(disk_radius_arr))
+    disc_temp = np.abs(disc_temp)
+    # Get log of disc surf density
     log_disc_surf_d = np.log10(disc_surf_d)
     log_disc_surf_d = np.nan_to_num(log_disc_surf_d)
-    #Get log of disc midplane temperature
-    #print("disc_temp",disc_temp)
+    # Get log of disc midplane temperature
     log_disc_temp = np.log10(disc_temp)
 
-    log_disc_surf_d_mig = np.log10(disc_surf_d_mig)
-    sort_log_orbs_a =np.sort(log_new_orbs_a)
-
-
-    Sigmalog_spline = scipy.interpolate.CubicSpline(sorted_log_orbs_a, log_disc_surf_d, extrapolate=False)
-    Templog_spline = scipy.interpolate.CubicSpline(sorted_log_orbs_a, log_disc_temp, extrapolate=False)
-    #Find derivates of Sigmalog_spline
+    Sigmalog_spline = scipy.interpolate.CubicSpline(log_disk_radius_arr, log_disc_surf_d, extrapolate=False)
+    Templog_spline = scipy.interpolate.CubicSpline(log_disk_radius_arr, log_disc_temp, extrapolate=False)
+    # Find derivates of Sigmalog_spline
     dSigmadR_spline = Sigmalog_spline.derivative()
     dTempdR_spline = Templog_spline.derivative()
-    #Evaluate dSigmadR_spline at the migrating orb_a values
+    # Evaluate dSigmadR_spline at the migrating orb_a values
     dSigmadR = dSigmadR_spline(log_new_orbs_a)
     dTempdR = dTempdR_spline(log_new_orbs_a)
-    #sortdSigmadR = dSigmadR_spline(sort_log_orbs_a)
 
-    #print("dSigmadR", dSigmadR)
-    #print("dTempdR", dTempdR)
-    #print("sortdSigmadR",sortdSigmadR)
-    #print("log_new_orbs_a",log_new_orbs_a)
-    #print("sorted_log_new_orbs_a",sort_log_orbs_a)
+    Torque_paardekooper_coeff = -0.85 + dSigmadR + (0.9 * dTempdR)
 
-    Torque_paardekooper_coeff = -0.85 + dSigmadR +0.9*dTempdR
+    assert np.all(~np.isnan(Torque_paardekooper_coeff))
 
     return Torque_paardekooper_coeff
 
-def paardekooper10_torque_binary(smbh_mass, disk_surf_density_func_log, disc_surf_density, temp_func, orbs_a, orbs_ecc, orb_ecc_crit, blackholes_binary,disk_radius_outer,disk_inner_stable_circ_orb):
+
+def paardekooper10_torque_binary(disc_surf_density, temp_func, orb_ecc_crit, blackholes_binary, disk_radius_outer, disk_inner_stable_circ_orb):
     """Return the Paardekooper (2010) torque coefficient for Type 1 migration for binaries
         Paardekooper_Coeff = [-0.85+0.9dTdR +dSigmadR]
     """
-    #Find the semi-major axis locations of the binaries
+    # Find the semi-major axis locations of the binaries
     bin_orb_a = blackholes_binary.bin_orb_a
-    #Find the eccentricities of the binaries
+    # Find the eccentricities of the binaries
     bin_orb_ecc = blackholes_binary.bin_orb_ecc
 
-    #Need to have at least 2 elements in sorted_log_orbs_a below.
-    # If insufficient elements, generate a new sorted range of default 100 pts across [disk_inner_radius,disk_outer_radius]
-    if np.size(orbs_a) < 100:
-        orbs_a = np.linspace(10*disk_inner_stable_circ_orb,disk_radius_outer,num=100)
-    #Sort the radii of BH and get their log (radii)
-    sorted_orbs_a = np.sort(orbs_a)
-    log_orbs_a = np.log10(orbs_a)
-    sorted_log_orbs_a = np.sort(log_orbs_a)
+    # generate a new sorted range of default 100 pts across [disk_inner_radius,disk_outer_radius]
+    disk_radius_arr = np.linspace(3*disk_inner_stable_circ_orb, disk_radius_outer, num=100)
+    log_disk_radius_arr = np.log10(disk_radius_arr)
 
     # Migration only occurs for sufficiently damped orbital ecc. If orb_ecc <= ecc_crit, then migrate.
     # Otherwise no change in semi-major axis (orb_a).
     # Get indices of objects with orb_ecc <= ecc_crit so we can only update orb_a for those.
     migration_indices = np.asarray(bin_orb_ecc <= orb_ecc_crit).nonzero()[0]
 
-
     # If nothing will migrate then end the function
     if migration_indices.shape == (0,):
-    #    return (orbs_a)
         return ()
     # If things will migrate then copy over the orb_a of objects that will migrate
     new_orbs_a = bin_orb_a[migration_indices].copy()
 
     log_new_orbs_a = np.log10(new_orbs_a)
-    #Evaluate disc surf density at locations of all BH
-    #disc_surf_d = disc_surf_density(orbs_a)
-    disc_surf_d = disc_surf_density(sorted_orbs_a)
-    disc_temp=temp_func(sorted_orbs_a)
-    #Evaluate disc surf density at only migrating BH
-    disc_surf_d_mig = disc_surf_density(new_orbs_a)
-    #Get log of disc surf density
+    # Evaluate disc surf density at locations of all BH
+    disc_surf_d = disc_surf_density(disk_radius_arr)
+    disc_temp = temp_func(disk_radius_arr)
+    # Get log of disc surf density
     log_disc_surf_d = np.log10(disc_surf_d)
-    #Get log of disc midplane temperature
+    # Get log of disc midplane temperature
     log_disc_temp = np.log10(disc_temp)
 
-    log_disc_surf_d_mig = np.log10(disc_surf_d_mig)
-    sort_log_orbs_a =np.sort(log_new_orbs_a)
-
-    Sigmalog_spline = scipy.interpolate.CubicSpline(sorted_log_orbs_a, log_disc_surf_d, extrapolate=False)
-    Templog_spline = scipy.interpolate.CubicSpline(sorted_log_orbs_a, log_disc_temp, extrapolate=False)
-    #Find derivates of Sigmalog_spline
+    Sigmalog_spline = scipy.interpolate.CubicSpline(log_disk_radius_arr, log_disc_surf_d, extrapolate=False)
+    Templog_spline = scipy.interpolate.CubicSpline(log_disk_radius_arr, log_disc_temp, extrapolate=False)
+    # Find derivates of Sigmalog_spline
     dSigmadR_spline = Sigmalog_spline.derivative()
     dTempdR_spline = Templog_spline.derivative()
-    #Evaluate dSigmadR_spline at the migrating orb_a values
+    # Evaluate dSigmadR_spline at the migrating orb_a values
     dSigmadR = dSigmadR_spline(log_new_orbs_a)
     dTempdR = dTempdR_spline(log_new_orbs_a)
-    #sortdSigmadR = dSigmadR_spline(sort_log_orbs_a)
 
-    #print("dSigmadR", dSigmadR)
-    #print("dTempdR", dTempdR)
-    #print("sortdSigmadR",sortdSigmadR)
-    #print("log_new_orbs_a",log_new_orbs_a)
-    #print("sorted_log_new_orbs_a",sort_log_orbs_a)
+    Torque_paardekooper_coeff = -0.85 + dSigmadR + (0.9 * dTempdR)
 
-    Torque_paardekooper_coeff = -0.85 + dSigmadR +0.9*dTempdR
+    assert np.all(~np.isnan(Torque_paardekooper_coeff))
 
     return Torque_paardekooper_coeff
 
-def normalized_torque(smbh_mass,orbs_a,masses, orbs_ecc, orb_ecc_crit,disk_surf_density_func,disk_aspect_ratio_func):
+
+def normalized_torque(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, disk_surf_density_func, disk_aspect_ratio_func):
     """Calculates the normalized torque from e.g. Grishin et al. '24
     Gamma_0 = (q/h)^2 * Sigma* a^4 * Omega^2
         where q= mass_of_bh/smbh_mass, h= disk aspect ratio at location of bh (a_bh),
@@ -170,9 +132,7 @@ def normalized_torque(smbh_mass,orbs_a,masses, orbs_ecc, orb_ecc_crit,disk_surf_
         can accept a simple float (constant), but this is deprecated
 
     """
-    #M_sun =2.e30kg
-    m_sun = 2.0*10**(30)
-    smbh_mass_in_kg = smbh_mass * m_sun
+    smbh_mass_in_kg = smbh_mass * u.Msun.to("kg")
     # Migration only occurs for sufficiently damped orbital ecc. If orb_ecc <= ecc_crit, then migrate.
     # Otherwise no change in semi-major axis (orb_a).
     # Get indices of objects with orb_ecc <= ecc_crit so we can only update orb_a for those.
@@ -197,16 +157,20 @@ def normalized_torque(smbh_mass,orbs_a,masses, orbs_ecc, orb_ecc_crit,disk_surf_
         disk_aspect_ratio = disk_aspect_ratio_func(orbs_a)[migration_indices]
     # find mass ratios
     mass_ratios = (masses[migration_indices]/smbh_mass)
-    #Convert orb_a of migrating BH to meters. r_g =GM_smbh/c^2.
+    # Convert orb_a of migrating BH to meters. r_g =GM_smbh/c^2.
     # Usefully, 1_rg=GM_smbh/c^2= 6.7e-11*2.e38/(9e16)~1.5e11m=1AU
     orb_a_in_meters = new_orbs_a*smbh_mass_in_kg*scipy.constants.G / (scipy.constants.c)**(2.0)
-    #Omega of migrating BH
+    # Omega of migrating BH
     Omega_bh = np.sqrt(scipy.constants.G * smbh_mass_in_kg/((orb_a_in_meters)**(3.0)))
-    #Normalized torque = (q/h)^2 * Sigma * a^4 * Omega^2
+    # Normalized torque = (q/h)^2 * Sigma * a^4 * Omega^2
     normalized_torque = ((mass_ratios/disk_aspect_ratio)**(2.0))*disk_surface_density*((orb_a_in_meters)**(4.0))*(Omega_bh**(2.0))
+
+    assert np.all(~np.isnan(normalized_torque))
+
     return normalized_torque
 
-def torque_mig_timescale(smbh_mass,orbs_a,masses, orbs_ecc, orb_ecc_crit,migration_torque):
+
+def torque_mig_timescale(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, migration_torque):
     """Calculates the migration timescale using an input migration torque
     t_mig = a/-(dot(a)) where dot(a)=-2aGamma_tot/L so
     t_mig = L/2Gamma_tot
@@ -232,9 +196,7 @@ def torque_mig_timescale(smbh_mass,orbs_a,masses, orbs_ecc, orb_ecc_crit,migrati
 
 
     """
-    #M_sun =2.e30kg
-    m_sun = 2.0*10**(30)
-    smbh_mass_in_kg = smbh_mass * m_sun
+    smbh_mass_in_kg = smbh_mass * u.Msun.to("kg")
     # Migration only occurs for sufficiently damped orbital ecc. If orb_ecc <= ecc_crit, then migrate.
     # Otherwise no change in semi-major axis (orb_a).
     # Get indices of objects with orb_ecc <= ecc_crit so we can only update orb_a for those.
@@ -265,11 +227,15 @@ def torque_mig_timescale(smbh_mass,orbs_a,masses, orbs_ecc, orb_ecc_crit,migrati
     #Omega of migrating BH in s^-1
     Omega_bh = np.sqrt(scipy.constants.G * smbh_mass_in_kg/((orb_a_in_meters)**(3.0)))
     #masses of BH in kg
-    bh_masses = m_sun*masses[migration_indices]
+    bh_masses = u.Msun.to("kg")*masses[migration_indices]
     #Normalized torque = (q/h)^2 * Sigma * a^4 * Omega^2 (in units of seconds)
     torque_mig_timescale = bh_masses*Omega_bh*((orb_a_in_meters)**(2.0))/(2.0*migration_torque)
     #print("torque_mig_timescale",torque_mig_timescale)
+
+    assert np.all(~np.isnan(torque_mig_timescale))
+
     return torque_mig_timescale
+
 
 def jiminezmasset17_torque(smbh_mass, disc_surf_density, disk_opacity_func, disk_aspect_ratio_func, temp_func, orbs_a, orbs_ecc, orb_ecc_crit, disk_radius_outer, disk_inner_stable_circ_orb):
     """Return the Jiminez & Masset (2017) torque coefficient for Type 1 migration
@@ -287,106 +253,80 @@ def jiminezmasset17_torque(smbh_mass, disc_surf_density, disk_opacity_func, disk
                 so rho^2H^4 = (rho*H)^2*H^2 = Sigma^2 (a*h)^2 and so
                 x=(16/3)*gamma*(gamma-1)*sigma_SB*T^4/kappa*Sigma^2*a^2*h^2*Omega^3
     """
-    #Constants
-    #Define adiabatic index (assume monatomic gas)
-    gamma=5./3.
-    #Stefan-Boltzmann constant
+    # Constants
+    # Define adiabatic index (assume monatomic gas)
+    gamma = 5./3.
+    # Stefan-Boltzmann constant
     sigma_SB = scipy.constants.Stefan_Boltzmann
-    #M_sun =2.e30kg
-    m_sun = 2.0*10**(30)
-    smbh_mass_in_kg = smbh_mass * m_sun
+    smbh_mass_in_kg = smbh_mass * u.Msun.to("kg")
 
-    #Need to have at least 2 elements in sorted_log_orbs_a below.
-    # If insufficient elements, generate a new sorted range of default 100 pts across [disk_inner_radius,disk_outer_radius]
-    if np.size(orbs_a) < 100:
-        orbs_a = np.linspace(10*disk_inner_stable_circ_orb,disk_radius_outer,num=100)
-    #Sort the radii of BH and get their log (radii)
-    sorted_orbs_a = np.sort(orbs_a)
-    log_orbs_a = np.log10(orbs_a)
-    sorted_log_orbs_a = np.sort(log_orbs_a)
+    # generate a new sorted range of default 100 pts across [disk_inner_radius,disk_outer_radius]
+    disk_radius_arr = np.linspace(3*disk_inner_stable_circ_orb, disk_radius_outer, num=100)
+    log_disk_radius_arr = np.log10(disk_radius_arr)
 
     # Migration only occurs for sufficiently damped orbital ecc. If orb_ecc <= ecc_crit, then migrate.
     # Otherwise no change in semi-major axis (orb_a).
     # Get indices of objects with orb_ecc <= ecc_crit so we can only update orb_a for those.
     migration_indices = np.asarray(orbs_ecc <= orb_ecc_crit).nonzero()[0]
 
-
     # If nothing will migrate then end the function
     if migration_indices.shape == (0,):
-    #    return (orbs_a)
         return ()
     # If things will migrate then copy over the orb_a of objects that will migrate
     new_orbs_a = orbs_a[migration_indices].copy()
-
 
     if isinstance(disk_aspect_ratio_func, float):
         disk_aspect_ratio = disk_aspect_ratio_func
     else:
         disk_aspect_ratio = disk_aspect_ratio_func(orbs_a)[migration_indices]
 
-    #Convert migrating orbs_a to meters
-    #Convert orb_a of migrating BH to meters. r_g =GM_smbh/c^2.
+    # Convert migrating orbs_a to meters
+    # Convert orb_a of migrating BH to meters. r_g =GM_smbh/c^2.
     # Usefully, 1_rg=GM_smbh/c^2= 6.7e-11*2.e38/(9e16)~1.5e11m=1AU
-    orb_a_in_meters = new_orbs_a*smbh_mass_in_kg*scipy.constants.G / (scipy.constants.c)**(2.0)
-    #Omega of migrating BH in s^-1
+    orb_a_in_meters = si_from_r_g(smbh_mass, new_orbs_a).to("m").value
+    # Omega of migrating BH in s^-1
     Omega_bh = np.sqrt(scipy.constants.G * smbh_mass_in_kg/((orb_a_in_meters)**(3.0)))
 
     log_new_orbs_a = np.log10(new_orbs_a)
-    #Evaluate disc surf density at locations of all BH
-    disc_surf_d = disc_surf_density(sorted_orbs_a)
-    #Evaluate disc temp at locations of all BH
-    disc_temp = temp_func(sorted_orbs_a)
-    #Evaluate disc opacity at locations of all BH
-    disc_opacity = disk_opacity_func(sorted_orbs_a)
+    # Evaluate disc surf density at locations of all BH
+    disc_surf_d = disc_surf_density(disk_radius_arr)
+    # Evaluate disc temp at locations of all BH
+    disc_temp = temp_func(disk_radius_arr)
 
-    #For migrating BH
-    #Evaluate disc surf density at only migrating BH
+    # For migrating BH
+    # Evaluate disc surf density at only migrating BH
     disc_surf_d_mig = disc_surf_density(new_orbs_a)
-    #Get log of disc surf density
+    # Get log of disc surf density
     log_disc_surf_d = np.log10(disc_surf_d)
-    #Get log of disc midplane temperature
+    # Get log of disc midplane temperature
     log_disc_temp = np.log10(disc_temp)
-    #Get log of disc opacity
-    log_disc_opacity = np.log10(disc_opacity)
 
-    log_disc_surf_d_mig = np.log10(disc_surf_d_mig)
-    sort_log_orbs_a =np.sort(log_new_orbs_a)
-
-
-    Sigmalog_spline = scipy.interpolate.CubicSpline(sorted_log_orbs_a, log_disc_surf_d, extrapolate=False)
-    Templog_spline = scipy.interpolate.CubicSpline(sorted_log_orbs_a, log_disc_temp, extrapolate=False)
-    Opacity_spline = scipy.interpolate.CubicSpline(sorted_log_orbs_a, log_disc_opacity, extrapolate=False)
-    #Find derivates of Sigmalog_spline
+    Sigmalog_spline = scipy.interpolate.CubicSpline(log_disk_radius_arr, log_disc_surf_d, extrapolate=False)
+    Templog_spline = scipy.interpolate.CubicSpline(log_disk_radius_arr, log_disc_temp, extrapolate=False)
+    # Find derivates of Sigmalog_spline
     dSigmadR_spline = Sigmalog_spline.derivative()
     dTempdR_spline = Templog_spline.derivative()
-    #Evaluate dSigmadR_spline at the migrating orb_a values
+    # Evaluate dSigmadR_spline at the migrating orb_a values
     dSigmadR = dSigmadR_spline(log_new_orbs_a)
-    #Evaluate dTempdR_spline at the migrating orb_a values
+    # Evaluate dTempdR_spline at the migrating orb_a values
     dTempdR = dTempdR_spline(log_new_orbs_a)
-    #Evaluate log disk opacity at the migrating orb_a values
-    ln_kappa = Opacity_spline(log_new_orbs_a)
-    #Find actual disk opacity at migrating orb_a values
-    kappa = np.exp(ln_kappa)
-    #Evaluate temp at the migrating orb_a values
+    # Evaluate temp at the migrating orb_a values
     temp_migrators = temp_func(new_orbs_a)
-    #Evaluate opacity at the migrating orb_a values
+    # Evaluate opacity at the migrating orb_a values
     opacity_migrators = disk_opacity_func(new_orbs_a)
 
     xfactor_1 = (16./3.)*gamma*(gamma-1.0)*sigma_SB*(temp_migrators**(4.0))
-    xfactor_2 =opacity_migrators*(disc_surf_d_mig**(2.0))*(disk_aspect_ratio**(2.0))*(orb_a_in_meters**(2.0))*(Omega_bh**(3.0))
+    xfactor_2 = opacity_migrators * (disc_surf_d_mig**(2.0))*(disk_aspect_ratio**(2.0))*(orb_a_in_meters**(2.0))*(Omega_bh**(3.0))
     xfactor = xfactor_1/xfactor_2
     sqrtfactor = np.sqrt(xfactor/2)
     factor = (sqrtfactor + 1.0/gamma)/(sqrtfactor + 1.0)
 
-    #print("dSigmadR", dSigmadR)
-    #print("dTempdR", dTempdR)
-    #print("sortdSigmadR",sortdSigmadR)
-    #print("log_new_orbs_a",log_new_orbs_a)
-    #print("sorted_log_new_orbs_a",sort_log_orbs_a)
+    Torque_jiminezmasset_coeff = (0.46 + 0.96 * dSigmadR - 1.8 * dTempdR)/gamma + (-2.34 - 0.1*dSigmadR + 1.5 * dTempdR) * factor
 
-    Torque_jiminezmasset_coeff = (0.46 + 0.96*dSigmadR -1.8*dTempdR)/gamma + (-2.34 - 0.1*dSigmadR + 1.5*dTempdR)*factor
+    assert np.all(~np.isnan(Torque_jiminezmasset_coeff))
 
     return Torque_jiminezmasset_coeff
+
 
 def jiminezmasset17_thermal_torque_coeff(smbh_mass, disc_surf_density, disk_opacity_func, disk_aspect_ratio_func, temp_func, sound_speed_func, density_func, disk_bh_eddington_ratio, orbs_a, orbs_ecc, orb_ecc_crit, bh_masses, flag_thermal_feedback, disk_radius_outer, disk_inner_stable_circ_orb):
     """Return the Jiminez & Masset (2017) thermal torque coefficient for Type 1 migration
@@ -417,37 +357,26 @@ def jiminezmasset17_thermal_torque_coeff(smbh_mass, disc_surf_density, disk_opac
     if flag_thermal_feedback == 0:
         return ()
 
-
-    #Constants
-    #Define adiabatic index (assume monatomic gas)
-    gamma=5.0/3.0
-    #kappa electron scattering
+    # Constants
+    # Define adiabatic index (assume monatomic gas)
+    gamma = 5.0/3.0
+    # kappa electron scattering
     kappa_e_scattering = 0.7
-    #Stefan-Boltzmann constant
+    # Stefan-Boltzmann constant
     sigma_SB = scipy.constants.Stefan_Boltzmann
-    #M_sun =2.e30kg
-    m_sun = 2.0*10**(30)
-    smbh_mass_in_kg = smbh_mass * m_sun
+    smbh_mass_in_kg = smbh_mass * u.Msun.to("kg")
 
-    #Need to have at least 2 elements in sorted_log_orbs_a below.
-    # If insufficient elements, generate a new sorted range of default 100 pts across [disk_inner_radius,disk_outer_radius]
-    if np.size(orbs_a) < 100:
-        orbs_a = np.linspace(10*disk_inner_stable_circ_orb,disk_radius_outer,num=100)
-
-    #Sort the radii of BH and get their log (radii)
-    sorted_orbs_a = np.sort(orbs_a)
-    log_orbs_a = np.log10(orbs_a)
-    sorted_log_orbs_a = np.sort(log_orbs_a)
+    # generate a new sorted range of default 100 pts across [disk_inner_radius,disk_outer_radius]
+    disk_radius_arr = np.linspace(3*disk_inner_stable_circ_orb, disk_radius_outer, num=100)
+    log_disk_radius_arr = np.log10(disk_radius_arr)
 
     # Migration only occurs for sufficiently damped orbital ecc. If orb_ecc <= ecc_crit, then migrate.
     # Otherwise no change in semi-major axis (orb_a).
     # Get indices of objects with orb_ecc <= ecc_crit so we can only update orb_a for those.
     migration_indices = np.asarray(orbs_ecc <= orb_ecc_crit).nonzero()[0]
 
-
     # If nothing will migrate then end the function
     if migration_indices.shape == (0,):
-    #    return (orbs_a)
         return ()
     # If things will migrate then copy over the orb_a of objects that will migrate
     new_orbs_a = orbs_a[migration_indices].copy()
@@ -464,105 +393,103 @@ def jiminezmasset17_thermal_torque_coeff(smbh_mass, disc_surf_density, disk_opac
     # Omega of migrating BH in s^-1
     Omega_bh = np.sqrt(scipy.constants.G * smbh_mass_in_kg/((orb_a_in_meters)**(3.0)))
 
-    #Height of disk in meters  H=orb_a_in_meters*disk_aspect_ratio
+    # Height of disk in meters  H=orb_a_in_meters*disk_aspect_ratio
     disk_height_in_meters = orb_a_in_meters*disk_aspect_ratio
-    #disk_height_in_meters_squared
+    # disk_height_in_meters_squared
     disk_height_m_sq = disk_height_in_meters * disk_height_in_meters
     # sound speed at location of migrating BH in m/s  (c_s = H*Omega_bh)
     sound_speed = disk_height_in_meters*Omega_bh
-    #print("sound_speed",sound_speed)
 
     # BH masses in kg
-    bh_masses_in_kg = bh_masses[migration_indices]*m_sun
+    bh_masses_in_kg = bh_masses[migration_indices]*u.Msun.to("kg")
     # Bondi radii for migrating BH
     r_bondi = scipy.constants.G*bh_masses_in_kg/(sound_speed**2.0)
-    #If r_bondi for a migrating BH is > disk_height, set effective Bondi radius to disk height
+    # If r_bondi for a migrating BH is > disk_height, set effective Bondi radius to disk height
     effective_bondi_radius = np.where(r_bondi < disk_height_in_meters, r_bondi, disk_height_in_meters)
     # Luminosity of migrating BH
     lum = disk_bh_eddington_ratio*4.0*np.pi*scipy.constants.G*bh_masses_in_kg*scipy.constants.c/kappa_e_scattering
 
     log_new_orbs_a = np.log10(new_orbs_a)
-    #Evaluate disc surf density at locations of all BH
-    disc_surf_d = disc_surf_density(sorted_orbs_a)
-    #Evaluate disc temp at locations of all BH
-    disc_temp = temp_func(sorted_orbs_a)
-    #Evaluate disc opacity at locations of all BH
-    disc_opacity = disk_opacity_func(sorted_orbs_a)
-    #Evaluate disc sound speed at locations of all BH
-    disk_sound_speed = sound_speed_func(sorted_orbs_a)
-    #Evaluate disc density at locations of all BH
-    disk_density = density_func(sorted_orbs_a)
-    #Disc total pressure midplane is c_s^2/rho
+    # Evaluate disc surf density at locations of all BH
+    disc_surf_d = disc_surf_density(disk_radius_arr)
+    # Evaluate disc temp at locations of all BH
+    disc_temp = temp_func(disk_radius_arr)
+    # Evaluate disc opacity at locations of all BH
+    disc_opacity = disk_opacity_func(disk_radius_arr)
+    # Evaluate disc sound speed at locations of all BH
+    disk_sound_speed = sound_speed_func(disk_radius_arr)
+    # Evaluate disc density at locations of all BH
+    disk_density = density_func(disk_radius_arr)
+    # Disc total pressure midplane is c_s^2/rho
     disk_midplane_Pressure = (disk_sound_speed**2.0)/disk_density
 
-    #For migrating BH
-    #Evaluate disc surf density at only migrating BH
+    # For migrating BH
+    # Evaluate disc surf density at only migrating BH
     disc_surf_d_mig = disc_surf_density(new_orbs_a)
-    #Evaluate sound speed at only migrating BH
+    # Evaluate sound speed at only migrating BH
     disc_sound_speed = sound_speed
-    #Get log of disc surf density
+    # Get log of disc surf density
     log_disc_surf_d = np.log10(disc_surf_d)
-    #Get log of disc midplane temperature
+    # Get log of disc midplane temperature
     log_disc_temp = np.log10(disc_temp)
-    #Get log of disc opacity
+    # Get log of disc opacity
     log_disc_opacity = np.log10(disc_opacity)
-    #Log of disk midplane pressure
+    # Log of disk midplane pressure
     log_midplane_pressure = np.log10(disk_midplane_Pressure)
 
     log_disc_surf_d_mig = np.log10(disc_surf_d_mig)
-    sort_log_orbs_a =np.sort(log_new_orbs_a)
+    sort_log_orbs_a = np.sort(log_new_orbs_a)
 
-
-
-    Pressurelog_spline = scipy.interpolate.CubicSpline(sorted_log_orbs_a, log_midplane_pressure, extrapolate=False)
-    #Find derivative of Pressurelog_spline
+    Pressurelog_spline = scipy.interpolate.CubicSpline(log_disk_radius_arr, log_midplane_pressure, extrapolate=False)
+    # Find derivative of Pressurelog_spline
     dPressuredR_spline = Pressurelog_spline.derivative()
 
-    #Evaluate dPressuredR_spline at the migrating orb_a values
+    # Evaluate dPressuredR_spline at the migrating orb_a values
     dPressuredR = dPressuredR_spline(log_new_orbs_a)
 
-    #Evaluate temp at the migrating orb_a values
+    # Evaluate temp at the migrating orb_a values
     temp_migrators = temp_func(new_orbs_a)
-    #Evaluate opacity at the migrating orb_a values
+    # Evaluate opacity at the migrating orb_a values
     opacity_migrators = disk_opacity_func(new_orbs_a)
 
     xfactor_1 = (16./3.)*gamma*(gamma-1.0)*sigma_SB*(temp_migrators**(4.0))
-    xfactor_2 =opacity_migrators*(disc_surf_d_mig**(2.0))*(disk_aspect_ratio**(2.0))*(orb_a_in_meters**(2.0))*(Omega_bh**(3.0))
+    xfactor_2 = opacity_migrators*(disc_surf_d_mig**(2.0))*(disk_aspect_ratio**(2.0))*(orb_a_in_meters**(2.0))*(Omega_bh**(3.0))
     xfactor = xfactor_1/xfactor_2
-
 
     # Critical Luminosity of migrating BH
     lum_crit = 4.0*np.pi*scipy.constants.G*bh_masses_in_kg*disc_surf_d_mig*xfactor*disc_sound_speed/gamma
 
-    #mu_thermal = Xi/c_s*r_Bondi and Xi=x*H^2*Omega so mu_thermal = x*H^2*Omega/c_s*r_Bondi = x*H/r_B (where r_B<=H)
+    # mu_thermal = Xi/c_s*r_Bondi and Xi=x*H^2*Omega so mu_thermal = x*H^2*Omega/c_s*r_Bondi = x*H/r_B (where r_B<=H)
     mu_thermal = xfactor*disk_height_in_meters/effective_bondi_radius
-    #Saturate the torque
-    mu_thermal =np.where(mu_thermal<1.0,mu_thermal,1.0)
+    # Saturate the torque
+    mu_thermal = np.where(mu_thermal < 1.0, mu_thermal, 1.0)
 
-    #lambda (length) = sqrt(2 Xi/3gamma Omega) =sqrt(2/3 x H^2) since Xi=x*H^2*Omega
+    # lambda (length) = sqrt(2 Xi/3gamma Omega) =sqrt(2/3 x H^2) since Xi=x*H^2*Omega
     length = np.sqrt(2.0*xfactor*disk_height_m_sq/3.0)
 
-    #x_crit = (dP/dr)*H^2/(3 gamma R)
+    # x_crit = (dP/dr)*H^2/(3 gamma R)
     x_crit = dPressuredR*disk_height_m_sq/(3.0*gamma*orb_a_in_meters)
-    #Thermal torque calculation
+    # Thermal torque calculation
     thermal_factor = 1.61*((gamma-1)/gamma)*(x_crit/length)
     Torque_hot = thermal_factor*lum/lum_crit
     Torque_cold = -thermal_factor
 
     Thermal_torque_coeff = Torque_hot *(4.0*mu_thermal/(1.0+4.0*mu_thermal)) + Torque_cold*(2.0*mu_thermal/(1.0+2.0*mu_thermal))
 
-    #decay factor of (1- exp(-length*tau/H) where tau is optical depth) and tau=kappa*Sigma/2
+    # decay factor of (1- exp(-length*tau/H) where tau is optical depth) and tau=kappa*Sigma/2
     optical_depth = disc_surf_d_mig*opacity_migrators/2.0
     exp_factor = length * optical_depth/disk_height_in_meters
     decay_factor = (1 - np.exp(-exp_factor))
 
     Thermal_torque_coeff = Thermal_torque_coeff * decay_factor
 
+    assert np.all(~np.isnan(Thermal_torque_coeff))
+
     return Thermal_torque_coeff
 
 
 def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, torque_mig_timescale, disk_feedback_ratio_func,
-                    disk_radius_trap, disk_radius_anti_trap, disk_radius_outer, timestep_duration_yr, flag_phenom_turb, phenom_turb_centroid, phenom_turb_std_dev, bh_min_mass, torque_prescription):
+                             disk_radius_trap, disk_radius_anti_trap, disk_radius_outer, timestep_duration_yr, flag_phenom_turb, phenom_turb_centroid, phenom_turb_std_dev, bh_min_mass, torque_prescription):
     """Calculates how far an object migrates in an AGN gas disk in a single timestep given a torque migration timescale
     calculated elsewhere (e.g. torque_migration_timescale)
     Returns their new locations after migration over one timestep.
@@ -623,7 +550,7 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
     # Array of migration timescales for each orbiter in seconds as calculated from torques elsewhere
     tau = torque_mig_timescale
 
-    #Normalized masses of migrators (normalized to BH minimum mass)
+    # Normalized masses of migrators (normalized to BH minimum mass)
     normalized_migrating_masses = masses[migration_indices]/bh_min_mass
     normalized_mig_masses_sq = normalized_migrating_masses**2.0
 
@@ -631,17 +558,15 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
     dt = timestep_duration_yr * (1 * u.yr).to(u.s).value / tau
     # migration distance is original locations times fraction of tau_mig elapsed
     migration_distance = new_orbs_a.copy() * dt
-    #print("torque_mig_distance",migration_distance)
-
+    # print("torque_mig_distance",migration_distance)
 
     if flag_phenom_turb == 1:
-        #Only need to perturb migrators for now
-        #size_of_turbulent_array = np.size(migration_indices)
+        # Only need to perturb migrators for now
+        # size_of_turbulent_array = np.size(migration_indices)
         # Assume migration is always inwards (true for 'old' and for 'jiminez_masset' for M_smbh>10^8Msun)
         migration_distance = np.abs(migration_distance)
-        #Calc migration distance as modified by turbulence.
-        migration_distance = migration_distance*(1.0 + rng.normal(phenom_turb_centroid,phenom_turb_std_dev,size=migration_indices.size))/normalized_mig_masses_sq
-
+        # Calc migration distance as modified by turbulence.
+        migration_distance = migration_distance*(1.0 + rng.normal(phenom_turb_centroid, phenom_turb_std_dev, size=migration_indices.size))/normalized_mig_masses_sq
 
     if torque_prescription == 'old' or torque_prescription == 'paardekooper':
         # Assume migration is always inwards (true for 'old' and for 'jiminez_masset' for M_smbh>10^8Msun)
@@ -695,14 +620,13 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
         new_orbs_a[new_orbs_a > disk_radius_outer] = disk_radius_outer - epsilon
 
     if torque_prescription == 'jiminez_masset':
-        #If smbh_mass >10^8Msun --assume migration is always inwards
+        # If smbh_mass >10^8Msun --assume migration is always inwards
         if smbh_mass > 1.e8:
             migration_distance = np.abs(migration_distance)
             new_orbs_a = new_orbs_a - migration_distance
-        #If smbh_mass = 1.e8, assume trap at disk_radius_trap, but Type 1 migration inward everywhere.
+        # If smbh_mass = 1.e8, assume trap at disk_radius_trap, but Type 1 migration inward everywhere.
         # ie. migrators interior & exterior to trap migrate inwards, but exteriors at trap stay there.
         if smbh_mass == 1.e8:
-            #migration_distance =np.abs(migration_distance)
             # Calculate epsilon --amount to adjust from disk_radius_trap for objects that will be set to disk_radius_trap
             epsilon_trap_radius = disk_radius_trap * ((masses[migration_indices] / (3 * (masses[migration_indices] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=migration_indices.size)
             # Get masks for if objects are inside or outside the trap radius (fixed to disk_radius_trap)
@@ -714,23 +638,23 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
             # If migration takes object inside trap, fix at trap
             temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_out_trap][temp_orbs_a <= disk_radius_trap]
             new_orbs_a[mask_out_trap] = temp_orbs_a
-            #If inside trap migrate inwards
+            # If inside trap migrate inwards
             temp_orbs_a = new_orbs_a[mask_in_trap] - migration_distance[mask_in_trap]
             new_orbs_a[mask_in_trap] = temp_orbs_a
 
-        if smbh_mass <1.e8 and smbh_mass > 1.e6:
+        if smbh_mass < 1.e8 and smbh_mass > 1.e6:
             # Calculate epsilon --amount to adjust from disk_radius_trap for objects that will be set to disk_radius_trap
             epsilon_trap_radius = disk_radius_trap * ((masses[migration_indices] / (3 * (masses[migration_indices] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=migration_indices.size)
             # Trap radius changes as a function of mass.
             # Also new(!) anti-trap radius. Region between trap and anti-trap migrates out, all others migrate inwards
             # Calc new trap radius from Grishin+24
-            #temp_disk_radius_trap = disk_radius_trap*((smbh_mass/1.e8)**(-1.225))
-            #temp_disk_radius_anti_trap = disk_radius_trap*((smbh_mass/1.e8)**(0.1))
-            #print("trap,anti-trap", temp_disk_radius_trap,temp_disk_radius_anti_trap)
+            # temp_disk_radius_trap = disk_radius_trap*((smbh_mass/1.e8)**(-1.225))
+            # temp_disk_radius_anti_trap = disk_radius_trap*((smbh_mass/1.e8)**(0.1))
+            # print("trap,anti-trap", temp_disk_radius_trap,temp_disk_radius_anti_trap)
             # Get masks for objects outside trap, inside trap and inside anti-trap
             mask_out_trap = new_orbs_a > disk_radius_trap
             mask_in_anti_trap = new_orbs_a < disk_radius_anti_trap
-            #mask_in_trap = new_orbs_a > disk_radius_anti_trap and new_orbs_a < disk_radius_trap
+            # mask_in_trap = new_orbs_a > disk_radius_anti_trap and new_orbs_a < disk_radius_trap
             mask_in_trap = (new_orbs_a > disk_radius_anti_trap) & (new_orbs_a < disk_radius_trap)
             # If outside trap migrate inwards
             temp_orbs_a = new_orbs_a[mask_out_trap] + migration_distance[mask_out_trap]
@@ -738,8 +662,8 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
             temp_orbs_a[temp_orbs_a <= disk_radius_trap] = disk_radius_trap - epsilon_trap_radius[mask_out_trap][temp_orbs_a <= disk_radius_trap]
             new_orbs_a[mask_out_trap] = temp_orbs_a
 
-            #If inside trap, but outside anti_trap, migrate outwards
-            #Commented out this out-migration line
+            # If inside trap, but outside anti_trap, migrate outwards
+            # Commented out this out-migration line
             #temp_orbs_a = new_orbs_a[mask_in_trap] + migration_distance[mask_in_trap]
             #Anything in out-migrating region ends up on trap in <0.01Myr (ie 1 timestep)
 
@@ -791,6 +715,9 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
     # Update orbs_a
     orbs_a[migration_indices] = new_orbs_a
     #print("new_orbs_a_torque",new_orbs_a)
+
+    assert np.all(~np.isnan(orbs_a))
+
     return (orbs_a)
 
 
@@ -956,6 +883,7 @@ def type1_migration(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
     orbs_a[migration_indices] = new_orbs_a
     #print("new_orbs_a_default",new_orbs_a)
     return (orbs_a)
+
 
 def type1_migration_single(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit,
                            disk_surf_density_func, disk_aspect_ratio_func, disk_feedback_ratio_func,


### PR DESCRIPTION
#### Summary

There was a bug caused by a BH having orb_a set to nan. This was due to torque coefficients being calculated as nan, which was due to the CubicSpline interpolators in `paardekooper10_torque_binary` taking the `orb_a` of `blackholes_pro`, which in some cases was a smaller range than the `bin_orb_a` of `blackholes_binary`, which the derivatives of the interpolators were then applied to.

Issue fixed by using an `np.linspace` array from 3x the `disk_inner_stable_circ_orb` to `disk_radius_outer` to form the x values for the interpolators in all the torque coefficient functions.