### PR TITLE
Moved torque interpolators into their own function, fixed misspelling

### DIFF
--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -28,7 +28,7 @@ disk_alpha_viscosity = 0.01
 inner_disk_outer_radius = 50.
 # Innermost Stable Circular Orbit around the SMBH (Rg)
 disk_inner_stable_circ_orb = 6.
-# Torque prescription ('old','paardekooper','jiminez_masset': Paaardekooper default; Jiminez-Masset option)
+# Torque prescription ('old','paardekooper','jimenez_masset': Paaardekooper default; Jimenez-Masset option)
 torque_prescription = 'paardekooper'
 #phenomenological turbulence
 flag_phenom_turb = 0

--- a/recipes/paper_3/p3_pAGN_off.ini
+++ b/recipes/paper_3/p3_pAGN_off.ini
@@ -28,7 +28,7 @@ disk_alpha_viscosity = 0.01
 inner_disk_outer_radius = 50.
 # Innermost Stable Circular Orbit around the SMBH (Rg)
 disk_inner_stable_circ_orb = 6.
-# Torque prescription ('old','paardekooper','jiminez_masset': Paaardekooper default; Jiminez-Masset option)
+# Torque prescription ('old','paardekooper','jimenez_masset': Paaardekooper default; Jimenez-Masset option)
 torque_prescription = 'paardekooper'
 #phenomenological turbulence
 flag_phenom_turb = 0

--- a/recipes/paper_3/p3_pAGN_on.ini
+++ b/recipes/paper_3/p3_pAGN_on.ini
@@ -28,7 +28,7 @@ disk_alpha_viscosity = 0.01
 inner_disk_outer_radius = 50.
 # Innermost Stable Circular Orbit around the SMBH (Rg)
 disk_inner_stable_circ_orb = 6.
-# Torque prescription ('old','paardekooper','jiminez_masset': Paaardekooper default; Jiminez-Masset option)
+# Torque prescription ('old','paardekooper','jimenez_masset': Paaardekooper default; Jimenez-Masset option)
 torque_prescription = 'paardekooper'
 #phenomenological turbulence
 flag_phenom_turb = 0

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -652,9 +652,9 @@ def main():
                     opts.disk_inner_stable_circ_orb
                 )
 
