### PR TITLE
fix behavior in ReadLog; add documentation

### DIFF
--- a/IOdocumentation.txt
+++ b/IOdocumentation.txt
@@ -190,6 +190,9 @@ star cluster variables second, and assorted other choices (time resolution etc.)
     save_snapshots : int
         Saving the snapshots of each object being per time step. Deafult is 0 [off] 
         default : 0
+    flag_use_surrogate : float
+        Switch (0) uses analytical kick prescription from Akiba et al. (2024). Switch (1) sets 200 km/s for each merger's kick velocity.
+        default : 0
 
     # =========================== DONT TOUCH STARS YET SINCE NOT ADDED ===========================
     disk_star_torque_condition

--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -13,7 +13,7 @@ smbh_mass = 1.e8
 disk_model_name = 'sirko_goodman'
 # pAGN flag (0/1) boolean
 flag_use_pagn = 1
-# surrogate model flag (0/1) boolean
+# surrogate model flag for kick velocities (0/1) boolean
 flag_use_surrogate = 0
 
 # trap radius in r_g

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -123,12 +123,14 @@ Inifile
         Innermost Stable Circular Orbit around SMBH
     "mass_pile_up"                  : float
         Pile-up of masses caused by cutoff (M_sun)
-    "save_snapshots"
+    "save_snapshots"                : int
         Save snapshots of the disk and NSC at each timestep
-    "mean_harden_energy_delta"
+    "mean_harden_energy_delta"      : float
         The Gaussian mean value for the energy change during a strong interaction
-    "var_harden_energy_delta"
+    "var_harden_energy_delta"       : float
         The Gaussian variance value for the energy change during a strong interaction
+    "flag_use_surrogate"            : int
+        Switch (0) uses analytical kick prescription from Akiba et al. (2024). Switch (1) sets 200 km/s for each merger's kick velocity.
 """
 # Things everyone needs
 import configparser as ConfigParser

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -13,6 +13,8 @@ smbh_mass = 1.e8
 disk_model_name = 'sirko_goodman'
 # pAGN flag (0/1) boolean
 flag_use_pagn = 0
+# surrogate model flag for kick velocities (0/1) boolean
+flag_use_surrogate = 0
 
 # trap radius in r_g
 disk_radius_trap = 700.

--- a/src/mcfacts/outputs/ReadOutputs.py
+++ b/src/mcfacts/outputs/ReadOutputs.py
@@ -87,7 +87,7 @@ def ReadLog(fname_log, verbose=0):
             log_dict[key] = OUTPUT_TYPES[key](value)
         # Store unexpected lines to report below
         if not (key in OUTPUT_TYPES):
-            log_dict[key] = OUTPUT_TYPES[key](value)
+            log_dict[key] = value
             extra_values[key] = value
         
     # Print the dictionary

--- a/src/mcfacts/outputs/ReadOutputs.py
+++ b/src/mcfacts/outputs/ReadOutputs.py
@@ -72,7 +72,7 @@ def ReadLog(fname_log, verbose=0):
         lines = f.readlines()
 
     # Initialize the dictionary
-    log_dict = {}
+    log_values = {}
     extra_values = {}
 
     # Loop through the lines
@@ -84,28 +84,29 @@ def ReadLog(fname_log, verbose=0):
         value = value.strip()
         # Convert the values
         if key in OUTPUT_TYPES:
-            log_dict[key] = OUTPUT_TYPES[key](value)
+            log_values[key] = OUTPUT_TYPES[key](value)
         # Store unexpected lines to report below
         if not (key in OUTPUT_TYPES):
-            log_dict[key] = value
+            log_values[key] = value
             extra_values[key] = value
         
     # Print the dictionary
     if verbose:
-        for key, value in log_dict.items():
+        for key, value in log_values.items():
             print(f"{key}: {value}")
 
     # Warning if extra values are found
     if len(extra_values) > 0:
         print(f"~~~~~~~~~~~~~~~~~~~~~~\n",
-               f"[ReadOutputs.py] Warning!: The log file you're using contains {len(extra_values)} additional"
-               "entries not found in OUTPUT_TYPES. They have been added to the log"
-               "dictionary as a STRING type. Please verify their types before you"
-               "use them in your analysis or add them to the OUTPUT_TYPES dictionary.")
+               f"[ReadOutputs.py] Warning!: The log file you're using contains "
+               f"{len(extra_values)} additional entries not found in OUTPUT_TYPES. "
+               "They have been added to the log dictionary as a STRING type. "
+               "Please verify their intended types before you use them in your "
+               "analysis or add them to the INPUT_TYPES or OUTPUT_TYPES dictionaries.")
         for key, value in extra_values.items():
             print(f"  {key}: {value}")
         print(f"~~~~~~~~~~~~~~~~~~~~~~")
         
 
-    return log_dict
+    return log_values
     


### PR DESCRIPTION
<!--
Thank you for contributing a pull request! Here are a few tips to help you:
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the GH issue).
-->
1. The `OUTPUT_TYPES` dictionary was incorrectly accessed for a type while parsing unknown log file entries in the `ReadLog` function. This raised an exception because - go figure - the unknown entry does not exist in the `OUTPUT_TYPES` dictionary! Now, the unknown value is added to the log dictionary as a string type and warns the user to check it's intended type before using the value in analysis.

2. `flag_use_surrogate` now has entries in all relevant documentation and has the default value included in the default `model_choice.ini` file.

#### Issue Link
<!--
If applicable, please include issue link.
-->