### PR TITLE
Changed variable names, removed usage of unused variable

### DIFF
--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -137,6 +137,6 @@ delta_energy_strong_mu = 0.1
 # Sigma of delta energy per strong interaction
 delta_energy_strong_sigma = 0.02
 # Average energy exchanged in a strong 2 + 1 interaction that hardens the binary
-mean_harden_energy_delta = 0.9
+harden_energy_delta_mu = 0.9
 # Variance of the energy exchanged in a strong 2 + 1 interaction that hardens the binary
-var_harden_energy_delta = 0.025
+harden_energy_delta_sigma = 0.025

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -624,7 +624,7 @@ def main():
                     stars_pro.orb_a,
                     disk_surface_density,
                     disk_opacity,
-                    opts.disk_star_eddington_ratio,
+                    opts.disk_bh_eddington_ratio,
                     opts.disk_alpha_viscosity,
                     opts.disk_radius_outer,)
             else:

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1361,8 +1361,8 @@ def main():
                         opts.disk_bh_pro_orb_ecc_crit,
                         opts.delta_energy_strong_mu,
                         opts.disk_radius_outer,
-                        opts.mean_harden_energy_delta,
-                        opts.var_harden_energy_delta
+                        opts.harden_energy_delta_mu,
+                        opts.harden_energy_delta_sigma
                     )
 
                     # Update filing cabinet with new bin_sep
@@ -1444,8 +1444,8 @@ def main():
                         opts.disk_bh_pro_orb_ecc_crit,
                         opts.delta_energy_strong_mu,
                         opts.disk_radius_outer,
-                        opts.mean_harden_energy_delta,
-                        opts.var_harden_energy_delta)
+                        opts.harden_energy_delta_mu,
+                        opts.harden_energy_delta_sigma)
 
                     if (bbh_id_nums_merged.size > 0):
                         # Change merger flag
@@ -2081,8 +2081,8 @@ def main():
                         opts.nsc_imf_bh_powerlaw_index,
                         opts.delta_energy_strong_mu,
                         opts.nsc_spheroid_normalization,