-            # Jiminez-Masset torque coeff (from Grishin+24)
-            if opts.torque_prescription == 'jiminez_masset':
-                jiminez_masset_torque_coeff_bh = migration.jiminezmasset17_torque(
+            # Jimenez-Masset torque coeff (from Grishin+24)
+            if opts.torque_prescription == 'jimenez_masset':
+                jimenez_masset_torque_coeff_bh = migration.jimenezmasset17_torque(
                     opts.smbh_mass,
                     disk_surface_density,
                     disk_opacity,
@@ -667,7 +667,7 @@ def main():
                     opts.disk_inner_stable_circ_orb
                 )
 
-                jiminez_masset_torque_coeff_star = migration.jiminezmasset17_torque(
+                jimenez_masset_torque_coeff_star = migration.jimenezmasset17_torque(
                     opts.smbh_mass,
                     disk_surface_density,
                     disk_opacity,
@@ -681,7 +681,7 @@ def main():
                 )
 
                 # Thermal torque from JM17 (if flag_thermal_feedback off, this component is 0.)
-                jiminez_masset_thermal_torque_coeff_bh = migration.jiminezmasset17_thermal_torque_coeff(
+                jimenez_masset_thermal_torque_coeff_bh = migration.jimenezmasset17_thermal_torque_coeff(
                     opts.smbh_mass,
                     disk_surface_density,
                     disk_opacity,
@@ -699,7 +699,7 @@ def main():
                     opts.disk_inner_stable_circ_orb
                 )
 
-                jiminez_masset_thermal_torque_coeff_star = migration.jiminezmasset17_thermal_torque_coeff(
+                jimenez_masset_thermal_torque_coeff_star = migration.jimenezmasset17_thermal_torque_coeff(
                     opts.smbh_mass,
                     disk_surface_density,
                     disk_opacity,
@@ -718,14 +718,14 @@ def main():
                 )
 
                 if opts.flag_thermal_feedback == 1:
-                    total_jiminez_masset_torque_bh = jiminez_masset_torque_coeff_bh + jiminez_masset_thermal_torque_coeff_bh
-                    total_jiminez_masset_torque_star = jiminez_masset_torque_coeff_star + jiminez_masset_thermal_torque_coeff_star
+                    total_jimenez_masset_torque_bh = jimenez_masset_torque_coeff_bh + jimenez_masset_thermal_torque_coeff_bh
+                    total_jimenez_masset_torque_star = jimenez_masset_torque_coeff_star + jimenez_masset_thermal_torque_coeff_star
                 else:
-                    total_jiminez_masset_torque_bh = jiminez_masset_torque_coeff_bh
-                    total_jiminez_masset_torque_star = jiminez_masset_torque_coeff_star
+                    total_jimenez_masset_torque_bh = jimenez_masset_torque_coeff_bh
+                    total_jimenez_masset_torque_star = jimenez_masset_torque_coeff_star
 
             # Normalized torque (multiplies torque coeff)
-            if opts.torque_prescription == 'paardekooper' or opts.torque_prescription == 'jiminez_masset':
+            if opts.torque_prescription == 'paardekooper' or opts.torque_prescription == 'jimenez_masset':
                 normalized_torque_bh = migration.normalized_torque(
                     opts.smbh_mass,
                     blackholes_pro.orb_a,
@@ -751,10 +751,10 @@ def main():
                     torque_star = paardekooper_torque_coeff_star * normalized_torque_star
                     disk_trap_radius = opts.disk_radius_trap
                     disk_anti_trap_radius = opts.disk_radius_trap
-                if opts.torque_prescription == 'jiminez_masset':
-                    torque_bh = total_jiminez_masset_torque_bh * normalized_torque_bh
-                    torque_star = total_jiminez_masset_torque_star * normalized_torque_star
-                    # Set up trap scaling as a function of mass for Jiminez-Masset (for SG-like disk)
+                if opts.torque_prescription == 'jimenez_masset':
+                    torque_bh = total_jimenez_masset_torque_bh * normalized_torque_bh
+                    torque_star = total_jimenez_masset_torque_star * normalized_torque_star
+                    # Set up trap scaling as a function of mass for Jimenez-Masset (for SG-like disk)
                     # No traps if M_smbh >10^8Msun (approx.)
                     if opts.smbh_mass > 1.e8:
                         disk_trap_radius = opts.disk_inner_stable_circ_orb
@@ -788,7 +788,7 @@ def main():
                     opts.disk_bh_pro_orb_ecc_crit,
                     torque_star
                 )
-                # Calculate new bh_orbs_a using torque (here including details from Jiminez& Masset '17 & Grishin+'24)
+                # Calculate new bh_orbs_a using torque (here including details from Jimenez & Masset '17 & Grishin+'24)
                 new_orb_a_bh = migration.type1_migration_distance(
                     opts.smbh_mass,
                     blackholes_pro.orb_a,
@@ -1612,9 +1612,9 @@ def main():
                         opts.disk_inner_stable_circ_orb
                     )
 
-                #Jiminez-Masset torque coeff (from Grishin+24)
-                if opts.torque_prescription == 'jiminez_masset':
-                    jiminez_masset_torque_coeff_bh = migration.jiminezmasset17_torque(
+                #Jimenez-Masset torque coeff (from Grishin+24)
+                if opts.torque_prescription == 'jimenez_masset':
+                    jimenez_masset_torque_coeff_bh = migration.jimenezmasset17_torque(
                         opts.smbh_mass,
                         disk_surface_density,
                         disk_opacity,
@@ -1626,7 +1626,7 @@ def main():
                         opts.disk_radius_outer,
                         opts.disk_inner_stable_circ_orb
                     )
-                    jiminez_masset_thermal_torque_coeff_bh = migration.jiminezmasset17_thermal_torque_coeff(
+                    jimenez_masset_thermal_torque_coeff_bh = migration.jimenezmasset17_thermal_torque_coeff(
                         opts.smbh_mass,
                         disk_surface_density,
                         disk_opacity,
@@ -1644,11 +1644,11 @@ def main():
                         opts.disk_inner_stable_circ_orb
                     )
                     if opts.flag_thermal_feedback > 0:
-                        total_jiminez_masset_torque_bh = jiminez_masset_torque_coeff_bh + jiminez_masset_thermal_torque_coeff_bh
+                        total_jimenez_masset_torque_bh = jimenez_masset_torque_coeff_bh + jimenez_masset_thermal_torque_coeff_bh
                     else:
-                        total_jiminez_masset_torque_bh = jiminez_masset_torque_coeff_bh
+                        total_jimenez_masset_torque_bh = jimenez_masset_torque_coeff_bh
                 #Normalized torque (multiplies torque coeff)
-                if opts.torque_prescription == 'paardekooper' or opts.torque_prescription == 'jiminez_masset':
+                if opts.torque_prescription == 'paardekooper' or opts.torque_prescription == 'jimenez_masset':
                     normalized_torque_bh = migration.normalized_torque(
                         opts.smbh_mass,
                         blackholes_binary.bin_orb_a,
@@ -1664,9 +1664,9 @@ def main():
                             torque =  paardekooper_torque_coeff_bh*normalized_torque_bh
                             disk_trap_radius = opts.disk_radius_trap
                             disk_anti_trap_radius = opts.disk_radius_trap
-                        if opts.torque_prescription == 'jiminez_masset':
-                            torque = total_jiminez_masset_torque_bh*normalized_torque_bh
-                        # Set up trap scaling as a function of mass for Jiminez-Masset (for SG-like disk)
+                        if opts.torque_prescription == 'jimenez_masset':
+                            torque = total_jimenez_masset_torque_bh*normalized_torque_bh
+                        # Set up trap scaling as a function of mass for Jimenez-Masset (for SG-like disk)
                         # No traps if M_smbh >10^8Msun (approx.)
                             if opts.smbh_mass > 1.e8:
                                 disk_trap_radius = opts.disk_inner_stable_circ_orb

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -635,25 +635,17 @@ def main():
             # Paardekooper torque coeff (default)
             if opts.torque_prescription == 'paardekooper':
                 paardekooper_torque_coeff_bh = migration.paardekooper10_torque(
-                    disk_surface_density,
-                    temp_func,
                     blackholes_pro.orb_a,
                     blackholes_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
-                    opts.disk_radius_outer,
-                    opts.disk_inner_stable_circ_orb,
                     dlogSigmadlogR_spline,
                     dlogTempdlogR_spline
                 )
 
                 paardekooper_torque_coeff_star = migration.paardekooper10_torque(
-                    disk_surface_density,
-                    temp_func,
                     stars_pro.orb_a,
                     stars_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
-                    opts.disk_radius_outer,
-                    opts.disk_inner_stable_circ_orb,
                     dlogSigmadlogR_spline,
                     dlogTempdlogR_spline
                 )
@@ -669,8 +661,6 @@ def main():
                     blackholes_pro.orb_a,
                     blackholes_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
-                    opts.disk_radius_outer,
-                    opts.disk_inner_stable_circ_orb,
                     dlogSigmadlogR_spline,
                     dlogTempdlogR_spline
                 )
@@ -684,8 +674,6 @@ def main():
                     stars_pro.orb_a,
                     stars_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
-                    opts.disk_radius_outer,
-                    opts.disk_inner_stable_circ_orb,
                     dlogSigmadlogR_spline,
                     dlogTempdlogR_spline
                 )
@@ -697,16 +685,12 @@ def main():
                     disk_opacity,
                     disk_aspect_ratio,
                     temp_func,
-                    disk_sound_speed,
-                    disk_density,
                     opts.disk_bh_eddington_ratio,
                     blackholes_pro.orb_a,
                     blackholes_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
                     blackholes_pro.mass,
                     opts.flag_thermal_feedback,
-                    opts.disk_radius_outer,
-                    opts.disk_inner_stable_circ_orb,
                     dlogPressuredlogR_spline
                 )
 
@@ -716,16 +700,12 @@ def main():
                     disk_opacity,
                     disk_aspect_ratio,
                     temp_func,
-                    disk_sound_speed,
-                    disk_density,
                     opts.disk_bh_eddington_ratio,
                     stars_pro.orb_a,
                     stars_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
                     blackholes_pro.mass,
                     opts.flag_thermal_feedback,
-                    opts.disk_radius_outer,
-                    opts.disk_inner_stable_circ_orb,
                     dlogPressuredlogR_spline
                 )
 
@@ -1604,7 +1584,6 @@ def main():
                 # Migrate binaries center of mass
                 # Choose torque prescription for binary migration
                 # Old is the original approximation used in v.0.1.0, based off (but not identical to Paardekooper 2010)-usually within factor [0.5-2]
-                #if opts.torque_prescription == 'old' or opts.torque_prescription == 'paardekooper':
                 if opts.torque_prescription == 'old':
                     blackholes_binary = migration.type1_migration_binary(
                         opts.smbh_mass, blackholes_binary,
@@ -1612,22 +1591,18 @@ def main():
                         disk_surface_density, disk_aspect_ratio, ratio_heat_mig_torques_bin_com,
                         opts.disk_radius_trap, opts.disk_radius_outer, opts.timestep_duration_yr)
 
-                #Alternatively, calculate actual torques from disk profiles.
-                #Paardekooper torque coeff (default)
+                # Alternatively, calculate actual torques from disk profiles.
+                # Paardekooper torque coeff (default)
                 if opts.torque_prescription == 'paardekooper':
                     paardekooper_torque_coeff_bh = migration.paardekooper10_torque(
-                        disk_surface_density,
-                        temp_func,
                         blackholes_binary.bin_orb_a,
                         blackholes_binary.bin_orb_ecc,
                         opts.disk_bh_pro_orb_ecc_crit,
-                        opts.disk_radius_outer,
-                        opts.disk_inner_stable_circ_orb,
                         dlogSigmadlogR_spline,
                         dlogTempdlogR_spline
                     )
 
-                #Jimenez-Masset torque coeff (from Grishin+24)
+                # Jimenez-Masset torque coeff (from Grishin+24)
                 if opts.torque_prescription == 'jimenez_masset':
                     jimenez_masset_torque_coeff_bh = migration.jimenezmasset17_torque(
                         opts.smbh_mass,
@@ -1638,8 +1613,6 @@ def main():
                         blackholes_binary.bin_orb_a,
                         blackholes_binary.bin_orb_ecc,
                         opts.disk_bh_pro_orb_ecc_crit,
-                        opts.disk_radius_outer,
-                        opts.disk_inner_stable_circ_orb,
                         dlogSigmadlogR_spline,
                         dlogTempdlogR_spline
                     )
@@ -1649,16 +1622,12 @@ def main():
                         disk_opacity,
                         disk_aspect_ratio,
                         temp_func,
-                        disk_sound_speed,
-                        disk_density,
                         opts.disk_bh_eddington_ratio,
                         blackholes_binary.bin_orb_a,
                         blackholes_binary.bin_orb_ecc,
                         opts.disk_bh_pro_orb_ecc_crit,
                         blackholes_binary.mass_1 + blackholes_binary.mass_2,
                         opts.flag_thermal_feedback,
-                        opts.disk_radius_outer,
-                        opts.disk_inner_stable_circ_orb,
                         dlogPressuredlogR_spline
                     )
                     if opts.flag_thermal_feedback > 0:
@@ -1696,7 +1665,7 @@ def main():
                             if opts.smbh_mass < 1.e8 and opts.smbh_mass > 1.e6:
                                 disk_trap_radius = opts.disk_radius_trap * (opts.smbh_mass/1.e8)**(-1.225)
                                 disk_anti_trap_radius = opts.disk_radius_trap * (opts.smbh_mass/1.e8)**(0.099)
-                            #Trap location changes again at low SMBH mass (Grishin+24)
+                            # Trap location changes again at low SMBH mass (Grishin+24)
                             if opts.smbh_mass < 1.e6:
                                 disk_trap_radius = opts.disk_radius_trap * (opts.smbh_mass/1.e8)**(-0.97)
                                 disk_anti_trap_radius = opts.disk_radius_trap * (opts.smbh_mass/1.e8)**(0.099)

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -199,7 +199,7 @@ def main():
     # Disk sound speed [m/s] is a function of radius, where radius is in r_g
     # Disk density [kg/m^3] is a function of radius, where radius is in r_g
     # Return disk log of disk surface density as a function of log (R)
-    disk_surface_density, disk_aspect_ratio, disk_opacity, disk_sound_speed, disk_density, disk_pressure_grad, disk_omega, disk_surface_density_log, temp_func = \
+    disk_surface_density, disk_aspect_ratio, disk_opacity, disk_sound_speed, disk_density, disk_pressure_grad, disk_omega, disk_surface_density_log, temp_func, disk_dlog10surfdens_dlog10R_func, disk_dlog10temp_dlog10R_func, disk_dlog10pressure_dlog10R_func = \
         ReadInputs.construct_disk_interp(opts.smbh_mass,
                                          opts.disk_radius_outer,
                                          opts.disk_model_name,
@@ -209,8 +209,6 @@ def main():
                                          flag_use_pagn=opts.flag_use_pagn,
                                          verbose=opts.verbose
                                          )
-
-    dlogSigmadlogR_spline, dlogTempdlogR_spline, dlogPressuredlogR_spline = migration.disk_derivative_functions(disk_surface_density, temp_func, disk_sound_speed, disk_density, opts.disk_inner_stable_circ_orb, opts.disk_radius_outer)
 
     blackholes_merged_pop = AGNMergedBlackHole()
     emris_pop = AGNBlackHole()
@@ -638,16 +636,16 @@ def main():
                     blackholes_pro.orb_a,
                     blackholes_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
-                    dlogSigmadlogR_spline,
-                    dlogTempdlogR_spline
+                    disk_dlog10surfdens_dlog10R_func,
+                    disk_dlog10temp_dlog10R_func
                 )
 
                 paardekooper_torque_coeff_star = migration.paardekooper10_torque(
                     stars_pro.orb_a,
                     stars_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
-                    dlogSigmadlogR_spline,
-                    dlogTempdlogR_spline
+                    disk_dlog10surfdens_dlog10R_func,
+                    disk_dlog10temp_dlog10R_func
                 )
 
             # Jimenez-Masset torque coeff (from Grishin+24)
@@ -661,8 +659,8 @@ def main():
                     blackholes_pro.orb_a,
                     blackholes_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
-                    dlogSigmadlogR_spline,
-                    dlogTempdlogR_spline
+                    disk_dlog10surfdens_dlog10R_func,
+                    disk_dlog10temp_dlog10R_func
                 )
 
                 jimenez_masset_torque_coeff_star = migration.jimenezmasset17_torque(
@@ -674,8 +672,8 @@ def main():
                     stars_pro.orb_a,
                     stars_pro.orb_ecc,
                     opts.disk_bh_pro_orb_ecc_crit,
-                    dlogSigmadlogR_spline,
-                    dlogTempdlogR_spline
+                    disk_dlog10surfdens_dlog10R_func,
+                    disk_dlog10temp_dlog10R_func
                 )
 
                 # Thermal torque from JM17 (if flag_thermal_feedback off, this component is 0.)
