### PR TITLE
restored galaxy_num back to its rightful value of 1

### DIFF
--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -111,7 +111,7 @@ timestep_duration_yr = 1.e4
 timestep_num = 60
 
 # number of galaxies of code (1 for testing. 30 for a quick run.)
-galaxy_num = 100
+galaxy_num = 1
 #
 # Other physics choices: 
 #


### PR DESCRIPTION
#### Summary
Accidentally changed `galaxy_num` to 100 and it should be 1 as the default.