### PR TITLE
Fixed initial star number code

### DIFF
--- a/IOdocumentation.txt
+++ b/IOdocumentation.txt
@@ -191,18 +191,44 @@ star cluster variables second, and assorted other choices (time resolution etc.)
         Saving the snapshots of each object being per time step. Deafult is 0 [off] 
         default : 0
 
-    # =========================== DONT TOUCH STARS YET SINCE NOT ADDED ===========================
-    disk_star_torque_condition
-    disk_star_orb_ecc_max_init
-    disk_star_eddington_ratio
-    disk_star_mass_min_init
-    disk_star_mass_max_init
-    nsc_star_metallicity_x_init
-    nsc_star_metallicity_y_init
-    nsc_star_metallicity_z_init
-    nsc_imf_star_mass_mode
-    nsc_imf_star_powerlaw_index
-    
+    flag_add_stars : int
+        Switch stars on (1) or off (0)
+        default: 0
+    flag_initial_stars_BH_immortal : int
+        Switch to turn initially drawn stars with mass greater than disk_star_initial_mass_cutoff into BH (1), otherwise stars above disk_star_initial_mass_cutoff are held at disk_star_initial_mass_cutoff (0)
+        default: 0
+    flag_coalesce_initial_stars : int
+        Switch to coalesce initially drawn stars that are within each other's Hill spheres (1) or not (0)
+        default: 0
+    disk_star_initial_mass_cutoff : float
+        Maximum star mass
+        default: 300 M_sun
+    disk_star_scale_factor : float
+        Factor by which to scale the number of stars in the disk at the beginning relative to the number of BH
+        default: 0.5e-2
+    disk_star_mass_min_init : float
+        Minimum star mass for the IMF
+        default: 0.5 M_sun
+    disk_star_mass_max_init : float
+        Maximum star mass for the IMF
+        default: 10.0 M_sun
+    nsc_imf_star_powerlaw_index : float
+        Powerlaw index for the IMF
+        default: 2.35
+    nsc_imf_star_mass_mode : float
+        default: 2.0
+    disk_star_torque_condition : float
+        default: 0.1
+    disk_star_eddington_ratio : float
+        default: 1.0
+    disk_star_orb_ecc_max_init : float
+        default: 0.3
+    nsc_star_metallicity_x_init : float
+        default: 0.7064
+    nsc_star_metallicity_y_init : float
+        default: 0.2735
+    nsc_star_metallicity_z_init : float
+        default: 0.02    
 
 
 Output file : output_mergers.dat

--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -85,10 +85,12 @@ mass_pile_up = 35.
 flag_add_stars = 0
 # If 1: stars over disk_star_initial_mass_cutoff turn into BH. If 0: stars over disk_star_initial_mass_cutoff are held at the cutoff and are immortal. Default 1.
 flag_initial_stars_BH_immortal = 0
+# If 0: star masses are drawn from IMF and not changed before beginning of time loop. If 1: stars within each others Hill spheres are merged together before the beginning of the time loop.
+flag_coalesce_initial_stars = 0
 # Maximum initial star mass before flag_initial_stars_BH_immortal behavior kicks in. Default 300.
 disk_star_initial_mass_cutoff = 298.
-# Factor by which to scale the number of stars in the disk at the beginning of the galaxy. Default 1.e-3.
-disk_star_scale_factor = 1.e-3
+# Factor by which to scale the number of stars in the disk at the beginning of the galaxy. Default 0.5e-2.
+disk_star_scale_factor = 0.5e-2
 disk_star_mass_min_init = 0.5
 disk_star_mass_max_init = 10.
 nsc_imf_star_powerlaw_index = 2.35

--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -108,7 +108,7 @@ nsc_star_metallicity_z_init = 0.02
 # timestep in years (float)
 timestep_duration_yr = 1.e4
 # For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
-timestep_num = 60
+timestep_num = 50
 
 # number of galaxies of code (1 for testing. 30 for a quick run.)
 galaxy_num = 1

--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -118,7 +118,7 @@ galaxy_num = 1
 # New retrograde binary switch
 fraction_bin_retro = 0.0
 # feedback on/off switch. Feedback = 1(0) means feedback is allowed(off)