@@ -691,7 +689,7 @@ def main():
                     opts.disk_bh_pro_orb_ecc_crit,
                     blackholes_pro.mass,
                     opts.flag_thermal_feedback,
-                    dlogPressuredlogR_spline
+                    disk_dlog10pressure_dlog10R_func
                 )
 
                 jimenez_masset_thermal_torque_coeff_star = migration.jimenezmasset17_thermal_torque_coeff(
@@ -706,7 +704,7 @@ def main():
                     opts.disk_bh_pro_orb_ecc_crit,
                     blackholes_pro.mass,
                     opts.flag_thermal_feedback,
-                    dlogPressuredlogR_spline
+                    disk_dlog10pressure_dlog10R_func
                 )
 
                 if opts.flag_thermal_feedback == 1:
@@ -1598,8 +1596,8 @@ def main():
                         blackholes_binary.bin_orb_a,
                         blackholes_binary.bin_orb_ecc,
                         opts.disk_bh_pro_orb_ecc_crit,
-                        dlogSigmadlogR_spline,
-                        dlogTempdlogR_spline
+                        disk_dlog10surfdens_dlog10R_func,
+                        disk_dlog10temp_dlog10R_func
                     )
 
                 # Jimenez-Masset torque coeff (from Grishin+24)
@@ -1613,8 +1611,8 @@ def main():
                         blackholes_binary.bin_orb_a,
                         blackholes_binary.bin_orb_ecc,
                         opts.disk_bh_pro_orb_ecc_crit,
