### PR TITLE
Fixed argparse bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ mcfacts_sim: clean
 	cd runs; \
 		python ../${MCFACTS_SIM_EXE} \
 		--galaxy_num 100 \
+		--fname-ini ../${FNAME_INI} \
 		--fname-log mcfacts.log \
 		--seed ${SEED}
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ mcfacts_sim: clean
 	cd runs; \
 		python ../${MCFACTS_SIM_EXE} \
 		--galaxy_num 100 \
-		--fname-ini ../${FNAME_INI} \
 		--fname-log mcfacts.log \
 		--seed ${SEED}
 

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -83,6 +83,9 @@ def arg():
     parser.add_argument("--fname-log", default="mcfacts.log", type=str,
                         help="Specify a file in which to save the arguments and some runtime information. Default: mcfacts.log")
 
+    #### Begin Argparse Nonsense
+    #### Please do not modify between this line and the END Argparse Nonsense
+    ####  line unless you have a good reason.
     # Add inifile arguments
     # Read default inifile
     _variable_inputs = ReadInputs.ReadInputs_ini(DEFAULT_INI, False)
@@ -96,21 +99,21 @@ def arg():
         _default = _variable_inputs[name]
         _dtype = type(_variable_inputs[name])
         parser.add_argument(_opt,
-                            default=_default,
+                            default=None,
                             type=_dtype,
                             metavar=_metavar,
                             )
 
-    # Parse arguments
+
+    # Parse arguments, using the opts namespace
+    # This causes the default inifile values to be overwritten
+    # by CLI arguments
     opts = parser.parse_args()
     # Check that the inifile exists
     assert isfile(opts.fname_ini)
     # Convert to path objects
     opts.fname_ini = Path(opts.fname_ini)
     assert opts.fname_ini.is_file()
-    opts.fname_snapshots_bh = Path(opts.fname_snapshots_bh)
-    opts.fname_output_mergers = Path(opts.fname_output_mergers)
-    opts.fname_output = Path(opts.fname_output)
 
     # Parse inifile
     print("opts.fname_ini", opts.fname_ini)
@@ -127,7 +130,7 @@ def arg():
             setattr(opts, name, variable_inputs[name])
             continue
         # Check for args not in the default_ini file
-        if getattr(opts, name) != _variable_inputs[name]:
+        if getattr(opts, name) is not None:
             # This is the case where the user has set the value of an argument
             # from the command line. We don't want to argue with the user.
             pass
@@ -139,7 +142,12 @@ def arg():
     # Case 3: if an attribute is in the default infile,
     #   and not the specified inifile,
     #   it remains unaltered.
+    #### End Argparse Nonsense ####
 
+    # Update paths of arguments to Path type
+    opts.fname_snapshots_bh = Path(opts.fname_snapshots_bh)
+    opts.fname_output_mergers = Path(opts.fname_output_mergers)
+    opts.fname_output = Path(opts.fname_output)
     if opts.verbose:
         for item in opts.__dict__:
             print(item, getattr(opts, item))

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -28,6 +28,16 @@ disk_alpha_viscosity = 0.01
 inner_disk_outer_radius = 50.
 # Innermost Stable Circular Orbit around the SMBH (Rg)
 disk_inner_stable_circ_orb = 6.
+# Torque prescription ('old','paardekooper','jimenez_masset': Paaardekooper default; Jimenez-Masset option)
+torque_prescription = 'paardekooper'
+#phenomenological turbulence
+flag_phenom_turb = 0
+#Centroid of Gaussian w.r.t. to migrating BH. 0 (default)
+phenom_turb_centroid = 0.
+#Variance of Gaussian around Centroid (default=0.1)
+phenom_turb_std_dev = 1.0
+
+
 #
 # Nuclear Star Cluster Population:
 #
@@ -72,9 +82,11 @@ mass_pile_up = 35.
 #
 #
 #Star stuff
-flag_add_stars = 1
+flag_add_stars = 0
 # If 1: stars over disk_star_initial_mass_cutoff turn into BH. If 0: stars over disk_star_initial_mass_cutoff are held at the cutoff and are immortal. Default 1.
 flag_initial_stars_BH_immortal = 0
+# If 0: star masses are drawn from IMF and not changed before beginning of time loop. If 1: stars within each others Hill spheres are merged together before the beginning of the time loop.
+flag_coalesce_initial_stars = 0
 # Maximum initial star mass before flag_initial_stars_BH_immortal behavior kicks in. Default 300.
 disk_star_initial_mass_cutoff = 298.
 # Factor by which to scale the number of stars in the disk at the beginning of the galaxy. Default 1.e-3.
@@ -96,10 +108,10 @@ nsc_star_metallicity_z_init = 0.02
 # timestep in years (float)
 timestep_duration_yr = 1.e4
 # For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
-timestep_num = 50
+timestep_num = 60
 
 # number of galaxies of code (1 for testing. 30 for a quick run.)
-galaxy_num = 1
+galaxy_num = 100
 #
 # Other physics choices: 
 #


### PR DESCRIPTION
@spacekaila pointed out to me that there was a bug in my argparse code.

I believe I have fixed the bug without changing any behavior.

I also updated `src/mcfacts/inputs/data/model_choice.ini` so that `mcfacts_sim.py` can function without an inifile provided at the command line.

#### Description

The desired behavior has always been a priority of:
- 1. CLI arguments
- 2. Inifile provided by CLI
- 3. default inifile in `src/mcfacts/inputs/data/model_choice.ini`

However, if the CLI argument had the same value as the default inifile value, it would be ignored in favor of the provided inifile.

This is because I was using whether the value of the argument had changed or not to decide if the argument was provided by the command line.

This should be fixed in this pull request.

#### Testing

I tested the behavior by printing:
```print(_variable_inputs["galaxy_num"])
print(variable_inputs["galaxy_num"])
print(opts.galaxy_num)
raise Exception
```
Below the "End Argparse Nonsense" comment line.

I tested:
- both inifiles have different values, and different from the command line value
- both inifiles have the same value as the command line value
- the default inifile and provided inifile disagree, but the command line value agrees with the default inifile (previously bugged)
- the default inifile and provided inifile disagree, but the command line value agrees with the provided inifile
- the default inifile and provided inifile agree, but are different from the command line value
- no inifile provided at the command line