### PR TITLE
dynamics: added flag_dynamics_sweep

### DIFF
--- a/IOdocumentation.txt
+++ b/IOdocumentation.txt
@@ -233,6 +233,9 @@ star cluster variables second, and assorted other choices (time resolution etc.)
         default: 0.2735
     nsc_star_metallicity_z_init : float
         default: 0.02    
+    flag_dynamics_sweep : int
+        Switch to turn on/off sweep function for dynamics functions
+        default: 0
 
 
 Output file : output_mergers.dat

--- a/recipes/model_choice_old.ini
+++ b/recipes/model_choice_old.ini
@@ -140,3 +140,6 @@ delta_energy_strong_sigma = 0.02
 harden_energy_delta_mu = 0.9
 # Variance of the energy exchanged in a strong 2 + 1 interaction that hardens the binary
 harden_energy_delta_sigma = 0.025
+
+# Computational
+flag_dynamics_sweep = 1

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1041,16 +1041,28 @@ def main():
             if opts.flag_dynamic_enc > 0:
 
                 # BH-BH encounters
-                blackholes_pro.orb_a, blackholes_pro.orb_ecc = dynamics.circular_singles_encounters_prograde(
-                    opts.smbh_mass,
-                    blackholes_pro.orb_a,
-                    blackholes_pro.mass,
-                    blackholes_pro.orb_ecc,
-                    opts.timestep_duration_yr,
-                    opts.disk_bh_pro_orb_ecc_crit,
-                    opts.delta_energy_strong_mu,
-                    opts.disk_radius_outer
-                )
+                if opts.flag_dynamics_sweep:
+                    blackholes_pro.orb_a, blackholes_pro.orb_ecc = dynamics.circular_singles_encounters_prograde_sweep(
+                        opts.smbh_mass,
+                        blackholes_pro.orb_a,
+                        blackholes_pro.mass,
+                        blackholes_pro.orb_ecc,
+                        opts.timestep_duration_yr,
+                        opts.disk_bh_pro_orb_ecc_crit,
+                        opts.delta_energy_strong_mu,
+                        opts.disk_radius_outer
+                    )
+                else:
+                    blackholes_pro.orb_a, blackholes_pro.orb_ecc = dynamics.circular_singles_encounters_prograde(
+                        opts.smbh_mass,
+                        blackholes_pro.orb_a,
+                        blackholes_pro.mass,
+                        blackholes_pro.orb_ecc,
+                        opts.timestep_duration_yr,
+                        opts.disk_bh_pro_orb_ecc_crit,
+                        opts.delta_energy_strong_mu,
+                        opts.disk_radius_outer
+                    )
 
                 # Star-star encounters
                 rstar_rhill_exponent = 2.0

--- a/src/mcfacts/inputs/ReadInputs.py
+++ b/src/mcfacts/inputs/ReadInputs.py
@@ -135,6 +135,8 @@ Inifile
         The Gaussian standard deviation value for the energy change during a strong interaction
     "flag_use_surrogate"            : int
         Switch (0) uses analytical kick prescription from Akiba et al. (2024). Switch (1) uses NRSurrogate model from (paper in prep).
+    "flag_dynamics_sweep"           : int
+        Use faster dynamics functions which implement sweep function (1 on/0 off)
 """
 # Things everyone needs
 import configparser as ConfigParser
@@ -207,13 +209,14 @@ INPUT_TYPES = {
     "disk_inner_stable_circ_orb"    : float,
     "mass_pile_up"                  : float,
     "save_snapshots"                : int,
-    "harden_energy_delta_mu"      : float,
-    "harden_energy_delta_sigma"       : float,
+    "harden_energy_delta_mu"        : float,
+    "harden_energy_delta_sigma"     : float,
     "torque_prescription"           : str,
     "flag_phenom_turb"              : int,
     "phenom_turb_centroid"          : float,
     "phenom_turb_std_dev"           : float,
-    "flag_use_surrogate"            : int
+    "flag_use_surrogate"            : int,
+    "flag_dynamics_sweep"           : int,
 }
 # Ensure none of the data types are bool to avoid issues casting ascii to boolean
 if bool in INPUT_TYPES.values():

--- a/src/mcfacts/inputs/data/model_choice.ini
+++ b/src/mcfacts/inputs/data/model_choice.ini
@@ -140,3 +140,6 @@ delta_energy_strong_sigma = 0.02
 harden_energy_delta_mu = 0.9
 # Variance of the energy exchanged in a strong 2 + 1 interaction that hardens the binary
 harden_energy_delta_sigma = 0.025
+
+# Computational
+flag_dynamics_sweep = 0


### PR DESCRIPTION
<!--
Thank you for contributing a pull request! Here are a few tips to help you:
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the GH issue).
-->
dynamics: added flag_dynamics_sweep option to use new circular_singles_encounters_prograde_sweep function


#### Issue Link
<!--
If applicable, please include issue link.
-->
Changes the default behavior of model_choice_old.ini to use the new sweep implementation created by Nico, and provides a way to turn it on/off (flag_dynamics_sweep).

Edit: See https://github.com/McFACTS/McFACTS/pull/319