-                        dlogSigmadlogR_spline,
-                        dlogTempdlogR_spline
+                        disk_dlog10surfdens_dlog10R_func,
+                        disk_dlog10temp_dlog10R_func
                     )
                     jimenez_masset_thermal_torque_coeff_bh = migration.jimenezmasset17_thermal_torque_coeff(
                         opts.smbh_mass,
@@ -1628,7 +1626,7 @@ def main():
                         opts.disk_bh_pro_orb_ecc_crit,
                         blackholes_binary.mass_1 + blackholes_binary.mass_2,
                         opts.flag_thermal_feedback,
-                        dlogPressuredlogR_spline
+                        disk_dlog10pressure_dlog10R_func
                     )
                     if opts.flag_thermal_feedback > 0:
                         total_jimenez_masset_torque_bh = jimenez_masset_torque_coeff_bh + jimenez_masset_thermal_torque_coeff_bh

--- a/src/mcfacts/external/DiskModelsPAGN.py
+++ b/src/mcfacts/external/DiskModelsPAGN.py
@@ -85,14 +85,13 @@ class AGNGasDiskModel(object):
         kappa = 2 * self.disk_model.tauV / Sigma  # Opacity = 2*tau/Sigma
         cs = self.disk_model.h * self.disk_model.Omega
         temp_midplane = self.disk_model.T # Disk midplane temp (K)