-flag_thermal_feedback = 0
+flag_thermal_feedback = 1
 # eccentricity damping (1/0) switch. 
 # orb_ecc_damping = 1 means orbital damping is on & orb ecc is drawn from e.g. uniform or thermal distribution
 # orb_ecc_damping = 0 means orbital damping is off and all BH are assumed to be on circularized orbits (=e_crit)

--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -108,7 +108,7 @@ nsc_star_metallicity_z_init = 0.02
 # timestep in years (float)
 timestep_duration_yr = 1.e4
 # For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
-timestep_num = 50
+timestep_num = 60
 
 # number of galaxies of code (1 for testing. 30 for a quick run.)
 galaxy_num = 1
@@ -118,7 +118,7 @@ galaxy_num = 1
 # New retrograde binary switch
 fraction_bin_retro = 0.0
 # feedback on/off switch. Feedback = 1(0) means feedback is allowed(off)
-flag_thermal_feedback = 1
+flag_thermal_feedback = 0
 # eccentricity damping (1/0) switch. 
 # orb_ecc_damping = 1 means orbital damping is on & orb ecc is drawn from e.g. uniform or thermal distribution
 # orb_ecc_damping = 0 means orbital damping is off and all BH are assumed to be on circularized orbits (=e_crit)

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1911,11 +1911,11 @@ def main():
                                                new_orb_a=stars_pro.at_id_num(star_merged_id_num_new, "orb_a"),
                                                new_mass=stars_pro.at_id_num(star_merged_id_num_new, "mass"),
                                                new_orb_ecc=stars_pro.at_id_num(star_merged_id_num_new, "orb_ecc"),
-                                               new_size=point_masses.r_g_from_units(opts.smbh_mass, (10 ** stars_pro.at_id_num(star_merged_id_num_new, "log_radius")) * astropy_units.Rsun).value,
+                                               new_size=point_masses.r_g_from_units(opts.smbh_mass, (10 ** stars_pro.at_id_num(star_merged_id_num_new, "log_radius")) * u.Rsun).value,
                                                new_direction=np.ones(star_merged_id_num_new.size),
                                                new_disk_inner_outer=np.ones(star_merged_id_num_new.size))
                     filing_cabinet.remove_id_num(starstar_id_nums.flatten())
-                    stars_pro.remove_id_nums(starstar_id_nums.flatten())
+                    stars_pro.remove_id_num(starstar_id_nums.flatten())
 
             # After this time period, was there a disk capture via orbital grind-down?
             # To do: What eccentricity do we want the captured BH to have? Right now ecc=0.0? Should it be ecc<h at a?             

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -8,6 +8,8 @@ Inifile
         Use pAGN to generate disk model?
     "flag_add_stars"                : int
         Add stars to the disk
+    "flag_coalesce_initial_stars"   : int
+        Keep stars as is (0) or coalesce before time loop starts (1)
     "flag_initial_stars_BH_immortal": int
         If stars over disk_star_initial_mass_cutoff turn into BH (0) or hold at cutoff (1, immortal)
     "smbh_mass"                     : float