-                        opts.mean_harden_energy_delta,
-                        opts.var_harden_energy_delta
+                        opts.harden_energy_delta_mu,
+                        opts.harden_energy_delta_sigma
                     )
                     # Update filing cabinet with new bin_sep
                     filing_cabinet.update(id_num=blackholes_binary.id_num,

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -129,10 +129,10 @@ Inifile
         Pile-up of masses caused by cutoff (M_sun)
     "save_snapshots"                : int
         Save snapshots of the disk and NSC at each timestep
-    "mean_harden_energy_delta"      : float
+    "harden_energy_delta_mu"      : float
         The Gaussian mean value for the energy change during a strong interaction
-    "var_harden_energy_delta"       : float
-        The Gaussian variance value for the energy change during a strong interaction
+    "harden_energy_delta_sigma"       : float
+        The Gaussian standard deviation value for the energy change during a strong interaction
     "flag_use_surrogate"            : int
         Switch (0) uses analytical kick prescription from Akiba et al. (2024). Switch (1) uses NRSurrogate model from (paper in prep).
 """
@@ -207,8 +207,8 @@ INPUT_TYPES = {
     "disk_inner_stable_circ_orb"    : float,
     "mass_pile_up"                  : float,
     "save_snapshots"                : int,
-    "mean_harden_energy_delta"      : float,
-    "var_harden_energy_delta"       : float,
+    "harden_energy_delta_mu"      : float,
+    "harden_energy_delta_sigma"       : float,
     "torque_prescription"           : str,
     "flag_phenom_turb"              : int,
     "phenom_turb_centroid"          : float,

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -137,6 +137,6 @@ delta_energy_strong_mu = 0.1
 # Sigma of delta energy per strong interaction
 delta_energy_strong_sigma = 0.02
 # Average energy exchanged in a strong 2 + 1 interaction that hardens the binary
-mean_harden_energy_delta = 0.9
+harden_energy_delta_mu = 0.9
 # Variance of the energy exchanged in a strong 2 + 1 interaction that hardens the binary
-var_harden_energy_delta = 0.025
+harden_energy_delta_sigma = 0.025

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -1781,8 +1781,8 @@ def circular_binaries_encounters_circ_prograde(
         disk_bh_pro_orb_ecc_crit,
         delta_energy_strong,
         disk_radius_outer,
-        mean_harden_energy_delta,
-        var_harden_energy_delta
+        harden_energy_delta_mu,
+        harden_energy_delta_sigma
         ):
     """"Adjust orb ecc due to encounters btw BBH and circularized singles
 
@@ -1808,9 +1808,9 @@ def circular_binaries_encounters_circ_prograde(
         complete description
     disk_radius_outer : float
         Outer radius of the inner disk (Rg)
-    var_harden_energy_delta : float
+    harden_energy_delta_sigma : float
         Average energy exchanged in a strong 2 + 1 interaction that hardens the binary
-    mean_harden_energy_delta : float
+    harden_energy_delta_mu : float
         Variance of the energy exchanged in a strong 2 + 1 interaction that hardens the binary
 
     Returns
@@ -1928,7 +1928,7 @@ def circular_binaries_encounters_circ_prograde(
     # delta_energy_strong (read into this module) refers to the perturbation of the orbit of the binary c.o.m. around the SMBH, which is not as strongly perturbed (we take an 'average' perturbation)
 
     # Pick from a normal distribution defined by the user, and bound it between 0 and 1.
-    de_strong = max(0., min(1., rng.normal(mean_harden_energy_delta, var_harden_energy_delta)))
+    de_strong = max(0., min(1., rng.normal(harden_energy_delta_mu, harden_energy_delta_sigma)))
 
     # eccentricity correction--do not let ecc>=1, catch and reset to 1-epsilon
     epsilon = 1e-8
@@ -2059,8 +2059,8 @@ def circular_binaries_encounters_circ_prograde_star(
         disk_bh_pro_orb_ecc_crit,
         delta_energy_strong,
         disk_radius_outer,
-        mean_harden_energy_delta,
-        var_harden_energy_delta
+        harden_energy_delta_mu,
+        harden_energy_delta_sigma
         ):
     """"Adjust orb ecc due to encounters btw BBH and circularized singles
 
@@ -2086,9 +2086,9 @@ def circular_binaries_encounters_circ_prograde_star(
         complete description
     disk_radius_outer : float
         Outer radius of the inner disk (Rg)
-    var_harden_energy_delta : float
+    harden_energy_delta_sigma : float
         Average energy exchanged in a strong 2 + 1 interaction that hardens the binary
-    mean_harden_energy_delta : float
+    harden_energy_delta_mu : float
         Variance of the energy exchanged in a strong 2 + 1 interaction that hardens the binary
 
     Returns
@@ -2199,7 +2199,7 @@ def circular_binaries_encounters_circ_prograde_star(
     # delta_energy_strong (read into this module) refers to the perturbation of the orbit of the binary c.o.m. around the SMBH, which is not as strongly perturbed (we take an 'average' perturbation)
 
     # Pick from a normal distribution defined by the user, and bound it between 0 and 1.
-    de_strong = max(0., min(1., rng.normal(mean_harden_energy_delta, var_harden_energy_delta)))
+    de_strong = max(0., min(1., rng.normal(harden_energy_delta_mu, harden_energy_delta_sigma)))
 
     # eccentricity correction--do not let ecc>=1, catch and reset to 1-epsilon
     epsilon = 1e-8
@@ -2387,8 +2387,8 @@ def bin_spheroid_encounter(
         nsc_bh_imf_powerlaw_index,
         delta_energy_strong,
         nsc_spheroid_normalization,
-        mean_harden_energy_delta,
-        var_harden_energy_delta
+        harden_energy_delta_mu,
+        harden_energy_delta_sigma
         ):
     """Perturb orbits due to encounters with spheroid (NSC) objects
 
@@ -2412,9 +2412,9 @@ def bin_spheroid_encounter(
     nsc_spheroid_normalization : float
         Normalization factor [unitless] determines the departures from sphericity of
         the initial distribution of perturbers (1.0=spherical)
-    var_harden_energy_delta : float
+    harden_energy_delta_sigma : float
         Average energy exchanged in a strong 2 + 1 interaction that hardens the binary
-    mean_harden_energy_delta : float
+    harden_energy_delta_mu : float
         Variance of the energy exchanged in a strong 2 + 1 interaction that hardens the binary
 
 
@@ -2547,7 +2547,7 @@ def bin_spheroid_encounter(
     # delta_energy_strong refers to the perturbation of the orbit of the binary c.o.m. around the SMBH, which is not as strongly perturbed (we take an 'average' perturbation) 
 
     # Pick from a normal distribution defined by the user, and bound it between 0 and 1.
-    de_strong = max(0., min(1., rng.normal(mean_harden_energy_delta, var_harden_energy_delta)))
+    de_strong = max(0., min(1., rng.normal(harden_energy_delta_mu, harden_energy_delta_sigma)))
 
     # eccentricity correction--do not let ecc>=1, catch and reset to 1-epsilon
     epsilon = 1e-8


### PR DESCRIPTION
#### Summary

The fractional energy change for binary components for a hardening encounter with a single BH is determined by a Gaussian with user-set mean and standard deviation. However, the standard deviation variable was named as variance. I renamed these variables as below to be more clear and consistent with how we name other Gaussian parameters
- `mean_harden_energy_delta` --> `harden_energy_delta_mu`
- `var_harden_energy_delta` --> `harden_energy_delta_sigma`

I also changed `opts.disk_star_eddington_ratio` to `opts.disk_bh_eddington_ratio` in the `feedback.feedback_stars_hankla` call, as everywhere else we use `opts.disk_bh_eddington_ratio` for both stars and BHs and the variable is identical for each.