-        
 
-        if flag_truncate_disk: # truncate to gas part of disk (no SFR)
+        if flag_truncate_disk:  # truncate to gas part of disk (no SFR)
             R = R[:self.disk_model.isf]
             Sigma = Sigma[:self.disk_model.isf]
             kappa = kappa[:self.disk_model.isf]
             cs = cs[:self.disk_model.isf]
-        #Temp interpolator function
+        # Temp interpolator function
         ln_temp_midplane = np.log(temp_midplane) # ln midplane temp.
         temp_func_log = scipy.interpolate.CubicSpline(
                                                             np.log(R),
@@ -108,7 +107,7 @@ class AGNGasDiskModel(object):
                                                            ln_Sigma,
                                                            extrapolate=False
                                                            )
-        
+
         surf_dens_func = lambda x, f=surf_dens_func_log: np.exp(f(np.log(x)))
 
         # Generate aspect ratio (h/r) interpolator function
@@ -169,6 +168,33 @@ class AGNGasDiskModel(object):
                                                           )
         disk_omega_func = lambda x, f=disk_omega_func_log: np.exp(f(np.log(x)))
 
+        # Generate disk log10 Sigma function
+        log10_Sigma = np.log10(Sigma)
+        surf_dens_log10_func = scipy.interpolate.CubicSpline(
+            np.log10(R),
+            log10_Sigma,
+            extrapolate=False
+        )
+        surf_dens_log10_derivative_func = surf_dens_log10_func.derivative()
+
+        # Generate disk log10 temp function
+        log10_temp_midplane = np.log10(temp_midplane)
+        temp_log10_func = scipy.interpolate.CubicSpline(
+            np.log10(R),
+            log10_temp_midplane,
+            extrapolate=False
+        )
+        temp_log10_derivative_func = temp_log10_func.derivative()
+
+        # Generate disk log10 midplane pressure func
+        log10_pressure = np.log10((cs ** 2) / self.disk_model.rho)
+        pressure_log10_func = scipy.interpolate.CubicSpline(
+            np.log10(R),
+            log10_pressure,
+            extrapolate=False
+        )
+        pressure_log10_derivative_func = pressure_log10_func.derivative()
+
         bonus_structures = {}
         bonus_structures['R_agn'] = R_agn
         bonus_structures['R'] = R
