### PR TITLE
Fixed bug that could cause ID numbers to be repeated

### DIFF
--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -227,6 +227,8 @@ def main():
     stars_explode_pop = AGNExplodedStar()
     stars_merge_pop = AGNMergedStar()
 
+    id_num_start_val = 0
+
     # Setting up arrays to keep track of how much mass is cycled through stars
     disk_arr_galaxy = []
     disk_arr_timestep_pop = np.array([])
@@ -334,7 +336,8 @@ def main():
                                   orb_arg_periapse=bh_orb_arg_periapse_initial,
                                   bh_num=disk_bh_num,
                                   galaxy=np.full(disk_bh_num, galaxy),
-                                  time_passed=np.zeros(disk_bh_num))
+                                  time_passed=np.zeros(disk_bh_num),
+                                  id_start_val=id_num_start_val)
 
         # Initialize filing_cabinet
         filing_cabinet = AGNFilingCabinet(id_num=blackholes.id_num,
@@ -1472,7 +1475,6 @@ def main():
                     if bh_binary_id_num_unphysical.size > 0:
                         blackholes_binary.remove_id_num(bh_binary_id_num_unphysical)
                         filing_cabinet.remove_id_num(bh_binary_id_num_unphysical)
-
                     blackholes_merged, blackholes_pro = merge.merge_blackholes(blackholes_binary,
                                                                                blackholes_pro,
                                                                                blackholes_merged,
@@ -2720,6 +2722,8 @@ def main():
                                   new_log_radius_final=stars_merge.log_radius_final,
                                   new_orb_ecc=stars_merge.orb_ecc,
                                   new_time_merged=stars_merge.time_merged)
+        
+        id_num_start_val = filing_cabinet.id_max + 1
 
         # Add mass cycled info to population arrays
         disk_arr_timestep_pop = np.concatenate([disk_arr_timestep_pop, disk_arr_timestep])

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -227,8 +227,6 @@ def main():
     stars_explode_pop = AGNExplodedStar()
     stars_merge_pop = AGNMergedStar()
 
-    id_num_start_val = 0
-
     # Setting up arrays to keep track of how much mass is cycled through stars
     disk_arr_galaxy = []
     disk_arr_timestep_pop = np.array([])
@@ -336,8 +334,7 @@ def main():
                                   orb_arg_periapse=bh_orb_arg_periapse_initial,
                                   bh_num=disk_bh_num,
                                   galaxy=np.full(disk_bh_num, galaxy),
-                                  time_passed=np.zeros(disk_bh_num),
-                                  id_start_val=id_num_start_val)
+                                  time_passed=np.zeros(disk_bh_num))
 
         # Initialize filing_cabinet
         filing_cabinet = AGNFilingCabinet(id_num=blackholes.id_num,
@@ -2722,8 +2719,6 @@ def main():
                                   new_log_radius_final=stars_merge.log_radius_final,
                                   new_orb_ecc=stars_merge.orb_ecc,
                                   new_time_merged=stars_merge.time_merged)
