### PR TITLE
Took out redundant slow np.argsort call, generate random numbers only once

### DIFF
--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1160,8 +1160,7 @@ def main():
                     filing_cabinet.remove_id_num(star_id_nums)
 
                     # BHs accrete mass and spin up
-                    a, b = np.where(blackholes_pro.id_num == bh_id_nums[:, None])
-                    bh_id_mask = b[np.argsort(a)]
+                    _, bh_id_mask = np.where(blackholes_pro.id_num == bh_id_nums[:, None])
                     blackholes_pro.mass[bh_id_mask] = accretion.change_bh_mass(
                         blackholes_pro.mass[bh_id_mask],
                         opts.disk_bh_eddington_ratio,
@@ -2015,8 +2014,7 @@ def main():
                     filing_cabinet.remove_id_num(star_id_nums)
 
                     # BHs accrete mass and spin up
-                    a, b = np.where(blackholes_pro.id_num == bh_id_nums[:, None])
-                    bh_id_mask = b[np.argsort(a)]
+                    _, bh_id_mask = np.where(blackholes_pro.id_num == bh_id_nums[:, None])
                     blackholes_pro.mass[bh_id_mask] = accretion.change_bh_mass(
                         blackholes_pro.mass[bh_id_mask],
                         opts.disk_bh_eddington_ratio,

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -314,8 +314,7 @@ class AGNObject(object):
             print(id_num_remove, type(id_num_remove))
             raise AttributeError("Passed id_num is not a valid type.")
         # Ensures that values are returned in the order of the original id_num array
-        a, b = np.where(getattr(self, "id_num") == id_num_remove_arr[:, None])
-        remove_idx = b[np.argsort(a)]
+        _, remove_idx = np.where(getattr(self, "id_num") == id_num_remove_arr[:, None])
         keep_idx = np.ones(self.num, dtype=bool)
         keep_idx[remove_idx] = False
         attr_list = get_attr_list(self)
@@ -373,8 +372,7 @@ class AGNObject(object):
             print(id_num_keep, type(id_num_keep))
             raise AttributeError("Passed id_num is not a valid type.")
         # Ensures that values are returned in the order of the original id_num array
-        a, b = np.where(getattr(self, "id_num") == id_num_keep_arr[:, None])
-        keep_idx = b[np.argsort(a)]
+        _, keep_idx = np.where(getattr(self, "id_num") == id_num_keep_arr[:, None])
         attr_list = get_attr_list(self)
         for attr in attr_list:
             setattr(self, attr, getattr(self, attr)[keep_idx])
@@ -409,8 +407,7 @@ class AGNObject(object):
             print(id_num, type(id_num))
             raise AttributeError("Passed id_num is not a valid type.")
         # Ensures that values are returned in the order of the original id_num array
-        a, b = np.where(getattr(self, "id_num") == id_num_arr[:, None])
-        id_mask = b[np.argsort(a)]
+        _, id_mask = np.where(getattr(self, "id_num") == id_num_arr[:, None])
 
         try:
             val = getattr(self, attr)[id_mask]

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -170,6 +170,8 @@ def circular_singles_encounters_prograde(
     N_circ_orbs_per_timestep = timestep_duration_yr/orbital_timescales_circ_pops
     ecc_orb_min = disk_bh_pro_orbs_a[ecc_prograde_population_indices]*(1.0-disk_bh_pro_orbs_ecc[ecc_prograde_population_indices])
     ecc_orb_max = disk_bh_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_bh_pro_orbs_ecc[ecc_prograde_population_indices])
+    # Generate all possible needed random numbers ahead of time
+    chance_of_enc = rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
     num_poss_ints = 0
     num_encounters = 0
     if len(circ_prograde_population_indices) > 0:
@@ -185,8 +187,7 @@ def circular_singles_encounters_prograde(
                     prob_enc_per_timestep = prob_orbit_overlap * N_circ_orbs_per_timestep[i]
                     if prob_enc_per_timestep > 1:
                         prob_enc_per_timestep = 1
-                    random_uniform_number = rng.uniform(size=1)
-                    if random_uniform_number < prob_enc_per_timestep:
+                    if chance_of_enc[i][j] < prob_enc_per_timestep:
                         num_encounters = num_encounters + 1
                         # if close encounter, pump ecc of circ orbiter to e=0.1 from near circular, and incr a_circ1 by 10%
                         # drop ecc of a_i by 10% and drop a_i by 10% (P.E. = -GMm/a)
@@ -378,6 +379,8 @@ def circular_singles_encounters_prograde_stars(
     N_circ_orbs_per_timestep = timestep_duration_yr/orbital_timescales_circ_pops
     ecc_orb_min = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0-disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
     ecc_orb_max = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
+    # Generate all possible needed random numbers ahead of time
+    chance_of_enc = rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
     num_poss_ints = 0
     num_encounters = 0
     id_nums_poss_touch = []
@@ -395,8 +398,7 @@ def circular_singles_encounters_prograde_stars(
                     prob_enc_per_timestep = prob_orbit_overlap * N_circ_orbs_per_timestep[i]
                     if prob_enc_per_timestep > 1:
                         prob_enc_per_timestep = 1
-                    random_uniform_number = rng.uniform(size=1)
-                    if random_uniform_number < prob_enc_per_timestep:
+                    if chance_of_enc[i][j] < prob_enc_per_timestep:
                         num_encounters = num_encounters + 1
                         # if close encounter, pump ecc of circ orbiter to e=0.1 from near circular, and incr a_circ1 by 10%
                         # drop ecc of a_i by 10% and drop a_i by 10% (P.E. = -GMm/a)
@@ -633,6 +635,8 @@ def circular_singles_encounters_prograde_star_bh(
     ecc_orb_max = disk_bh_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_bh_pro_orbs_a[ecc_prograde_population_indices])
     num_poss_ints = 0
     num_encounters = 0
+    # Generate all possible needed random numbers ahead of time
+    chance_of_enc = rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
     id_nums_poss_touch = []
     frac_rhill_sep = []
     if len(circ_prograde_population_indices) > 0:
@@ -648,8 +652,7 @@ def circular_singles_encounters_prograde_star_bh(
                     prob_enc_per_timestep = prob_orbit_overlap * N_circ_orbs_per_timestep[i]
                     if prob_enc_per_timestep > 1:
                         prob_enc_per_timestep = 1
-                    random_uniform_number = rng.uniform(size=1)
-                    if random_uniform_number < prob_enc_per_timestep:
+                    if chance_of_enc[i][j] < prob_enc_per_timestep:
                         num_encounters = num_encounters + 1
                         # if close encounter, pump ecc of circ orbiter to e=0.1 from near circular, and incr a_circ1 by 10%
                         # drop ecc of a_i by 10% and drop a_i by 10% (P.E. = -GMm/a)


### PR DESCRIPTION
#### Summary
- Realized that I was doing the same thing twice with my np.argsort calls, so I took that out
- Generate array of random numbers once at the beginning of dynamics functions, instead of a single random number every time we loop