@@ -179,7 +205,7 @@ class AGNGasDiskModel(object):
         bonus_structures["T"] = self.disk_model.T
         bonus_structures["tauV"] = self.disk_model.tauV
 
-        return surf_dens_func, aspect_func, opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, surf_dens_func_log, temp_func, bonus_structures
+        return surf_dens_func, aspect_func, opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, surf_dens_func_log, temp_func, surf_dens_log10_derivative_func, temp_log10_derivative_func, pressure_log10_derivative_func, bonus_structures
 
 
 

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -518,13 +518,29 @@ def construct_disk_direct(
         np.log(trunc_temperature_data[0]), np.log(trunc_temperature_data[1]))
     disk_temperature_func = lambda x, f=disk_temperatures_func_log: np.exp(f(np.log(x)))
 
+    # Create log10 Sigma function
+    disk_surf_dens_func_log10 = scipy.interpolate.CubicSpline(
+        np.log10(trunc_surf_density_data[0]), np.log10(trunc_surf_density_data[1]))
+    disk_surf_dens_func_log10_derivative = disk_surf_dens_func_log10.derivative()
+
+    # Create log10 temp function
+    disk_temp_func_log10 = scipy.interpolate.CubicSpline(
+        np.log10(trunc_temperature_data[0]), np.log10(trunc_temperature_data[1]))
+    disk_temp_func_log10_derivative = disk_temp_func_log10.derivative()
+
+    # Create log10 midplane pressure function
+    disk_midplane_pressure = (trunc_sound_speed_data[1] ** 2) / trunc_density_data[1]
+    disk_pressure_func_log10 = scipy.interpolate.CubicSpline(
+        np.log10(trunc_density_data[0]), np.log10(disk_midplane_pressure))
+    disk_pressure_func_log10_derivative = disk_pressure_func_log10.derivative()
+
     # Define properties we want to return
     disk_model_properties ={}
     disk_model_properties['Sigma'] = disk_surf_dens_func
     disk_model_properties['h_over_r'] = disk_aspect_ratio_func
     disk_model_properties['kappa'] = disk_opacity_func
 