-        
-        id_num_start_val = filing_cabinet.id_max + 1
 
         # Add mass cycled info to population arrays
         disk_arr_timestep_pop = np.concatenate([disk_arr_timestep_pop, disk_arr_timestep])

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -197,6 +197,7 @@ class AGNObject(object):
         self.num = obj_num
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def add_objects(self,
                     new_mass=empty_arr,
@@ -267,6 +268,7 @@ class AGNObject(object):
         self.num += obj_num
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def remove_index(self, idx_remove=None):
         """
@@ -290,6 +292,7 @@ class AGNObject(object):
         self.num -= np.sum(idx_change)
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def remove_id_num(self, id_num_remove=None):
         """
@@ -326,6 +329,7 @@ class AGNObject(object):
         self.num -= len(remove_idx)
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def keep_index(self, idx_keep):
         """
@@ -349,6 +353,7 @@ class AGNObject(object):
         self.num -= np.sum(idx_change)
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def keep_id_num(self, id_num_keep):
         """
@@ -382,6 +387,7 @@ class AGNObject(object):
         self.num = len(keep_idx)
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def at_id_num(self, id_num, attr):
         """Returns the attribute at the specified ID numbers
@@ -519,6 +525,7 @@ class AGNObject(object):
         assert fname is not None, "Need to pass filename"
 
         self.check_consistency()
+        self.unique_id_nums()
 
         import pandas
         samples_out = self.return_record_array()
@@ -550,6 +557,7 @@ class AGNObject(object):
         assert fname is not None, "Need to pass filename"
 
         self.check_consistency()
+        self.unique_id_nums()
 
         if cols is not None:
             attributes = cols
@@ -1168,6 +1176,7 @@ class AGNBinaryBlackHole(AGNObject):
         self.num = bin_bh_num
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def __repr__(self):
         return ('AGNBinaryBlackHole(): {} black hole binaries'.format(self.num))
@@ -1284,6 +1293,7 @@ class AGNBinaryBlackHole(AGNObject):
         #self.mass_total = np.concatenate([self.mass_total, new_mass_1 + new_mass_2])
 
         self.check_consistency()
+        self.unique_id_nums()
 
     @property
     def mass_total(self):
@@ -1397,6 +1407,7 @@ class AGNMergedBlackHole(AGNObject):
         self.num = num_obj_merge
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def add_blackholes(self, new_id_num=empty_arr, new_galaxy=empty_arr, new_bin_orb_a=empty_arr,
                        new_mass_final=empty_arr, new_spin_final=empty_arr, new_spin_angle_final=empty_arr,
@@ -1479,6 +1490,7 @@ class AGNMergedBlackHole(AGNObject):
         self.num += num_obj_merge
 
         self.check_consistency()
+        self.unique_id_nums()
 
 
 class AGNMergedStar(AGNObject):
@@ -1548,6 +1560,7 @@ class AGNMergedStar(AGNObject):
         self.num = num_obj_merge
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def add_stars(self, new_id_num=empty_arr, new_galaxy=empty_arr, new_orb_a_final=empty_arr, new_gen_final=empty_arr,
                   new_mass_final=empty_arr,
@@ -1605,6 +1618,7 @@ class AGNMergedStar(AGNObject):
         self.num += num_obj_merge
 
         self.check_consistency()
+        self.unique_id_nums()
 
 
 class AGNExplodedStar(AGNObject):
@@ -1850,6 +1864,7 @@ class AGNFilingCabinet(AGNObject):
         self.num = fc_num
 
         self.check_consistency()
+        self.unique_id_nums()
 
     def __repr__(self):
         """
@@ -1967,3 +1982,5 @@ class AGNFilingCabinet(AGNObject):
         self.num += fc_num
 
         self.check_consistency()
+        self.unique_id_nums()
+        self.id_max

--- a/src/mcfacts/objects/agnobject.py
+++ b/src/mcfacts/objects/agnobject.py
@@ -197,7 +197,6 @@ class AGNObject(object):
         self.num = obj_num
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def add_objects(self,
                     new_mass=empty_arr,
@@ -268,7 +267,6 @@ class AGNObject(object):
         self.num += obj_num
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def remove_index(self, idx_remove=None):
         """
@@ -292,7 +290,6 @@ class AGNObject(object):
         self.num -= np.sum(idx_change)
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def remove_id_num(self, id_num_remove=None):
         """
@@ -329,7 +326,6 @@ class AGNObject(object):
         self.num -= len(remove_idx)
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def keep_index(self, idx_keep):
         """
@@ -353,7 +349,6 @@ class AGNObject(object):
         self.num -= np.sum(idx_change)
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def keep_id_num(self, id_num_keep):
         """
@@ -387,7 +382,6 @@ class AGNObject(object):
         self.num = len(keep_idx)
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def at_id_num(self, id_num, attr):
         """Returns the attribute at the specified ID numbers
@@ -525,7 +519,6 @@ class AGNObject(object):
         assert fname is not None, "Need to pass filename"
 
         self.check_consistency()
-        self.unique_id_nums()
 
         import pandas
         samples_out = self.return_record_array()
@@ -557,7 +550,6 @@ class AGNObject(object):
         assert fname is not None, "Need to pass filename"
 
         self.check_consistency()
-        self.unique_id_nums()
 
         if cols is not None:
             attributes = cols
@@ -1176,7 +1168,6 @@ class AGNBinaryBlackHole(AGNObject):
         self.num = bin_bh_num
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def __repr__(self):
         return ('AGNBinaryBlackHole(): {} black hole binaries'.format(self.num))
@@ -1293,7 +1284,6 @@ class AGNBinaryBlackHole(AGNObject):
         #self.mass_total = np.concatenate([self.mass_total, new_mass_1 + new_mass_2])
 
         self.check_consistency()
-        self.unique_id_nums()
 
     @property
     def mass_total(self):
@@ -1407,7 +1397,6 @@ class AGNMergedBlackHole(AGNObject):
         self.num = num_obj_merge
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def add_blackholes(self, new_id_num=empty_arr, new_galaxy=empty_arr, new_bin_orb_a=empty_arr,
                        new_mass_final=empty_arr, new_spin_final=empty_arr, new_spin_angle_final=empty_arr,
@@ -1490,7 +1479,6 @@ class AGNMergedBlackHole(AGNObject):
         self.num += num_obj_merge
 
         self.check_consistency()
-        self.unique_id_nums()
 
 
 class AGNMergedStar(AGNObject):
@@ -1560,7 +1548,6 @@ class AGNMergedStar(AGNObject):
         self.num = num_obj_merge
 
         self.check_consistency()
-        self.unique_id_nums()
 
     def add_stars(self, new_id_num=empty_arr, new_galaxy=empty_arr, new_orb_a_final=empty_arr, new_gen_final=empty_arr,
                   new_mass_final=empty_arr,
@@ -1618,7 +1605,6 @@ class AGNMergedStar(AGNObject):
         self.num += num_obj_merge
 
         self.check_consistency()
-        self.unique_id_nums()
 
 
 class AGNExplodedStar(AGNObject):


### PR DESCRIPTION
#### Summary

`AGNFilingCabinet.id_max` returns the current highest ID number, but it is only updated when `id_max` is called, meaning if you call `id_max` to help create a new BH but don't call it again afterward, `id_max` will not be updated to include the ID number of the new BH. Now we call `id_max` in the `AGNFilingCabinet.add_objects` function so it is always up to date.