### PR TITLE
Cube optimizations

### DIFF
--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1078,7 +1078,8 @@ def main():
                     opts.disk_bh_pro_orb_ecc_crit,
                     opts.delta_energy_strong_mu,
                     opts.delta_energy_strong_sigma,
-                    opts.disk_radius_outer
+                    opts.disk_radius_outer,
+                    opts.flag_dynamics_sweep
                 )
 
                 if stars_unbound_id_nums.size > 0:

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -83,6 +83,47 @@ def cubic_y_root(x0, y0, sanity=False):
         print(yval, val0)
     return roots
 
+def cubic_y_root_cardano(x0, y0, sanity=False):
+    """
+    Optimized version of cubic_y_root using an analytic solver.
+    Solves the equation: x0*y^3 + 1.5*y - y0 = 0
+    """
+    # handle the edge case where x0 is zero, becomes 1.5*y - y0 = 0
+    if x0 == 0:
+        return np.array([y0 / 1.5])
+
+    # convert to the standard depressed cubic form y^3 + p*y + q = 0
+    # by dividing the original equation by the leading coefficient x0
+    p = 1.5 / x0
+    q = -y0 / x0
+
+    # calculate the discriminant term to see if there will be one or three real roots
+    delta = (q/2)**2 + (p/3)**3
+
+    if delta >= 0:
+        # discriminant positive or 0, one real root, two complex roots
+        sqrt_delta = np.sqrt(delta)
+        u = np.cbrt(-q/2 + sqrt_delta)
+        v = np.cbrt(-q/2 - sqrt_delta)
+        roots = np.array([u + v])
+    else:
+        # discriminant negative, three real roots
+        term1 = 2 * np.sqrt(-p / 3)
+        phi = np.arccos((3 * q) / (p * term1))
+        
+        y1 = term1 * np.cos(phi / 3)
+        y2 = term1 * np.cos((phi + 2 * np.pi) / 3)
+        y3 = term1 * np.cos((phi + 4 * np.pi) / 3)
+        roots = np.array([y1, y2, y3])
+    
+    if sanity:
+        print(" Root sanity check ", roots)
+        yval = roots[0]
+        val0 = x0 * yval**3 + 1.5 * yval - y0
+        print(yval, val0)
+        
+    return roots
+
 
 def cubic_finite_step_root(x0, y0, OmegaS, sanity=False):
     """Determine allowed finite step size
@@ -118,8 +159,59 @@ def cubic_finite_step_root(x0, y0, OmegaS, sanity=False):
         print(roots_y - y0 - (roots_x - x0) / OmegaS, roots_x + 1. / (2 * roots_y ** 2))
     return np.c_[roots_x, roots_y]
 
+def cubic_finite_step_root_cardano(x0, y0, OmegaS, sanity = False):
+    """
+    Optimized version to determine allowed finite step size using an
+    analytic solution for the depressed cubic equation.
+    """
 
-def transition_physical_as_EL(E1, L1, E2, L2, DeltaE, m1, m2, units='geometric', smbh_mass=1e8, sanity=False):
+    # we have a polynomial y**3 + (2(x_0 - OmegaS * y_0)) * y + 2 * OmegaS 
+    # which we will summarize as y**3 + p*y + q = 0
+    # it's a depressed cubic root, with no square term
+
+    p = 2 * (x0 - OmegaS * y0)
+    q = 2 * OmegaS
+
+    if p == 0: 
+        roots_y = np.array([np.cbrt(-q)]) # just return the cube root of -2*OmegaS
+    else:
+        # calculate the discriminant term to see if there will be one or three real roots
+        delta = (q/2)**2 + (p/3)**3
+
+        if delta >= 0:
+            # discriminant positive or 0, one real root, two complex roots
+            sqrt_delta = np.sqrt(delta)
+            u = np.cbrt(-q/2 + sqrt_delta)
+            v = np.cbrt(-q/2 - sqrt_delta)
+            roots_y = np.array([u + v]) # The only real root
+        else:
+            # discriminant negative, three real roots
+            # this is more numerically stable than the standard Cardano formula for this case
+            term1 = 2 * np.sqrt(-p / 3)
+            phi = np.arccos( (3 * q) / (p * term1) ) # simplified from (3q)/(2p*sqrt(-p/3))
+
+            y1 = term1 * np.cos(phi / 3)
+            y2 = term1 * np.cos((phi + 2 * np.pi) / 3)
+            y3 = term1 * np.cos((phi + 4 * np.pi) / 3)
+            roots_y = np.array([y1, y2, y3])
+
+    with np.errstate(divide='ignore'): # ignore division by zero warnings for invalid roots
+        roots_x = -1 / (2 * roots_y ** 2)
+
+    # filter for valid, physical roots
+    indx_ok = np.logical_and(roots_y > 0, np.isfinite(roots_x))
+    indx_ok = np.logical_and(indx_ok, roots_x < 0)  # only pick roots that are bound
+
+    roots_x = roots_x[indx_ok]
+    roots_y = roots_y[indx_ok]
+
+    if sanity:
+        print(" Finite stepsize sanity check, both should be zero; second is trivial ")
+        print(roots_y - y0 - (roots_x - x0) / OmegaS, roots_x + 1. / (2 * roots_y ** 2))
+
+    return np.c_[roots_x, roots_y] 
+
+def transition_physical_as_EL(E1, L1, E2, L2, DeltaE, m1, m2, units='geometric', smbh_mass=1e8, sanity=False, cardano = False):
     """Calculates final energy and angular momentum states
 
     Parameters