-    return disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, disk_sound_speed_func, disk_density_func, disk_pressure_gradient_func, disk_omega_func, disk_surf_dens_func_log, disk_temperature_func, disk_model_properties
+    return disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, disk_sound_speed_func, disk_density_func, disk_pressure_gradient_func, disk_omega_func, disk_surf_dens_func_log, disk_temperature_func, disk_surf_dens_func_log10_derivative, disk_temp_func_log10_derivative, disk_pressure_func_log10_derivative, disk_model_properties
 
 
 def construct_disk_pAGN(
@@ -607,7 +623,7 @@ def construct_disk_pAGN(
 
     # Run pAGN
     pagn_model = dm_pagn.AGNGasDiskModel(disk_type=pagn_name, **base_args)
-    disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, bonus_structures = \
+    disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, surf_dens_log10_derivative_func, temp_log10_derivative_func, pressure_log10_derivative_func, bonus_structures = \
         pagn_model.return_disk_surf_model()
 
     # Define properties we want to return
@@ -617,7 +633,7 @@ def construct_disk_pAGN(
     disk_model_properties['kappa'] = disk_opacity_func
     disk_model_properties['dSigmadR'] = disk_surf_dens_func_log
     disk_model_properties['T'] = temp_func
-    return disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, disk_model_properties, bonus_structures
+    return disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, surf_dens_log10_derivative_func, temp_log10_derivative_func, pressure_log10_derivative_func, disk_model_properties, bonus_structures
 
 
 def construct_disk_interp(
@@ -669,7 +685,7 @@ def construct_disk_interp(
     #   infile = model_surface_density.txt, where model is user choice
     if not(flag_use_pagn):
         # Load interpolators
-        disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, disk_model_properties = \
+        disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, surf_dens_log10_derivative_func, temp_log10_derivative_func, pressure_log10_derivative_func, disk_model_properties = \
             construct_disk_direct(
                 disk_model_name,
                 disk_radius_outer,
@@ -678,7 +694,7 @@ def construct_disk_interp(
 
     else:
         # instead, populate with pagn
-        disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, disk_model_properties, bonus_structures = \
+        disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, surf_dens_log10_derivative_func, temp_log10_derivative_func, pressure_log10_derivative_func, disk_model_properties, bonus_structures = \
             construct_disk_pAGN(
                 disk_model_name,
                 smbh_mass,
@@ -692,7 +708,7 @@ def construct_disk_interp(
         print("I read and digested your disk model")
         print("Sending variables back")
 
-    return disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func
+    return disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, surf_dens_log10_derivative_func, temp_log10_derivative_func, pressure_log10_derivative_func
 
 def ReadInputs_prior_mergers(fname='recipes/sg1Myrx2_survivors.dat', verbose=0):
     """This function reads your prior mergers from a file user specifies or

--- a/src/mcfacts/physics/migration.py
+++ b/src/mcfacts/physics/migration.py
@@ -229,9 +229,9 @@ def torque_mig_timescale(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, migr
     return torque_mig_timescale
 
 
-def jiminezmasset17_torque(smbh_mass, disc_surf_density, disk_opacity_func, disk_aspect_ratio_func, temp_func, orbs_a, orbs_ecc, orb_ecc_crit, disk_radius_outer, disk_inner_stable_circ_orb):
-    """Return the Jiminez & Masset (2017) torque coefficient for Type 1 migration
-        Jiminez-Masset_torque = [0.46 + 0.96dSigmadR -1/8dTdR]/gamma
+def jimenezmasset17_torque(smbh_mass, disc_surf_density, disk_opacity_func, disk_aspect_ratio_func, temp_func, orbs_a, orbs_ecc, orb_ecc_crit, disk_radius_outer, disk_inner_stable_circ_orb):
+    """Return the Jimenez & Masset (2017) torque coefficient for Type 1 migration
+        Jimenez-Masset_torque = [0.46 + 0.96dSigmadR -1/8dTdR]/gamma
                                 +[-2.34 -0.1dSigmadR +1.5dTdR]*factor
             where    factor = ((x/2)^{1/2} + (1/gamma))/((x/2)^{1/2} + 1)
             and      x=(16/3)*gamma*(gamma-1)*sigma_SB*T^4/kappa*rho^2*H^4*Omega^3
@@ -313,17 +313,17 @@ def jiminezmasset17_torque(smbh_mass, disc_surf_density, disk_opacity_func, disk
     sqrtfactor = np.sqrt(xfactor/2)
     factor = (sqrtfactor + 1.0/gamma)/(sqrtfactor + 1.0)
 
-    Torque_jiminezmasset_coeff = (0.46 + 0.96 * dSigmadR - 1.8 * dTempdR)/gamma + (-2.34 - 0.1*dSigmadR + 1.5 * dTempdR) * factor
+    Torque_jimenezmasset_coeff = (0.46 + 0.96 * dSigmadR - 1.8 * dTempdR)/gamma + (-2.34 - 0.1*dSigmadR + 1.5 * dTempdR) * factor
 
-    assert np.isfinite(Torque_jiminezmasset_coeff).all(), \
-        "Finite check failure: Torque_jiminezmasset_coeff"
+    assert np.isfinite(Torque_jimenezmasset_coeff).all(), \
+        "Finite check failure: Torque_jimenezmasset_coeff"
 
-    return Torque_jiminezmasset_coeff
+    return Torque_jimenezmasset_coeff
 
 
-def jiminezmasset17_thermal_torque_coeff(smbh_mass, disc_surf_density, disk_opacity_func, disk_aspect_ratio_func, temp_func, sound_speed_func, density_func, disk_bh_eddington_ratio, orbs_a, orbs_ecc, orb_ecc_crit, bh_masses, flag_thermal_feedback, disk_radius_outer, disk_inner_stable_circ_orb):
-    """Return the Jiminez & Masset (2017) thermal torque coefficient for Type 1 migration
-        Jiminez-Masset_thermal_torque_coeff = Torque_hot*(4mu_thermal/(1+4.*mu_thermal))+ Torque_cold*(2mu_thermal/(1+2.*mu_thermal))
+def jimenezmasset17_thermal_torque_coeff(smbh_mass, disc_surf_density, disk_opacity_func, disk_aspect_ratio_func, temp_func, sound_speed_func, density_func, disk_bh_eddington_ratio, orbs_a, orbs_ecc, orb_ecc_crit, bh_masses, flag_thermal_feedback, disk_radius_outer, disk_inner_stable_circ_orb):
+    """Return the Jimenez & Masset (2017) thermal torque coefficient for Type 1 migration
+        Jimenez-Masset_thermal_torque_coeff = Torque_hot*(4mu_thermal/(1+4.*mu_thermal))+ Torque_cold*(2mu_thermal/(1+2.*mu_thermal))
             Given   Torque_hot=thermal_factor*(L/L_c)
                     Torque_cold =-thermal_factor
                 with  L= 4piGm_bh*c/kappa_e_scattering (assuming f_Edd=1, the Eddington fraction of the luminosity)
@@ -522,7 +522,7 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
     bh_min_mass : float
         Minimum mass of BH IMF. Phenom. turbulence is largest for this value. Decreases with bh_mass^2 since normalized torque propto m_bh^2.
     torque_prescription : str
-        Torque prescription 'paardekooper' or 'jiminez_masset' ('old' is deprecated)
+        Torque prescription 'paardekooper' or 'jimenez_masset' ('old' is deprecated)
     Returns
     -------
     orbs_a : float array
@@ -562,12 +562,12 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
     if flag_phenom_turb == 1:
         # Only need to perturb migrators for now
         # size_of_turbulent_array = np.size(migration_indices)
-        # Assume migration is always inwards (true for 'old' and for 'jiminez_masset' for M_smbh>10^8Msun)
+        # Assume migration is always inwards (true for 'old' and for 'jimenez_masset' for M_smbh>10^8Msun)
         # Calc migration distance as modified by turbulence.
         migration_distance = migration_distance*(1.0 + rng.normal(phenom_turb_centroid, phenom_turb_std_dev, size=migration_indices.size))/normalized_mig_masses_sq
 
     if torque_prescription == 'old' or torque_prescription == 'paardekooper':
-        # Assume migration is always inwards (true for 'old' and for 'jiminez_masset' for M_smbh>10^8Msun)
+        # Assume migration is always inwards (true for 'old' and for 'jimenez_masset' for M_smbh>10^8Msun)
         # Disk feedback ratio
         disk_feedback_ratio = disk_feedback_ratio_func[migration_indices]
 
@@ -614,7 +614,7 @@ def type1_migration_distance(smbh_mass, orbs_a, masses, orbs_ecc, orb_ecc_crit, 
         epsilon = disk_radius_outer * ((masses[migration_indices][new_orbs_a > disk_radius_outer] / (3 * (masses[migration_indices][new_orbs_a > disk_radius_outer] + smbh_mass)))**(1. / 3.)) * rng.uniform(size=np.sum(new_orbs_a > disk_radius_outer))
         new_orbs_a[new_orbs_a > disk_radius_outer] = disk_radius_outer - epsilon
 
-    if torque_prescription == 'jiminez_masset':
+    if torque_prescription == 'jimenez_masset':
         # If smbh_mass >10^8Msun --assume migration is always inwards
         if smbh_mass > 1.e8:
             new_orbs_a = new_orbs_a - migration_distance

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -7,7 +7,7 @@ import conftest as provider
 from conftest import InputParameterSet
 import mcfacts.physics.feedback as feedback
 
-disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, disk_model_properties, bonus_structures = construct_disk_pAGN("sirko_goodman", 1.e8, 50000, 0.01, 1.0)
+disk_surf_dens_func, disk_aspect_ratio_func, disk_opacity_func, sound_speed_func, disk_density_func, disk_pressure_grad_func, disk_omega_func, disk_surf_dens_func_log, temp_func, disk_dlog10surfdens_dlog10R_func, disk_dlog10temp_dlog10R_func, disk_dlog10pressure_dlog10R_func, disk_model_properties, bonus_structures = construct_disk_pAGN("sirko_goodman", 1.e8, 50000, 0.01, 1.0)
 
 
 def feedback_bh_hankla_param():


### PR DESCRIPTION
#### Summary

- Moved interpolators for d log(Sigma) / d log(R), d log(temp) / d log(R), and d log(midplane pressure) / d log(R) into their own function that is called at the beginning of mcfacts_sim
- Deleted `paardekooper10_torque_binary` function as binaries can just use the `paardekooper10_torque` function
- Changed jim*I*nez_masset to jim*E*nez_masset