@@ -149,6 +151,7 @@ INPUT_TYPES = {
     "disk_model_name"               : str,
     "flag_use_pagn"                 : int,
     "flag_add_stars"                : int,
+    "flag_coalesce_initial_stars"   : int,
     "flag_initial_stars_BH_immortal": int,
     "smbh_mass"                     : float,
     "disk_radius_trap"              : float,

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -377,7 +377,8 @@ def circular_singles_encounters_prograde_stars(
     ecc_orb_max = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
     num_poss_ints = 0
     num_encounters = 0
-    id_nums_touch = []
+    id_nums_poss_touch = []
+    frac_rhill_sep = []
     if len(circ_prograde_population_indices) > 0:
         for i, circ_idx in enumerate(circ_prograde_population_indices):
             for j, ecc_idx in enumerate(ecc_prograde_population_indices):
@@ -411,7 +412,8 @@ def circular_singles_encounters_prograde_stars(
                                                         weights=[disk_star_pro_masses[circ_idx], disk_star_pro_masses[ecc_idx]])
                             rhill_poss_encounter = center_of_mass * ((disk_star_pro_masses[circ_idx] + disk_star_pro_masses[ecc_idx]) / (3. * smbh_mass)) ** (1./3.)
                             if (separation - rhill_poss_encounter < 0):
-                                id_nums_touch.append(np.array([disk_star_pro_id_nums[circ_idx], disk_star_pro_id_nums[ecc_idx]]))
+                                id_nums_poss_touch.append(np.array([disk_star_pro_id_nums[circ_idx], disk_star_pro_id_nums[ecc_idx]]))
+                                frac_rhill_sep.append(separation / rhill_poss_encounter)
                     num_poss_ints = num_poss_ints + 1
             num_poss_ints = 0
             num_encounters = 0
@@ -422,8 +424,31 @@ def circular_singles_encounters_prograde_stars(
     assert np.isfinite(disk_star_pro_orbs_ecc).all(), \
         "Finite check failed for disk_star_pro_orbs_ecc"
 
-    # Put ID nums array into correct shape
-    id_nums_touch = np.array(id_nums_touch)
+    id_nums_poss_touch = np.array(id_nums_poss_touch)
+    frac_rhill_sep = np.array(frac_rhill_sep)
+
+    # Test if there are any duplicate pairs, if so only return ID numbers of pair with smallest fractional Hill sphere separation
+    if np.unique(id_nums_poss_touch).shape != id_nums_poss_touch.flatten().shape:
+        sort_idx = np.argsort(frac_rhill_sep)
+        id_nums_poss_touch = id_nums_poss_touch[sort_idx]
+        uniq_vals, unq_counts = np.unique(id_nums_poss_touch, return_counts=True)
+        dupe_vals = uniq_vals[unq_counts > 1]
+        dupe_rows = id_nums_poss_touch[np.any(np.isin(id_nums_poss_touch, dupe_vals), axis=1)]
+        uniq_rows = id_nums_poss_touch[np.all(~np.isin(id_nums_poss_touch, dupe_vals), axis=1)]
+
+        rm_rows = []
+        for row in dupe_rows:
+            dupe_indices = np.any(np.isin(dupe_rows, row), axis=1).nonzero()[0][1:]
+            rm_rows.append(dupe_indices)
+        rm_rows = np.unique(np.concatenate(rm_rows))
+        keep_mask = np.ones(len(dupe_rows))
+        keep_mask[rm_rows] = 0
+
+        id_nums_touch = np.concatenate((dupe_rows[keep_mask.astype(bool)], uniq_rows))
+
+    else:
+        id_nums_touch = id_nums_poss_touch
+
     id_nums_touch = id_nums_touch.T
     return (disk_star_pro_orbs_a, disk_star_pro_orbs_ecc, id_nums_touch)
 
@@ -601,7 +626,8 @@ def circular_singles_encounters_prograde_star_bh(
     ecc_orb_max = disk_bh_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_bh_pro_orbs_a[ecc_prograde_population_indices])
     num_poss_ints = 0
     num_encounters = 0
-    id_nums_touch = []
+    id_nums_poss_touch = []
+    frac_rhill_sep = []
     if len(circ_prograde_population_indices) > 0:
         for i, circ_idx in enumerate(circ_prograde_population_indices):
             for j, ecc_idx in enumerate(ecc_prograde_population_indices):
@@ -635,7 +661,8 @@ def circular_singles_encounters_prograde_star_bh(
                                                         weights=[disk_star_pro_masses[circ_idx], disk_bh_pro_masses[ecc_idx]])
                             rhill_poss_encounter = center_of_mass * ((disk_star_pro_masses[circ_idx] + disk_bh_pro_masses[ecc_idx]) / (3. * smbh_mass)) ** (1./3.)
                             if (separation - rhill_poss_encounter < 0):
-                                id_nums_touch.append(np.array([disk_star_pro_id_nums[circ_idx], disk_bh_pro_id_nums[ecc_idx]]))
+                                id_nums_poss_touch.append(np.array([disk_star_pro_id_nums[circ_idx], disk_bh_pro_id_nums[ecc_idx]]))
+                                frac_rhill_sep.append(separation / rhill_poss_encounter)
                     num_poss_ints = num_poss_ints + 1
             num_poss_ints = 0
             num_encounters = 0
@@ -651,7 +678,31 @@ def circular_singles_encounters_prograde_star_bh(
         "Finite check failed for disk_bh_pro_orbs_ecc"
 
     # Put ID nums array into correct shape
-    id_nums_touch = np.array(id_nums_touch)
+    id_nums_poss_touch = np.array(id_nums_poss_touch)
+    frac_rhill_sep = np.array(frac_rhill_sep)
+
+    # Test if there are any duplicate pairs, if so only return ID numbers of pair with smallest fractional Hill sphere separation
+    if np.unique(id_nums_poss_touch).shape != id_nums_poss_touch.flatten().shape:
+        sort_idx = np.argsort(frac_rhill_sep)
+        id_nums_poss_touch = id_nums_poss_touch[sort_idx]
+        uniq_vals, unq_counts = np.unique(id_nums_poss_touch, return_counts=True)
+        dupe_vals = uniq_vals[unq_counts > 1]
+        dupe_rows = id_nums_poss_touch[np.any(np.isin(id_nums_poss_touch, dupe_vals), axis=1)]
+        uniq_rows = id_nums_poss_touch[np.all(~np.isin(id_nums_poss_touch, dupe_vals), axis=1)]
+
+        rm_rows = []
+        for row in dupe_rows:
+            dupe_indices = np.any(np.isin(dupe_rows, row), axis=1).nonzero()[0][1:]
+            rm_rows.append(dupe_indices)
+        rm_rows = np.unique(np.concatenate(rm_rows))
+        keep_mask = np.ones(len(dupe_rows))
+        keep_mask[rm_rows] = 0
+
+        id_nums_touch = np.concatenate((dupe_rows[keep_mask.astype(bool)], uniq_rows))
+
+    else:
+        id_nums_touch = id_nums_poss_touch
+
     id_nums_touch = id_nums_touch.T
     return (disk_star_pro_orbs_a, disk_star_pro_orbs_ecc, disk_bh_pro_orbs_a, disk_bh_pro_orbs_ecc, id_nums_touch)
 

--- a/src/mcfacts/setup/initializediskstars.py
+++ b/src/mcfacts/setup/initializediskstars.py
@@ -1,9 +1,8 @@
-from mcfacts.setup import setupdiskstars, setupdiskblackholes
+from mcfacts.setup import setupdiskstars
 from mcfacts.setup import diskstars_hillspheremergers
 from mcfacts.physics import stellar_interpolation
 from mcfacts.objects.agnobject import AGNStar
 import numpy as np
-from mcfacts.mcfacts_random_state import rng
 
 
 def init_single_stars(opts, disk_aspect_ratio, galaxy, id_start_val=None):
@@ -22,28 +21,37 @@ def init_single_stars(opts, disk_aspect_ratio, galaxy, id_start_val=None):
             opts.nsc_radius_crit,
             opts.nsc_density_index_inner,
         )
-    print("num stars initial", star_num_initial)
 
-    # Generate initial masses for the initial number of stars, pre-Hill sphere mergers
-    masses_initial = setupdiskstars.setup_disk_stars_masses(star_num=star_num_initial,
-                                                            disk_star_mass_min_init=opts.disk_star_mass_min_init,
-                                                            disk_star_mass_max_init=opts.disk_star_mass_max_init,
-                                                            nsc_imf_star_powerlaw_index=opts.nsc_imf_star_powerlaw_index)
+    if opts.flag_coalesce_initial_stars:
+        print("num stars initial", star_num_initial)
 
-    orbs_a_initial = setupdiskstars.setup_disk_stars_orb_a(star_num_initial, opts.disk_radius_outer, opts.disk_inner_stable_circ_orb)
+        # Generate initial masses for the initial number of stars, pre-Hill sphere mergers
+        masses_initial = setupdiskstars.setup_disk_stars_masses(star_num=star_num_initial,
+                                                                disk_star_mass_min_init=opts.disk_star_mass_min_init,
+                                                                disk_star_mass_max_init=opts.disk_star_mass_max_init,
+                                                                nsc_imf_star_powerlaw_index=opts.nsc_imf_star_powerlaw_index)
 
-    # Sort the mass and location arrays by the location array
-    sort_idx = np.argsort(orbs_a_initial)
-    orbs_a_initial_sorted = orbs_a_initial[sort_idx]
-    masses_initial_sorted = masses_initial[sort_idx]
-    masses_stars, orbs_a_stars = diskstars_hillspheremergers.hillsphere_mergers(n_stars=star_num_initial,
-                                                                                masses_initial_sorted=masses_initial_sorted,
-                                                                                orbs_a_initial_sorted=orbs_a_initial_sorted,
-                                                                                min_initial_star_mass=opts.disk_star_mass_min_init,
-                                                                                disk_radius_outer=opts.disk_radius_outer,
-                                                                                smbh_mass=opts.smbh_mass,
-                                                                                P_m=1.35,
-                                                                                P_r=1.)
+        orbs_a_initial = setupdiskstars.setup_disk_stars_orb_a(star_num_initial, opts.disk_radius_outer, opts.disk_inner_stable_circ_orb)
+
+        # Sort the mass and location arrays by the location array
+        sort_idx = np.argsort(orbs_a_initial)
+        orbs_a_initial_sorted = orbs_a_initial[sort_idx]
+        masses_initial_sorted = masses_initial[sort_idx]
+        masses_stars, orbs_a_stars = diskstars_hillspheremergers.hillsphere_mergers(n_stars=star_num_initial,
+                                                                                    masses_initial_sorted=masses_initial_sorted,
+                                                                                    orbs_a_initial_sorted=orbs_a_initial_sorted,
+                                                                                    min_initial_star_mass=opts.disk_star_mass_min_init,
+                                                                                    disk_radius_outer=opts.disk_radius_outer,
+                                                                                    smbh_mass=opts.smbh_mass,
+                                                                                    P_m=1.35,
+                                                                                    P_r=1.)
+    else:
+        masses_stars = setupdiskstars.setup_disk_stars_masses(star_num=star_num_initial,
+                                                              disk_star_mass_min_init=opts.disk_star_mass_min_init,
+                                                              disk_star_mass_max_init=opts.disk_star_mass_max_init,
+                                                              nsc_imf_star_powerlaw_index=opts.nsc_imf_star_powerlaw_index)
+        orbs_a_stars = setupdiskstars.setup_disk_stars_orb_a(star_num_initial, opts.disk_radius_outer, opts.disk_inner_stable_circ_orb)
+
     star_num = len(masses_stars)
 
     if (opts.flag_initial_stars_BH_immortal == 0):

--- a/src/mcfacts/setup/setupdiskstars.py
+++ b/src/mcfacts/setup/setupdiskstars.py
@@ -392,7 +392,7 @@ def setup_disk_stars_num(nsc_mass, nsc_ratio_bh_num_star_num, nsc_ratio_mbh_mass
         nsc_ratio_mbh_mass_star_mass : float
             Ratio of mass of typical BH in NSC to typical star in NSC [unitless]. Set by user. Default is 10 (BH=10M_sun,star=1M_sun)
         disk_star_scale_factor : float
-            Scale factor [unitless] to go from number of BH to number of stars. Set by user. Default is 1.e-2.
+            Scale factor [unitless] to go from number of BH to number of stars. Set by user.
         nsc_radius_outer : float
             Outer radius of NSC [pc]. Set by user. Default is 5pc.
         nsc_density_index_outer : float


### PR DESCRIPTION
#### Summary

Added flag to options: `opts.flag_coalesce_initial_stars`. If set to 0, then the initial number of stars is taken from `setupdiskstars.setup_disk_stars_num` and parameters are set accordingly. If set to 1, then the initial number of stars is taken from `setupdiskstars.setup_disk_stars_num`, then stars within mutual Hill spheres are merged together before the beginning of the time loop. This is only necessary if you are starting with a large number of stars (>> 1000). By default the flag is set to 0 and the number of stars is set to ~1000.