@@ -195,7 +287,12 @@ def transition_physical_as_EL(E1, L1, E2, L2, DeltaE, m1, m2, units='geometric',
         # But the stepsize constraint is set by object 1 (x0_alt), intersecting the boundary
         #   -  Object 1 is moving to tighter orbits (lower energy magnitude), so root of x is increasing in magnitude!
         Omega_trial = Omega2  # np.min([Omega2, Omega2_f, Omega1, Omega1_f])
-        my_stepsize_roots = cubic_finite_step_root(x0_alt, y0_alt, Omega_trial / Omega0)
+
+        if cardano:
+            my_stepsize_roots = cubic_finite_step_root_cardano(x0_alt, y0_alt, Omega_trial / Omega0)
+        else: 
+            my_stepsize_roots = cubic_finite_step_root(x0_alt, y0_alt, Omega_trial / Omega0)
+
         if sanity:
             print(" Pick root n between : x", my_stepsize_roots[:, 0], "between ", (x0, x0_alt), ", y ", my_stepsize_roots[:, 1],  " between ", (y0, y0_alt))
         my_stepsize_roots = my_stepsize_roots[my_stepsize_roots[:, 0] < x0]  # pick in between the two initial points
@@ -219,7 +316,12 @@ def transition_physical_as_EL(E1, L1, E2, L2, DeltaE, m1, m2, units='geometric',
             print(" Expansion ")
             print("Dimensionless root finder: coordinates (should be close to -1/2, 1)", x0, y0)
         # Slope calculation, based on object 2 ('accepting' object/circular case)
-        my_roots = cubic_y_root(x0, y0)
+
+        if cardano:
+            my_roots = cubic_y_root_cardano(x0, y0)
+        else:
+            my_roots = cubic_y_root(x0, y0)
+
         # restore physical units, these are y values; ell = y*ell0; and \Omega = (GM)^2/ell^3
         my_roots_ell = ell0 * my_roots
         my_roots_omega = (G_val * smbh_mass) ** 2 / my_roots_ell ** 3  # note order reversal!
@@ -236,7 +338,12 @@ def transition_physical_as_EL(E1, L1, E2, L2, DeltaE, m1, m2, units='geometric',
 
         if sanity:
             print(" Dimensionless root finder part 2: coordinates for eccentric system ", x0_alt, y0_alt)
-        my_roots_alt = cubic_y_root(x0_alt, y0_alt)
+
+        if cardano:
+            my_roots_alt = cubic_y_root_cardano(x0_alt, y0_alt)
+        else:
+            my_roots_alt = cubic_y_root(x0_alt, y0_alt)
+
         my_roots_omega_alt = (G_val * smbh_mass) ** 2/(ell0 * my_roots_alt) ** 3
         my_roots_omega_alt = np.real(my_roots_omega_alt[np.real(my_roots_omega_alt) > 0])
         my_roots_omega_alt.sort()
@@ -265,7 +372,8 @@ def encounters_new_orba_ecc(smbh_mass,
                             id_num_give,
                             id_num_take,
                             delta_energy_strong,
-                            flag_obj_types):
+                            flag_obj_types,
+                            cardano = False):
     """Calculate new orb_a and ecc values for two objects that dynamically interact
 
     Parameters
@@ -348,7 +456,7 @@ def encounters_new_orba_ecc(smbh_mass,
     id_num_unbound = None
     id_num_flipped_rotation = None
 
-    E_give_final, E_take_final, J_give_final, J_take_final = transition_physical_as_EL(E_give_initial, J_give_initial, E_take_initial, J_take_initial, Delta_E, mass_give_geometric, mass_take_geometric, smbh_mass=smbh_mass_geometric, sanity=False)
+    E_give_final, E_take_final, J_give_final, J_take_final = transition_physical_as_EL(E_give_initial, J_give_initial, E_take_initial, J_take_initial, Delta_E, mass_give_geometric, mass_take_geometric, smbh_mass=smbh_mass_geometric, sanity=False, cardano = cardano)
 
     # if object is unbound, don't change parameters so they can be recorded
     # give object (typically eccentric) is unbound
@@ -740,227 +848,6 @@ def circular_singles_encounters_prograde_sweep(
     return (disk_bh_pro_orbs_a, disk_bh_pro_orbs_ecc)
 
 
-def circular_singles_encounters_prograde_stars_sweep(
-        smbh_mass,
-        disk_star_pro_orbs_a,
-        disk_star_pro_masses,
-        disk_star_pro_radius,
-        disk_star_pro_orbs_ecc,
-        disk_star_pro_id_nums,
-        rstar_rhill_exponent,
-        timestep_duration_yr,
-        disk_bh_pro_orb_ecc_crit,
-        delta_energy_strong_mu,
-        delta_energy_strong_sigma,
-        disk_radius_outer,
-        rng_here = rng
-        ):
-    # Find the e< crit_ecc. population. These are the (circularized) population that can form binaries.
-    circ_prograde_population_indices = np.asarray(disk_star_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
-    # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
-    ecc_prograde_population_indices = np.asarray(disk_star_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit).nonzero()[0]
-
-    if (len(circ_prograde_population_indices) == 0) or (len(ecc_prograde_population_indices) == 0):
-        return disk_star_pro_orbs_a, disk_star_pro_orbs_ecc, np.array([]), np.array([]), np.array([])
-
-    # Put stellar radii in rg
-    disk_star_pro_radius_rg = r_g_from_units(smbh_mass, ((10 ** disk_star_pro_radius) * u.Rsun)).value
-
-    # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    epsilon = (disk_radius_outer * ((disk_star_pro_masses[circ_prograde_population_indices] / (3 * (disk_star_pro_masses[circ_prograde_population_indices] + smbh_mass)))**(1. / 3.)))[:, None] * rng_here.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
-
-    # T_orb = pi (R/r_g)^1.5 (GM_smbh/c^2) = pi (R/r_g)^1.5 (GM_smbh*2e30/c^2)
-    #      = pi (R/r_g)^1.5 (6.7e-11 2e38/27e24)= pi (R/r_g)^1.5 (1.3e11)s =(R/r_g)^1/5 (1.3e4)
-    orbital_timescales_circ_pops = scipy.constants.pi*((disk_star_pro_orbs_a[circ_prograde_population_indices])**(1.5))*(2.e30*smbh_mass*scipy.constants.G)/(scipy.constants.c**(3.0)*3.15e7) 
-    N_circ_orbs_per_timestep = timestep_duration_yr/orbital_timescales_circ_pops
-    ecc_orb_min = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0-disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
-    ecc_orb_max = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
-    # Generate all possible needed random numbers ahead of time
-    chance_of_enc = rng_here.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
-    delta_energy_strong = np.exp(rng_here.normal(loc=np.log(delta_energy_strong_mu), scale=np.log(1. + delta_energy_strong_sigma), size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices))))
-    num_poss_ints = 0
-    num_encounters = 0
-    id_nums_poss_touch = []
-    frac_rhill_sep = []
-    id_nums_unbound = []
-    id_nums_flipped_rotation = []
-    
-    circ_len = len(circ_prograde_population_indices)
-    ecc_len = len(ecc_prograde_population_indices)
-
-    if  circ_len > 0:
-        # if True engage the sweep algorithm
-
-        # create the events array
-        # define types to ensure correct sorting at boundary conditions:
-        # START events are processed first, then POINTs, then ENDs
-        START, POINT, END = -1, 0, 1
-        
-        # C = circ_prograde_population_indices.size
-        # ecc_len = ecc_prograde_population_indices.size
-
-        # create a single, flat, contiguous array for all events
-        events = np.empty(circ_len + 2 * ecc_len, dtype=[('radius', 'f8'), ('type', 'i4'), ('rel_idx', 'u4')])
-
-        # add POINT events for each circular object
-        events[:circ_len] = np.array(list(zip(disk_star_pro_orbs_a[circ_prograde_population_indices], [POINT] * circ_len, np.arange(circ_len))), dtype=events.dtype)
-
-        # Add START and ecc_lenND events for each eccentric object's interval
-        ecc_orb_min = disk_star_pro_orbs_a[ecc_prograde_population_indices] * (1.0 - disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
-        ecc_orb_max = disk_star_pro_orbs_a[ecc_prograde_population_indices] * (1.0 + disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
-        events[circ_len:circ_len+ecc_len] = np.array(list(zip(ecc_orb_min, [START] * ecc_len, np.arange(ecc_len))), dtype=events.dtype)
-        events[circ_len+ecc_len:] = np.array(list(zip(ecc_orb_max, [END] * ecc_len, np.arange(ecc_len))), dtype=events.dtype)
-
-        # sort the events by radius
-        # uses numpy sort, very performant
-        events.sort(order=['radius', 'type'])
-
-        # for a two-pass system to ensure parity, we collect
-        # the overlaps up front
-        overlaps = {}
-
-        # first we sweep in order to construct the overlaps object
-        active_ecc_indices = set()
-
-        for radius, type, rel_idx in events:
-            if type == START:
-                active_ecc_indices.add(rel_idx)
-            elif type == END:
-                active_ecc_indices.discard(rel_idx) # Use discard for safety
-            elif type == POINT:
-                # when we hit a POINT event, the `active_ecc_indices` set contains
-                # ALL eccentric particles whose intervals contain this point
-                if not active_ecc_indices:
-                    continue
-
-                circ_rel_idx = rel_idx
-
-                if active_ecc_indices: 
-                    sorted_interlopers = sorted(list(active_ecc_indices))
-                    overlaps[circ_rel_idx] = sorted_interlopers
-
-        # turn these lists into sets for the time being in order to much more effectively 
-        # search them for the indices
-        # we will turn them back into arrays later for return
-        id_nums_flipped_rotation = set(id_nums_flipped_rotation)
-        id_nums_unbound = set(id_nums_unbound)
-
-        # now we actualy go through the dictionary of interlopers
-        for circ_rel_idx in range(len(circ_prograde_population_indices)):
-            circ_idx = circ_prograde_population_indices[circ_rel_idx]
-                
-            interlopers = overlaps.get(circ_rel_idx, [])
-
-            for ecc_rel_idx in interlopers:
-                ecc_idx = ecc_prograde_population_indices[ecc_rel_idx]
-
-                if ((disk_star_pro_id_nums[ecc_idx] not in id_nums_flipped_rotation) and
-                    (disk_star_pro_id_nums[circ_idx] not in id_nums_flipped_rotation) and
-                    (disk_star_pro_id_nums[circ_idx] not in id_nums_unbound) and
-                    (disk_star_pro_id_nums[ecc_idx] not in id_nums_unbound)):
-
-                    temp_bin_mass = disk_star_pro_masses[circ_idx] + disk_star_pro_masses[ecc_idx]
-                    star_smbh_mass_ratio = temp_bin_mass/(3.0*smbh_mass)
-                    mass_ratio_factor = (star_smbh_mass_ratio)**(1./3.)
-                    prob_orbit_overlap = (1./scipy.constants.pi)*mass_ratio_factor
-                    prob_enc_per_timestep = prob_orbit_overlap * N_circ_orbs_per_timestep[circ_rel_idx]
-                    if prob_enc_per_timestep > 1:
-                        prob_enc_per_timestep = 1
-                    if chance_of_enc[circ_rel_idx][ecc_rel_idx] < prob_enc_per_timestep:
-                        if disk_star_pro_orbs_ecc[circ_idx] <= disk_bh_pro_orb_ecc_crit:
-                            new_orb_a_ecc, new_orb_a_circ, new_ecc_ecc, new_ecc_circ, id_num_out, id_num_flip = encounters_new_orba_ecc(
-                                smbh_mass,
-                                disk_star_pro_orbs_a[ecc_idx], disk_star_pro_orbs_a[circ_idx],
-                                disk_star_pro_masses[ecc_idx], disk_star_pro_masses[circ_idx],
-                                disk_star_pro_orbs_ecc[ecc_idx], disk_star_pro_orbs_ecc[circ_idx],
-                                disk_star_pro_radius_rg[ecc_idx], disk_star_pro_radius_rg[circ_idx],
-                                disk_star_pro_id_nums[ecc_idx], disk_star_pro_id_nums[circ_idx],
-                                delta_energy_strong[circ_rel_idx][ecc_rel_idx], flag_obj_types=0)
-                            if id_num_out is not None:
-                                id_nums_unbound.add(id_num_out)
-                            if id_num_flip is not None:
-                                id_nums_flipped_rotation.add(id_num_flip)
-                            # Check if any stars are outside the disk
-                            if new_orb_a_ecc > disk_radius_outer:
-                                new_orb_a_ecc = disk_radius_outer - epsilon[circ_rel_idx][ecc_rel_idx]
-                            if new_orb_a_circ > disk_radius_outer:
-                                new_orb_a_circ = disk_radius_outer - epsilon[circ_rel_idx][ecc_rel_idx]
-                            disk_star_pro_orbs_a[ecc_idx] = new_orb_a_ecc
-                            disk_star_pro_orbs_a[circ_idx] = new_orb_a_circ
-                            disk_star_pro_orbs_ecc[circ_idx] = new_ecc_circ
-                            disk_star_pro_orbs_ecc[ecc_idx] = new_ecc_ecc
-#                             # Look for stars that are inside each other's Hill spheres and if so return them as mergers
-                            if (id_num_flip is None) and (id_num_out is None):
-                                separation = np.abs(disk_star_pro_orbs_a[circ_idx] - disk_star_pro_orbs_a[ecc_idx])
-                                center_of_mass = np.average([disk_star_pro_orbs_a[circ_idx], disk_star_pro_orbs_a[ecc_idx]],
-                                                            weights=[disk_star_pro_masses[circ_idx], disk_star_pro_masses[ecc_idx]])
-                                rhill_poss_encounter = center_of_mass * ((disk_star_pro_masses[circ_idx] + disk_star_pro_masses[ecc_idx]) / (3. * smbh_mass)) ** (1./3.)
-                                if (separation - rhill_poss_encounter < 0):
-                                    id_nums_poss_touch.append(np.array([disk_star_pro_id_nums[circ_idx], disk_star_pro_id_nums[ecc_idx]]))
-                                    frac_rhill_sep.append(separation / rhill_poss_encounter)
-    if not np.all(disk_star_pro_orbs_a > 0):
-        zero_mask = ~(disk_star_pro_orbs_a > 0)
-        print(disk_star_pro_orbs_a[zero_mask])
-        print(np.argwhere(zero_mask))
-
-    # Check finite
-    assert np.isfinite(disk_star_pro_orbs_a).all(), \
-        "Finite check failed for disk_star_pro_orbs_a"
-    assert np.isfinite(disk_star_pro_orbs_ecc).all(), \
-        "Finite check failed for disk_star_pro_orbs_ecc"
-    assert np.all(disk_star_pro_orbs_a < disk_radius_outer), \
-        "disk_star_pro_orbs_a contains values greater than disk_radius_outer"
-    assert np.all(disk_star_pro_orbs_a > 0), \
-        "disk_star_pro_orbs_a contains values <= 0"
-
-    id_nums_poss_touch = np.array(id_nums_poss_touch)
-    frac_rhill_sep = np.array(frac_rhill_sep)
-    id_nums_unbound = np.array(id_nums_unbound)
-    id_nums_flipped_rotation = np.array(id_nums_flipped_rotation)
-
-    if id_nums_poss_touch.size > 0:
-        # Check if any stars are marked as both unbound and within another star's Hill sphere
-        # If yes, remove them from the within Hill sphere array
-        if np.any(np.isin(id_nums_poss_touch, id_nums_unbound)):
-            frac_rhill_sep = frac_rhill_sep[~(np.isin(id_nums_poss_touch, id_nums_unbound)[:, 0]) == True]
-            frac_rhill_sep = frac_rhill_sep[~(np.isin(id_nums_poss_touch, id_nums_unbound)[:, 1]) == True]
-            id_nums_poss_touch = id_nums_poss_touch[~(np.isin(id_nums_poss_touch, id_nums_unbound)[:, 0]) == True, :]
-            id_nums_poss_touch = id_nums_poss_touch[~(np.isin(id_nums_poss_touch, id_nums_unbound)[:, 1]) == True, :]
-
-        # Check if any stars are marked as both flipping from pro to retro and within another star's Hill sphere
-        # If yes, remove them from the within Hill sphere array
-        if np.any(np.isin(id_nums_flipped_rotation, id_nums_poss_touch)):
-            frac_rhill_sep = frac_rhill_sep[~(np.isin(id_nums_poss_touch, id_nums_flipped_rotation)[:, 0]) == True]
-            frac_rhill_sep = frac_rhill_sep[~(np.isin(id_nums_poss_touch, id_nums_flipped_rotation)[:, 1]) == True]
-            id_nums_poss_touch = id_nums_poss_touch[~(np.isin(id_nums_poss_touch, id_nums_flipped_rotation)[:, 0]) == True, :]
-            id_nums_poss_touch = id_nums_poss_touch[~(np.isin(id_nums_poss_touch, id_nums_flipped_rotation)[:, 1]) == True, :]
-
-    # Test if there are any duplicate pairs, if so only return ID numbers of pair with smallest fractional Hill sphere separation
-    if np.unique(id_nums_poss_touch).shape != id_nums_poss_touch.flatten().shape:
-        sort_idx = np.argsort(frac_rhill_sep)
-        id_nums_poss_touch = id_nums_poss_touch[sort_idx]
-        uniq_vals, unq_counts = np.unique(id_nums_poss_touch, return_counts=True)
-        dupe_vals = uniq_vals[unq_counts > 1]
-        dupe_rows = id_nums_poss_touch[np.any(np.isin(id_nums_poss_touch, dupe_vals), axis=1)]
-        uniq_rows = id_nums_poss_touch[np.all(~np.isin(id_nums_poss_touch, dupe_vals), axis=1)]
-
-        rm_rows = []
-        for row in dupe_rows:
-            dupe_indices = np.any(np.isin(dupe_rows, row), axis=1).nonzero()[0][1:]
-            rm_rows.append(dupe_indices)
-        rm_rows = np.unique(np.concatenate(rm_rows))
-        keep_mask = np.ones(len(dupe_rows))
-        keep_mask[rm_rows] = 0
-
-        id_nums_touch = np.concatenate((dupe_rows[keep_mask.astype(bool)], uniq_rows))
-
-    else:
-        id_nums_touch = id_nums_poss_touch
-
-    id_nums_touch = id_nums_touch.T
-
-    return (disk_star_pro_orbs_a, disk_star_pro_orbs_ecc, id_nums_touch, id_nums_unbound, id_nums_flipped_rotation)
-
 
 
 def circular_singles_encounters_prograde_stars(
@@ -977,6 +864,7 @@ def circular_singles_encounters_prograde_stars(
         delta_energy_strong_sigma,
         disk_radius_outer,
         rng_here = rng,
+        cardano = False
         ):
     """"Adjust orb ecc due to encounters between 2 single circ pro stars
 
@@ -1171,7 +1059,7 @@ def circular_singles_encounters_prograde_stars(
                                     disk_star_pro_orbs_ecc[ecc_idx], disk_star_pro_orbs_ecc[circ_idx],
                                     disk_star_pro_radius_rg[ecc_idx], disk_star_pro_radius_rg[circ_idx],
                                     disk_star_pro_id_nums[ecc_idx], disk_star_pro_id_nums[circ_idx],
-                                    delta_energy_strong[i][j], flag_obj_types=0)
+                                    delta_energy_strong[i][j], flag_obj_types=0, cardano = cardano)
                                 if id_num_out is not None:
                                     id_nums_unbound.append(id_num_out)
                                 if id_num_flip is not None:

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -752,7 +752,8 @@ def circular_singles_encounters_prograde_stars_sweep(
         disk_bh_pro_orb_ecc_crit,
         delta_energy_strong_mu,
         delta_energy_strong_sigma,
-        disk_radius_outer
+        disk_radius_outer,
+        rng_here = rng
         ):
     # Find the e< crit_ecc. population. These are the (circularized) population that can form binaries.
     circ_prograde_population_indices = np.asarray(disk_star_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
@@ -766,7 +767,7 @@ def circular_singles_encounters_prograde_stars_sweep(
     disk_star_pro_radius_rg = r_g_from_units(smbh_mass, ((10 ** disk_star_pro_radius) * u.Rsun)).value
 
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    epsilon = (disk_radius_outer * ((disk_star_pro_masses[circ_prograde_population_indices] / (3 * (disk_star_pro_masses[circ_prograde_population_indices] + smbh_mass)))**(1. / 3.)))[:, None] * rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
+    epsilon = (disk_radius_outer * ((disk_star_pro_masses[circ_prograde_population_indices] / (3 * (disk_star_pro_masses[circ_prograde_population_indices] + smbh_mass)))**(1. / 3.)))[:, None] * rng_here.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
 
     # T_orb = pi (R/r_g)^1.5 (GM_smbh/c^2) = pi (R/r_g)^1.5 (GM_smbh*2e30/c^2)
     #      = pi (R/r_g)^1.5 (6.7e-11 2e38/27e24)= pi (R/r_g)^1.5 (1.3e11)s =(R/r_g)^1/5 (1.3e4)
@@ -775,8 +776,8 @@ def circular_singles_encounters_prograde_stars_sweep(
     ecc_orb_min = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0-disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
     ecc_orb_max = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
     # Generate all possible needed random numbers ahead of time
-    chance_of_enc = rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
-    delta_energy_strong = np.exp(rng.normal(loc=np.log(delta_energy_strong_mu), scale=np.log(1. + delta_energy_strong_sigma), size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices))))
+    chance_of_enc = rng_here.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
+    delta_energy_strong = np.exp(rng_here.normal(loc=np.log(delta_energy_strong_mu), scale=np.log(1. + delta_energy_strong_sigma), size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices))))
     num_poss_ints = 0
     num_encounters = 0
     id_nums_poss_touch = []
