### PR TITLE
Bug in torque calculations

### DIFF
--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -17,7 +17,7 @@ flag_use_pagn = 1
 flag_use_surrogate = 0
 
 # trap radius in r_g
-disk_radius_trap = 700.
+disk_radius_trap = 500.
 # disk outer radius in r_g
 disk_radius_outer = 50000.
 # Maximum disk outer radius (pc) (0. turns this off)
@@ -109,14 +109,14 @@ timestep_duration_yr = 1.e4
 timestep_num = 60
 
 # number of galaxies of code (1 for testing. 30 for a quick run.)
-galaxy_num = 1
+galaxy_num = 100
 #
 # Other physics choices: 
 #
 # New retrograde binary switch
 fraction_bin_retro = 0.0
 # feedback on/off switch. Feedback = 1(0) means feedback is allowed(off)
-flag_thermal_feedback = 0
+flag_thermal_feedback = 1
 # eccentricity damping (1/0) switch. 
 # orb_ecc_damping = 1 means orbital damping is on & orb ecc is drawn from e.g. uniform or thermal distribution
 # orb_ecc_damping = 0 means orbital damping is off and all BH are assumed to be on circularized orbits (=e_crit)

--- a/src/mcfacts/physics/migration.py
+++ b/src/mcfacts/physics/migration.py
@@ -552,7 +552,7 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
     new_orbs_a = orbs_a[migration_indices].copy()
 
     # Array of migration timescales for each orbiter in seconds as calculated from torques elsewhere
-    tau = torque_mig_timescale
+    tau = np.abs(torque_mig_timescale)
 
     # Normalized masses of migrators (normalized to BH minimum mass)
     normalized_migrating_masses = masses[migration_indices]/bh_min_mass
@@ -562,19 +562,16 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
     dt = timestep_duration_yr * (1 * u.yr).to(u.s).value / tau
     # migration distance is original locations times fraction of tau_mig elapsed
     migration_distance = new_orbs_a.copy() * dt
-    # print("torque_mig_distance",migration_distance)
 
     if flag_phenom_turb == 1:
         # Only need to perturb migrators for now
         # size_of_turbulent_array = np.size(migration_indices)
         # Assume migration is always inwards (true for 'old' and for 'jiminez_masset' for M_smbh>10^8Msun)
-        migration_distance = np.abs(migration_distance)
         # Calc migration distance as modified by turbulence.
         migration_distance = migration_distance*(1.0 + rng.normal(phenom_turb_centroid, phenom_turb_std_dev, size=migration_indices.size))/normalized_mig_masses_sq
 
     if torque_prescription == 'old' or torque_prescription == 'paardekooper':
         # Assume migration is always inwards (true for 'old' and for 'jiminez_masset' for M_smbh>10^8Msun)
-        migration_distance = np.abs(migration_distance)
         # Disk feedback ratio
         disk_feedback_ratio = disk_feedback_ratio_func[migration_indices]
         # Calculate epsilon --amount to adjust from disk_radius_trap for objects that will be set to disk_radius_trap
@@ -626,7 +623,6 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
     if torque_prescription == 'jiminez_masset':
         # If smbh_mass >10^8Msun --assume migration is always inwards
         if smbh_mass > 1.e8:
-            migration_distance = np.abs(migration_distance)
             new_orbs_a = new_orbs_a - migration_distance
         # If smbh_mass = 1.e8, assume trap at disk_radius_trap, but Type 1 migration inward everywhere.
         # ie. migrators interior & exterior to trap migrate inwards, but exteriors at trap stay there.


### PR DESCRIPTION
#### Summary

`migration.type1_migration_distance` now takes migration_distance as the absolute value, as it can end up negative due to the signs on the torque coefficients.