@@ -974,7 +975,8 @@ def circular_singles_encounters_prograde_stars(
         disk_bh_pro_orb_ecc_crit,
         delta_energy_strong_mu,
         delta_energy_strong_sigma,
-        disk_radius_outer
+        disk_radius_outer,
+        rng_here = rng,
         ):
     """"Adjust orb ecc due to encounters between 2 single circ pro stars
 
@@ -1122,7 +1124,7 @@ def circular_singles_encounters_prograde_stars(
     disk_star_pro_radius_rg = r_g_from_units(smbh_mass, ((10 ** disk_star_pro_radius) * u.Rsun)).value
 
     # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
-    epsilon = (disk_radius_outer * ((disk_star_pro_masses[circ_prograde_population_indices] / (3 * (disk_star_pro_masses[circ_prograde_population_indices] + smbh_mass)))**(1. / 3.)))[:, None] * rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
+    epsilon = (disk_radius_outer * ((disk_star_pro_masses[circ_prograde_population_indices] / (3 * (disk_star_pro_masses[circ_prograde_population_indices] + smbh_mass)))**(1. / 3.)))[:, None] * rng_here.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
 
     # T_orb = pi (R/r_g)^1.5 (GM_smbh/c^2) = pi (R/r_g)^1.5 (GM_smbh*2e30/c^2)
     #      = pi (R/r_g)^1.5 (6.7e-11 2e38/27e24)= pi (R/r_g)^1.5 (1.3e11)s =(R/r_g)^1/5 (1.3e4)
@@ -1131,8 +1133,8 @@ def circular_singles_encounters_prograde_stars(
     ecc_orb_min = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0-disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
     ecc_orb_max = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
     # Generate all possible needed random numbers ahead of time
-    chance_of_enc = rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
-    delta_energy_strong = np.exp(rng.normal(loc=np.log(delta_energy_strong_mu), scale=np.log(1. + delta_energy_strong_sigma), size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices))))
+    chance_of_enc = rng_here.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
+    delta_energy_strong = np.exp(rng_here.normal(loc=np.log(delta_energy_strong_mu), scale=np.log(1. + delta_energy_strong_sigma), size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices))))
     num_poss_ints = 0
     num_encounters = 0
     id_nums_poss_touch = []

--- a/src/mcfacts/physics/dynamics.py
+++ b/src/mcfacts/physics/dynamics.py
@@ -740,14 +740,213 @@ def circular_singles_encounters_prograde_sweep(
     return (disk_bh_pro_orbs_a, disk_bh_pro_orbs_ecc)
 
 
+def circular_singles_encounters_prograde_stars_sweep(
+        smbh_mass,
+        disk_star_pro_orbs_a,
+        disk_star_pro_masses,
+        disk_star_pro_radius,
+        disk_star_pro_orbs_ecc,
+        disk_star_pro_id_nums,
+        rstar_rhill_exponent,
+        timestep_duration_yr,
+        disk_bh_pro_orb_ecc_crit,
+        delta_energy_strong_mu,
+        delta_energy_strong_sigma,
+        disk_radius_outer
+        ):
+    # Find the e< crit_ecc. population. These are the (circularized) population that can form binaries.
+    circ_prograde_population_indices = np.asarray(disk_star_pro_orbs_ecc <= disk_bh_pro_orb_ecc_crit).nonzero()[0]
+    # Find the e> crit_ecc population. These are the interlopers that can perturb the circularized population
+    ecc_prograde_population_indices = np.asarray(disk_star_pro_orbs_ecc > disk_bh_pro_orb_ecc_crit).nonzero()[0]
 
+    if (len(circ_prograde_population_indices) == 0) or (len(ecc_prograde_population_indices) == 0):
+        return disk_star_pro_orbs_a, disk_star_pro_orbs_ecc, np.array([]), np.array([]), np.array([])
 
+    # Put stellar radii in rg
+    disk_star_pro_radius_rg = r_g_from_units(smbh_mass, ((10 ** disk_star_pro_radius) * u.Rsun)).value
 
+    # Calculate epsilon --amount to subtract from disk_radius_outer for objects with orb_a > disk_radius_outer
+    epsilon = (disk_radius_outer * ((disk_star_pro_masses[circ_prograde_population_indices] / (3 * (disk_star_pro_masses[circ_prograde_population_indices] + smbh_mass)))**(1. / 3.)))[:, None] * rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
 
+    # T_orb = pi (R/r_g)^1.5 (GM_smbh/c^2) = pi (R/r_g)^1.5 (GM_smbh*2e30/c^2)
+    #      = pi (R/r_g)^1.5 (6.7e-11 2e38/27e24)= pi (R/r_g)^1.5 (1.3e11)s =(R/r_g)^1/5 (1.3e4)
+    orbital_timescales_circ_pops = scipy.constants.pi*((disk_star_pro_orbs_a[circ_prograde_population_indices])**(1.5))*(2.e30*smbh_mass*scipy.constants.G)/(scipy.constants.c**(3.0)*3.15e7) 
+    N_circ_orbs_per_timestep = timestep_duration_yr/orbital_timescales_circ_pops
+    ecc_orb_min = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0-disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
+    ecc_orb_max = disk_star_pro_orbs_a[ecc_prograde_population_indices]*(1.0+disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
+    # Generate all possible needed random numbers ahead of time
+    chance_of_enc = rng.uniform(size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices)))
+    delta_energy_strong = np.exp(rng.normal(loc=np.log(delta_energy_strong_mu), scale=np.log(1. + delta_energy_strong_sigma), size=(len(circ_prograde_population_indices), len(ecc_prograde_population_indices))))
+    num_poss_ints = 0
+    num_encounters = 0
+    id_nums_poss_touch = []
+    frac_rhill_sep = []
+    id_nums_unbound = []
+    id_nums_flipped_rotation = []
+    
+    circ_len = len(circ_prograde_population_indices)
+    ecc_len = len(ecc_prograde_population_indices)
 
+    if  circ_len > 0:
+        # if True engage the sweep algorithm
 
+        # create the events array
+        # define types to ensure correct sorting at boundary conditions:
+        # START events are processed first, then POINTs, then ENDs
+        START, POINT, END = -1, 0, 1
+        
+        # C = circ_prograde_population_indices.size
+        # ecc_len = ecc_prograde_population_indices.size
 
+        # create a single, flat, contiguous array for all events
+        events = np.empty(circ_len + 2 * ecc_len, dtype=[('radius', 'f8'), ('type', 'i4'), ('rel_idx', 'u4')])
 
+        # add POINT events for each circular object
+        events[:circ_len] = np.array(list(zip(disk_star_pro_orbs_a[circ_prograde_population_indices], [POINT] * circ_len, np.arange(circ_len))), dtype=events.dtype)
+
+        # Add START and ecc_lenND events for each eccentric object's interval
+        ecc_orb_min = disk_star_pro_orbs_a[ecc_prograde_population_indices] * (1.0 - disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
+        ecc_orb_max = disk_star_pro_orbs_a[ecc_prograde_population_indices] * (1.0 + disk_star_pro_orbs_ecc[ecc_prograde_population_indices])
+        events[circ_len:circ_len+ecc_len] = np.array(list(zip(ecc_orb_min, [START] * ecc_len, np.arange(ecc_len))), dtype=events.dtype)
+        events[circ_len+ecc_len:] = np.array(list(zip(ecc_orb_max, [END] * ecc_len, np.arange(ecc_len))), dtype=events.dtype)
+
+        # sort the events by radius
+        # uses numpy sort, very performant
+        events.sort(order=['radius', 'type'])
+
+        # turn these lists into sets for the time being in order to much more effectively 
+        # search them for the indices
+        # we will turn them back into arrays later for return
+        id_nums_flipped_rotation = set(id_nums_flipped_rotation)
+        id_nums_unbound = set(id_nums_unbound)
+
+        active_ecc_indices = set()
+        for radius, type, rel_idx in events:
+            if type == START:
+                active_ecc_indices.add(rel_idx)
+            elif type == END:
+                active_ecc_indices.discard(rel_idx) # Use discard for safety
+            elif type == POINT:
+                # when we hit a POINT event, the `active_ecc_indices` set contains
+                # ALL eccentric particles whose intervals contain this point
+                if not active_ecc_indices:
+                    continue
+
+                circ_rel_idx = rel_idx
+                circ_idx = circ_prograde_population_indices[circ_rel_idx]
+                
+                # sort the indices to ensure deterministic processing order
+                sorted_interlopers = sorted(list(active_ecc_indices))
+
+                for ecc_rel_idx in sorted_interlopers:
+                    ecc_idx = ecc_prograde_population_indices[ecc_rel_idx]
+
+                    if ((disk_star_pro_id_nums[ecc_idx] not in id_nums_flipped_rotation) and
+                        (disk_star_pro_id_nums[circ_idx] not in id_nums_flipped_rotation) and
+                        (disk_star_pro_id_nums[circ_idx] not in id_nums_unbound) and
+                        (disk_star_pro_id_nums[ecc_idx] not in id_nums_unbound)):
+
+                        temp_bin_mass = disk_star_pro_masses[circ_idx] + disk_star_pro_masses[ecc_idx]
+                        star_smbh_mass_ratio = temp_bin_mass/(3.0*smbh_mass)
+                        mass_ratio_factor = (star_smbh_mass_ratio)**(1./3.)
+                        prob_orbit_overlap = (1./scipy.constants.pi)*mass_ratio_factor
+                        prob_enc_per_timestep = prob_orbit_overlap * N_circ_orbs_per_timestep[circ_rel_idx]
+                        if prob_enc_per_timestep > 1:
+                            prob_enc_per_timestep = 1
+                        if chance_of_enc[circ_rel_idx][ecc_rel_idx] < prob_enc_per_timestep:
+                            if disk_star_pro_orbs_ecc[circ_idx] <= disk_bh_pro_orb_ecc_crit:
+                                new_orb_a_ecc, new_orb_a_circ, new_ecc_ecc, new_ecc_circ, id_num_out, id_num_flip = encounters_new_orba_ecc(
+                                    smbh_mass,
+                                    disk_star_pro_orbs_a[ecc_idx], disk_star_pro_orbs_a[circ_idx],
+                                    disk_star_pro_masses[ecc_idx], disk_star_pro_masses[circ_idx],
+                                    disk_star_pro_orbs_ecc[ecc_idx], disk_star_pro_orbs_ecc[circ_idx],
+                                    disk_star_pro_radius_rg[ecc_idx], disk_star_pro_radius_rg[circ_idx],
+                                    disk_star_pro_id_nums[ecc_idx], disk_star_pro_id_nums[circ_idx],
+                                    delta_energy_strong[circ_rel_idx][ecc_rel_idx], flag_obj_types=0)
+                                if id_num_out is not None:
+                                    id_nums_unbound.add(id_num_out)
+                                if id_num_flip is not None:
+                                    id_nums_flipped_rotation.add(id_num_flip)
+                                # Check if any stars are outside the disk
+                                if new_orb_a_ecc > disk_radius_outer:
+                                    new_orb_a_ecc = disk_radius_outer - epsilon[circ_rel_idx][ecc_rel_idx]
+                                if new_orb_a_circ > disk_radius_outer:
+                                    new_orb_a_circ = disk_radius_outer - epsilon[circ_rel_idx][ecc_rel_idx]
+                                disk_star_pro_orbs_a[ecc_idx] = new_orb_a_ecc
+                                disk_star_pro_orbs_a[circ_idx] = new_orb_a_circ
+                                disk_star_pro_orbs_ecc[circ_idx] = new_ecc_circ
+                                disk_star_pro_orbs_ecc[ecc_idx] = new_ecc_ecc
+#                             # Look for stars that are inside each other's Hill spheres and if so return them as mergers
+                                if (id_num_flip is None) and (id_num_out is None):
+                                    separation = np.abs(disk_star_pro_orbs_a[circ_idx] - disk_star_pro_orbs_a[ecc_idx])
+                                    center_of_mass = np.average([disk_star_pro_orbs_a[circ_idx], disk_star_pro_orbs_a[ecc_idx]],
+                                                                weights=[disk_star_pro_masses[circ_idx], disk_star_pro_masses[ecc_idx]])
+                                    rhill_poss_encounter = center_of_mass * ((disk_star_pro_masses[circ_idx] + disk_star_pro_masses[ecc_idx]) / (3. * smbh_mass)) ** (1./3.)
+                                    if (separation - rhill_poss_encounter < 0):
+                                        id_nums_poss_touch.append(np.array([disk_star_pro_id_nums[circ_idx], disk_star_pro_id_nums[ecc_idx]]))
+                                        frac_rhill_sep.append(separation / rhill_poss_encounter)
+    if not np.all(disk_star_pro_orbs_a > 0):
+        zero_mask = ~(disk_star_pro_orbs_a > 0)
+        print(disk_star_pro_orbs_a[zero_mask])
+        print(np.argwhere(zero_mask))
+
+    # Check finite
+    assert np.isfinite(disk_star_pro_orbs_a).all(), \
+        "Finite check failed for disk_star_pro_orbs_a"
+    assert np.isfinite(disk_star_pro_orbs_ecc).all(), \
+        "Finite check failed for disk_star_pro_orbs_ecc"
+    assert np.all(disk_star_pro_orbs_a < disk_radius_outer), \
+        "disk_star_pro_orbs_a contains values greater than disk_radius_outer"
+    assert np.all(disk_star_pro_orbs_a > 0), \
+        "disk_star_pro_orbs_a contains values <= 0"
+
+    id_nums_poss_touch = np.array(id_nums_poss_touch)
+    frac_rhill_sep = np.array(frac_rhill_sep)
+    id_nums_unbound = np.array(id_nums_unbound)
+    id_nums_flipped_rotation = np.array(id_nums_flipped_rotation)
+
+    if id_nums_poss_touch.size > 0:
+        # Check if any stars are marked as both unbound and within another star's Hill sphere
+        # If yes, remove them from the within Hill sphere array
+        if np.any(np.isin(id_nums_poss_touch, id_nums_unbound)):
+            frac_rhill_sep = frac_rhill_sep[~(np.isin(id_nums_poss_touch, id_nums_unbound)[:, 0]) == True]
+            frac_rhill_sep = frac_rhill_sep[~(np.isin(id_nums_poss_touch, id_nums_unbound)[:, 1]) == True]
+            id_nums_poss_touch = id_nums_poss_touch[~(np.isin(id_nums_poss_touch, id_nums_unbound)[:, 0]) == True, :]
+            id_nums_poss_touch = id_nums_poss_touch[~(np.isin(id_nums_poss_touch, id_nums_unbound)[:, 1]) == True, :]
+
+        # Check if any stars are marked as both flipping from pro to retro and within another star's Hill sphere
+        # If yes, remove them from the within Hill sphere array
+        if np.any(np.isin(id_nums_flipped_rotation, id_nums_poss_touch)):
+            frac_rhill_sep = frac_rhill_sep[~(np.isin(id_nums_poss_touch, id_nums_flipped_rotation)[:, 0]) == True]
+            frac_rhill_sep = frac_rhill_sep[~(np.isin(id_nums_poss_touch, id_nums_flipped_rotation)[:, 1]) == True]
+            id_nums_poss_touch = id_nums_poss_touch[~(np.isin(id_nums_poss_touch, id_nums_flipped_rotation)[:, 0]) == True, :]
+            id_nums_poss_touch = id_nums_poss_touch[~(np.isin(id_nums_poss_touch, id_nums_flipped_rotation)[:, 1]) == True, :]
+
+    # Test if there are any duplicate pairs, if so only return ID numbers of pair with smallest fractional Hill sphere separation
+    if np.unique(id_nums_poss_touch).shape != id_nums_poss_touch.flatten().shape:
+        sort_idx = np.argsort(frac_rhill_sep)
+        id_nums_poss_touch = id_nums_poss_touch[sort_idx]
+        uniq_vals, unq_counts = np.unique(id_nums_poss_touch, return_counts=True)
+        dupe_vals = uniq_vals[unq_counts > 1]
+        dupe_rows = id_nums_poss_touch[np.any(np.isin(id_nums_poss_touch, dupe_vals), axis=1)]
+        uniq_rows = id_nums_poss_touch[np.all(~np.isin(id_nums_poss_touch, dupe_vals), axis=1)]
+
+        rm_rows = []
+        for row in dupe_rows:
+            dupe_indices = np.any(np.isin(dupe_rows, row), axis=1).nonzero()[0][1:]
+            rm_rows.append(dupe_indices)
+        rm_rows = np.unique(np.concatenate(rm_rows))
+        keep_mask = np.ones(len(dupe_rows))
+        keep_mask[rm_rows] = 0
+
+        id_nums_touch = np.concatenate((dupe_rows[keep_mask.astype(bool)], uniq_rows))
+
+    else:
+        id_nums_touch = id_nums_poss_touch
+
+    id_nums_touch = id_nums_touch.T
+
+    return (disk_star_pro_orbs_a, disk_star_pro_orbs_ecc, id_nums_touch, id_nums_unbound, id_nums_flipped_rotation)
 
 
 

--- a/tests/cube_stars_optimization_test.py
+++ b/tests/cube_stars_optimization_test.py
@@ -114,10 +114,10 @@ def run_benchmark_stars(N: int, circ_proportion: float):
 
 
 
-if __name__ == "__main__":
+
+def test_circular_singles_encounters_parity():
     # Define the set of test cases to run
     test_cases = [
-        # Test scaling with N at a 50/50 C/E split
         (10, 0.5),
         (20, 0.5),
         (30, 0.5),
@@ -127,21 +127,34 @@ if __name__ == "__main__":
         (250, 0.5),   
         (500, 0.5),
         (1000, 0.5),
-        (2000, 0.5),
-        (4000, 0.5),  
-        (8000, 0.5),
-        # (10000, 0.5),  
-        # (15000, 0.5),
-        # (20000, 0.5),
-        # (25000, 0.5),
-        # (30000, 0.5),
-        # (40000, 0.5),
-        # (60000, 0.5),
-        # (80000, 0.5),
-        # (100000, 0.5),
-        # (160000, 0.5),
-        # The C*E product is largest at 0.5, so these should be faster for the original
+        (10, 0.1),
+        (20, 0.1),
+        (30, 0.1),
+        (40, 0.1),
+        (50, 0.1),
+        (100, 0.1),
+        (250, 0.1),   
+        (500, 0.1),
+        (1000, 0.1),
+        (10, 0.9),
+        (20, 0.9),
+        (30, 0.9),
+        (40, 0.9),
+        (50, 0.9),
+        (100, 0.9),
+        (250, 0.9),   
+        (500, 0.9),
+        (1000, 0.9),
     ]
 
     for N, prop in test_cases:
         run_benchmark_stars(N, prop)
+
+######## Main ########
+def main():
+    test_circular_singles_encounters_parity()
+
+######## Execution ########
+if __name__ == "__main__":
+    main()
+

--- a/tests/cube_stars_optimization_test.py
+++ b/tests/cube_stars_optimization_test.py
@@ -1,0 +1,147 @@
+import time
+import sys
+import numpy as np
+import astropy.units as u
+import astropy.constants as const
+import scipy
+
+SINGLETON_PROP = 0.15
+AXIS_TOLERANCE =  0.0000001
+ECCENTRICITY_TOLERANCE = 0.0001 # the eccentricities are much less reliable than the axes
+SPEED_TOLERANCE = 0.80
+
+from mcfacts.physics.dynamics import circular_singles_encounters_prograde_stars
+
+def generate_data_stars(N: int, circ_proportion: float, singleton_proportion: float, rng: np.random.Generator):
+    """Generates random mock data for the star simulation functions."""
+    # Mock physical constants
+    mock_params = {
+        "smbh_mass": 1.0e8,
+        "timestep_duration_yr": 1.0e4,
+        "disk_star_pro_orb_ecc_crit": 0.1,
+        "rstar_rhill_exponent": 2, # 2 is the default
+        "delta_energy_strong_mu": 0.11,
+        "delta_energy_strong_sigma": 0.05,
+        "disk_radius_outer": 20000.0
+    }
+
+    # Generate random BH properties
+    num_circ = int(N * circ_proportion)
+    num_ecc = N - num_circ
+
+    # Generate eccentricities to match the desired C/E proportion
+    ecc_crit = mock_params["disk_star_pro_orb_ecc_crit"]
+    e_circ = rng.uniform(0, ecc_crit, size=num_circ)
+    e_ecc = rng.uniform(ecc_crit * 1.01, 0.8, size=num_ecc) # Ensure e > e_crit
+    
+    # Combine and shuffle to avoid any ordering bias
+    all_eccs = np.concatenate((e_circ, e_ecc))
+    rng.shuffle(all_eccs)
+    
+    mock_params["disk_star_pro_orbs_ecc"] = all_eccs
+    mock_params["disk_star_pro_masses"] = rng.uniform(5, 50, size=N)
+    # Ensure semi-major axis is always positive and within the disk
+    mock_params["disk_star_pro_orbs_a"] = rng.uniform(
+        100, mock_params["disk_radius_outer"] * 0.95, size=N
+    )
+    mock_params["disk_star_pro_radius"] = rng.uniform(1, 20, size = N)
+    # mocking a certain proportion of these stars as singletons, non-repeating
+    mock_params["disk_star_pro_id_nums"] = np.arange(0, N)
+    
+    return mock_params
+
+def run_benchmark_stars(N: int, circ_proportion: float):
+    """Runs a single benchmark test for a given N and C/E proportion."""
+    print(f"--- Testing: N={N}, C/E Proportion={circ_proportion:.2f} ---")
+
+    data_rng = np.random.default_rng(seed=123)
+    data = generate_data_stars(N, circ_proportion, singleton_proportion = SINGLETON_PROP, rng = data_rng)
+
+    # We need separate, identically-seeded RNGs for the functions themselves
+    # to ensure they use the same random numbers internally for the test.
+    rng1 = np.random.default_rng(seed=456)
+    rng2 = np.random.default_rng(seed=456)
+    
+
+    # --- Run Original Function ---
+    # Important: Copy data as the functions modify arrays in-place
+    data_for_orig = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in data.items()}
+    start_time = time.perf_counter()
+    a_orig, ecc_orig, id_nums_touch_orig, id_nums_unbound_orig, id_nums_flipped_rotation_orig = circular_singles_encounters_prograde_stars(**data_for_orig, rng_here=rng1, cardano=False)
+    time_orig = time.perf_counter() - start_time
+    print(f"Original took:   {time_orig:.4f} seconds")
+
+    # --- Run Optimized Function ---
+    data_for_opt = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in data.items()}
+    start_time = time.perf_counter()
+    a_opt, ecc_opt, id_nums_touch_opt, id_nums_unbound_opt, id_nums_flipped_rotation_opt = circular_singles_encounters_prograde_stars(**data_for_opt, rng_here=rng2, cardano = True)
+    time_opt = time.perf_counter() - start_time
+    print(f"Optimized took:  {time_opt:.4f} seconds")
+
+    # --- Correctness ---
+    correct_a = np.allclose(a_orig, a_opt, rtol = AXIS_TOLERANCE)
+    correct_ecc = np.allclose(ecc_orig, ecc_opt, rtol = ECCENTRICITY_TOLERANCE) # the eccentricities are much less reliable than the axes
+    correct_touch = np.all(id_nums_touch_orig == id_nums_touch_opt)
+    correct_unbound = np.all(id_nums_unbound_orig == id_nums_unbound_opt)
+    correct_flipped_rotation = np.all(id_nums_flipped_rotation_orig == id_nums_flipped_rotation_opt)
+
+    assert correct_a, \
+        "The returned semi-major axes were not within specified tolerances"
+
+    assert correct_ecc, \
+        "The returned eccentricities were not within specified tolerances"
+
+    assert correct_touch, \
+        "The returned touch ids were not identical"
+
+    assert correct_unbound, \
+        "The returned unbound ids were not identical"
+
+    assert correct_flipped_rotation, \
+        "The returned flipped rotation ids were not identical"
+
+
+    speedup = time_orig / time_opt if time_opt > 0 else float('inf')
+    print(f"🚀 Speedup: {speedup:.2f}x")
+
+    # --- Speedup ---
+    # we should at least see parity, and never see a considerable slowdown
+    # otherwise, we haven't set the length check correctly and we're using an ill-suited algorithm
+
+    # speedup = time_orig / time_opt if time_opt > 0 else float('inf')
+    # assert speedup > SPEED_TOLERANCE, \
+    #     "We see a considerable slowdown"
+
+
+
+if __name__ == "__main__":
+    # Define the set of test cases to run
+    test_cases = [
+        # Test scaling with N at a 50/50 C/E split
+        (10, 0.5),
+        (20, 0.5),
+        (30, 0.5),
+        (40, 0.5),
+        (50, 0.5),
+        (100, 0.5),
+        (250, 0.5),   
+        (500, 0.5),
+        (1000, 0.5),
+        (2000, 0.5),
+        (4000, 0.5),  
+        (8000, 0.5),
+        # (10000, 0.5),  
+        # (15000, 0.5),
+        # (20000, 0.5),
+        # (25000, 0.5),
+        # (30000, 0.5),
+        # (40000, 0.5),
+        # (60000, 0.5),
+        # (80000, 0.5),
+        # (100000, 0.5),
+        # (160000, 0.5),
+        # The C*E product is largest at 0.5, so these should be faster for the original
+    ]
+
+    for N, prop in test_cases:
+        run_benchmark_stars(N, prop)

--- a/tests/cube_stars_optimization_test.py
+++ b/tests/cube_stars_optimization_test.py
@@ -18,7 +18,7 @@ def generate_data_stars(N: int, circ_proportion: float, singleton_proportion: fl
     mock_params = {
         "smbh_mass": 1.0e8,
         "timestep_duration_yr": 1.0e4,
-        "disk_star_pro_orb_ecc_crit": 0.1,
+        "disk_bh_pro_orb_ecc_crit": 0.1,
         "rstar_rhill_exponent": 2, # 2 is the default
         "delta_energy_strong_mu": 0.11,
         "delta_energy_strong_sigma": 0.05,
@@ -30,7 +30,7 @@ def generate_data_stars(N: int, circ_proportion: float, singleton_proportion: fl
     num_ecc = N - num_circ
 
     # Generate eccentricities to match the desired C/E proportion
-    ecc_crit = mock_params["disk_star_pro_orb_ecc_crit"]
+    ecc_crit = mock_params["disk_bh_pro_orb_ecc_crit"]
     e_circ = rng.uniform(0, ecc_crit, size=num_circ)
     e_ecc = rng.uniform(ecc_crit * 1.01, 0.8, size=num_ecc) # Ensure e > e_crit
     


### PR DESCRIPTION
By changing from using np.poly.root() to find the cube roots of various items, we can instead make use of a closed form analytical solution. This leads to an ~1.6x runtime speed improvement over the original function, since numpy's polynomial is a general, eigenvalue-based solver for polynomials of any degree, and requires a good deal of overhead every single time it is invoked. 

By recognizing that we are solving the same couple of small, closed-form polynomials every time, we can make the more efficient decision to eliminate this call and directly compute the solutions. 

In the current proposal, this is accomplished by adding a cardano boolean flag to the circular_singles_encounters_prograde_star function and the functions it calls in order to do this (encounters_new_orba_ecc, transition_physical_as_EL). This is done for ease of testing. If this passes muster, we can directly replace the cubic functions with the new analytic ones and go back to our original structure.

Since circular_singles_encounters_prograde_star_bh also calls the encounters_new_orba_ecc function, we would then see runtime improvement there as well.