### PR TITLE
Retrograde Math Fix

### DIFF
--- a/recipes/model_choice.ini
+++ b/recipes/model_choice.ini
@@ -80,7 +80,7 @@ disk_bh_torque_condition = 0.1
 #   Eddington accretion rate
 disk_bh_eddington_ratio = 1.0
 # Maximum initial eccentricity
-disk_bh_orb_ecc_max_init = 0.3
+disk_bh_orb_ecc_max_init = 0.9
 # Mass pile-up term
 mass_pile_up = 35.
 #
@@ -112,7 +112,7 @@ nsc_star_metallicity_z_init = 0.02
 # timestep in years (float)
 timestep_duration_yr = 1.e4
 # For timestep=1.e4, number_of_timesteps=100 gives us 1Myr disk lifetime
-timestep_num = 50
+timestep_num = 70
 
 # number of galaxies of code (1 for testing. 30 for a quick run.)
 galaxy_num = 1

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1039,6 +1039,10 @@ def main():
                 opts.disk_radius_outer,
                 opts.r_g_in_meters
             )
+
+            # Check for retrograde ecc smaller than the critical value
+            blackholes_retro.orb_ecc[blackholes_retro.orb_ecc < opts.disk_bh_pro_orb_ecc_crit] = opts.disk_bh_pro_orb_ecc_crit
+
             # KN: Does this function apply to all disk objects and if so should we rename it?
             stars_retro.orb_ecc, stars_retro.orb_a, stars_retro.orb_inc = disk_capture.retro_bh_orb_disk_evolve(
                 opts.smbh_mass,
@@ -1064,8 +1068,9 @@ def main():
                                   new_info=[stars_retro.orb_ecc,
                                             stars_retro.orb_a])
 
-            # Check for hyperbolic eccentricity (ejected from disk)
-            bh_retro_id_num_ecc_hyperbolic = blackholes_retro.id_num[blackholes_retro.orb_ecc >= 1.]
+            # Check for things ejected from the disk or hitting the SMBH.
+            # TODO: Add specific checks to see if the orbit would fall inside of the ISCO
+            bh_retro_id_num_ecc_hyperbolic = blackholes_retro.id_num[blackholes_retro.orb_ecc > .99]
             if bh_retro_id_num_ecc_hyperbolic.size > 0:
                 blackholes_retro.remove_id_num(bh_retro_id_num_ecc_hyperbolic)
                 filing_cabinet.remove_id_num(bh_retro_id_num_ecc_hyperbolic)

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1026,26 +1026,19 @@ def main():
             #   note this is dyn friction only, not true 'migration'
             # change retrograde eccentricity (some damping, some pumping)
             # damp orbital inclination
-            bh_ecc_mask = blackholes_retro.orb_ecc > opts.disk_bh_pro_orb_ecc_crit
-
-            (
-                blackholes_retro.orb_ecc[bh_ecc_mask],
-                blackholes_retro.orb_a[bh_ecc_mask],
-                blackholes_retro.orb_inc[bh_ecc_mask]
-            ) = disk_capture.retro_bh_orb_disk_evolve(
+            blackholes_retro.orb_ecc, blackholes_retro.orb_a, blackholes_retro.orb_inc = disk_capture.retro_bh_orb_disk_evolve(
                 opts.smbh_mass,
-                blackholes_retro.mass[bh_ecc_mask],
-                blackholes_retro.orb_a[bh_ecc_mask],
-                blackholes_retro.orb_ecc[bh_ecc_mask],
-                blackholes_retro.orb_inc[bh_ecc_mask],
-                blackholes_retro.orb_arg_periapse[bh_ecc_mask],
+                blackholes_retro.mass,
+                blackholes_retro.orb_a,
+                blackholes_retro.orb_ecc,
+                blackholes_retro.orb_inc,
+                blackholes_retro.orb_arg_periapse,
                 opts.disk_inner_stable_circ_orb,
                 disk_surface_density,
                 opts.timestep_duration_yr,
                 opts.disk_radius_outer,
                 opts.r_g_in_meters
             )
-
             # KN: Does this function apply to all disk objects and if so should we rename it?
             stars_retro.orb_ecc, stars_retro.orb_a, stars_retro.orb_inc = disk_capture.retro_bh_orb_disk_evolve(
                 opts.smbh_mass,

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -3015,8 +3015,11 @@ def main():
             # stop treating them with crude retro evolution--it will be sad
             # SF: fix the inc threshhold later to be truly 'in disk' but should be non-stupid as-is!!!
             inc_threshhold = 5.0 * np.pi/180.0
-            bh_id_num_flip_to_pro = blackholes_retro.id_num[np.where((np.abs(blackholes_retro.orb_inc) <= inc_threshhold) | (blackholes_retro.orb_ecc == 0.0))]
-            if (bh_id_num_flip_to_pro.size > 0):
+
+            bh_flip_to_pro_flag = (np.abs(blackholes_retro.orb_inc) <= inc_threshhold) & (blackholes_retro.orb_ecc == 0.0)
+            bh_id_num_flip_to_pro = blackholes_retro.id_num[bh_flip_to_pro_flag]
+
+            if bh_id_num_flip_to_pro.size > 0:
                 # add to prograde arrays
                 blackholes_pro.add_blackholes(
                     new_mass=blackholes_retro.at_id_num(bh_id_num_flip_to_pro, "mass"),
@@ -3039,7 +3042,9 @@ def main():
                                       attr="direction",
                                       new_info=np.ones(bh_id_num_flip_to_pro.size))
 
-            star_id_num_flip_to_pro_or_tde = stars_retro.id_num[np.where((np.abs(stars_retro.orb_inc) <= inc_threshhold) | (stars_retro.orb_ecc == 0.0))]
+            star_flip_to_pro_flag = (np.abs(stars_retro.orb_inc) <= inc_threshhold) & (stars_retro.orb_ecc == 0.0)
+            star_id_num_flip_to_pro_or_tde = stars_retro.id_num[star_flip_to_pro_flag]
+
             star_id_num_tde, star_id_num_flip_to_pro = tde.check_tde_or_flip(star_id_num_flip_to_pro_or_tde,
                                                                              stars_retro.at_id_num(star_id_num_flip_to_pro_or_tde, "mass"),
                                                                              stars_retro.at_id_num(star_id_num_flip_to_pro_or_tde, "log_radius"),

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -3016,7 +3016,7 @@ def main():
             # SF: fix the inc threshhold later to be truly 'in disk' but should be non-stupid as-is!!!
             inc_threshhold = 5.0 * np.pi/180.0
 
-            bh_flip_to_pro_flag = (np.abs(blackholes_retro.orb_inc) <= inc_threshhold) & (blackholes_retro.orb_ecc == 0.0)
+            bh_flip_to_pro_flag = (np.abs(blackholes_retro.orb_inc) <= inc_threshhold) & (blackholes_retro.orb_ecc <= opts.disk_bh_pro_orb_ecc_crit)
             bh_id_num_flip_to_pro = blackholes_retro.id_num[bh_flip_to_pro_flag]
 
             if bh_id_num_flip_to_pro.size > 0:
@@ -3042,7 +3042,7 @@ def main():
                                       attr="direction",
                                       new_info=np.ones(bh_id_num_flip_to_pro.size))
 
-            star_flip_to_pro_flag = (np.abs(stars_retro.orb_inc) <= inc_threshhold) & (stars_retro.orb_ecc == 0.0)
+            star_flip_to_pro_flag = (np.abs(stars_retro.orb_inc) <= inc_threshhold) & (stars_retro.orb_ecc <= opts.disk_bh_pro_orb_ecc_crit)
             star_id_num_flip_to_pro_or_tde = stars_retro.id_num[star_flip_to_pro_flag]
 
             star_id_num_tde, star_id_num_flip_to_pro = tde.check_tde_or_flip(star_id_num_flip_to_pro_or_tde,

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1026,19 +1026,26 @@ def main():
             #   note this is dyn friction only, not true 'migration'
             # change retrograde eccentricity (some damping, some pumping)
             # damp orbital inclination
-            blackholes_retro.orb_ecc, blackholes_retro.orb_a, blackholes_retro.orb_inc = disk_capture.retro_bh_orb_disk_evolve(
+            bh_ecc_mask = blackholes_retro.orb_ecc > opts.disk_bh_pro_orb_ecc_crit
+
+            (
+                blackholes_retro.orb_ecc[bh_ecc_mask],
+                blackholes_retro.orb_a[bh_ecc_mask],
+                blackholes_retro.orb_inc[bh_ecc_mask]
+            ) = disk_capture.retro_bh_orb_disk_evolve(
                 opts.smbh_mass,
-                blackholes_retro.mass,
-                blackholes_retro.orb_a,
-                blackholes_retro.orb_ecc,
-                blackholes_retro.orb_inc,
-                blackholes_retro.orb_arg_periapse,
+                blackholes_retro.mass[bh_ecc_mask],
+                blackholes_retro.orb_a[bh_ecc_mask],
+                blackholes_retro.orb_ecc[bh_ecc_mask],
+                blackholes_retro.orb_inc[bh_ecc_mask],
+                blackholes_retro.orb_arg_periapse[bh_ecc_mask],
                 opts.disk_inner_stable_circ_orb,
                 disk_surface_density,
                 opts.timestep_duration_yr,
                 opts.disk_radius_outer,
                 opts.r_g_in_meters
             )
+
             # KN: Does this function apply to all disk objects and if so should we rename it?
             stars_retro.orb_ecc, stars_retro.orb_a, stars_retro.orb_inc = disk_capture.retro_bh_orb_disk_evolve(
                 opts.smbh_mass,

--- a/scripts/mcfacts_sim.py
+++ b/scripts/mcfacts_sim.py
@@ -1068,9 +1068,8 @@ def main():
                                   new_info=[stars_retro.orb_ecc,
                                             stars_retro.orb_a])
 
-            # Check for things ejected from the disk or hitting the SMBH.
-            # TODO: Add specific checks to see if the orbit would fall inside of the ISCO
-            bh_retro_id_num_ecc_hyperbolic = blackholes_retro.id_num[blackholes_retro.orb_ecc > .99]
+            # Check for hyperbolic retrogrades
+            bh_retro_id_num_ecc_hyperbolic = blackholes_retro.id_num[blackholes_retro.orb_ecc >= 1]
             if bh_retro_id_num_ecc_hyperbolic.size > 0:
                 blackholes_retro.remove_id_num(bh_retro_id_num_ecc_hyperbolic)
                 filing_cabinet.remove_id_num(bh_retro_id_num_ecc_hyperbolic)
@@ -3021,8 +3020,7 @@ def main():
             # SF: fix the inc threshhold later to be truly 'in disk' but should be non-stupid as-is!!!
             inc_threshhold = 5.0 * np.pi/180.0
 
-            bh_flip_to_pro_flag = (np.abs(blackholes_retro.orb_inc) <= inc_threshhold) & (blackholes_retro.orb_ecc <= opts.disk_bh_pro_orb_ecc_crit)
-            bh_id_num_flip_to_pro = blackholes_retro.id_num[bh_flip_to_pro_flag]
+            bh_id_num_flip_to_pro = blackholes_retro.id_num[(np.abs(blackholes_retro.orb_inc) <= inc_threshhold)]
 
             if bh_id_num_flip_to_pro.size > 0:
                 # add to prograde arrays
@@ -3047,8 +3045,7 @@ def main():
                                       attr="direction",
                                       new_info=np.ones(bh_id_num_flip_to_pro.size))
 
-            star_flip_to_pro_flag = (np.abs(stars_retro.orb_inc) <= inc_threshhold) & (stars_retro.orb_ecc <= opts.disk_bh_pro_orb_ecc_crit)
-            star_id_num_flip_to_pro_or_tde = stars_retro.id_num[star_flip_to_pro_flag]
+            star_id_num_flip_to_pro_or_tde = stars_retro.id_num[(np.abs(stars_retro.orb_inc) <= inc_threshhold)]
 
             star_id_num_tde, star_id_num_flip_to_pro = tde.check_tde_or_flip(star_id_num_flip_to_pro_or_tde,
                                                                              stars_retro.at_id_num(star_id_num_flip_to_pro_or_tde, "mass"),

--- a/src/mcfacts/physics/disk_capture.py
+++ b/src/mcfacts/physics/disk_capture.py
@@ -536,7 +536,7 @@ def tau_semi_lat(smbh_mass, retrograde_bh_locations, retrograde_bh_masses, retro
     tau_p_dyn = np.abs(np.sin(inc)) * ((delta - np.cos(inc)) ** 1.5) \
                 * (smbh_mass ** 2) * period / (
                             retro_mass * disk_surf_model(retrograde_bh_locations) * np.pi * (semi_lat_rec ** 2)) \
-                / (np.sqrt(2)) * kappa * np.abs(np.cos(inc) - zeta)
+                / (np.sqrt(2) * kappa * np.abs(np.cos(inc) - zeta))
 
     assert np.isfinite(tau_p_dyn).all(), \
         "Finite check failure: tau_p_dyn"

--- a/src/mcfacts/setup/setupdiskblackholes.py
+++ b/src/mcfacts/setup/setupdiskblackholes.py
@@ -424,7 +424,9 @@ def setup_disk_blackholes_circularized(disk_bh_num, disk_bh_pro_orb_ecc_crit):
 def setup_disk_blackholes_arg_periapse(disk_bh_num):
     """Generates disk BH initial orb arg periapse [radian]
 
-    Generates an orb arg. periapse between 0.1pi or pi/2 radians uniformly.
+    Assumes a orb arg. periapse either 0 or pi/2 radians.
+    TO DO: Set between [0,2pi] uniformly.
+    But issue with calculating retrograde capture when uniform to be fixed.
 
     Parameters
     ----------
@@ -437,7 +439,7 @@ def setup_disk_blackholes_arg_periapse(disk_bh_num):
             Initial BH orb arg periapse [radian] with :obj:`float` type.
     """
 
-    bh_initial_orb_arg_periapse = rng.uniform(low=0.1*np.pi, high=0.5*np.pi, size=disk_bh_num)
+    bh_initial_orb_arg_periapse = rng.choice(a=[0., 0.5*np.pi],size=disk_bh_num)
     return bh_initial_orb_arg_periapse
 
 

--- a/src/mcfacts/setup/setupdiskblackholes.py
+++ b/src/mcfacts/setup/setupdiskblackholes.py
@@ -424,9 +424,7 @@ def setup_disk_blackholes_circularized(disk_bh_num, disk_bh_pro_orb_ecc_crit):
 def setup_disk_blackholes_arg_periapse(disk_bh_num):
     """Generates disk BH initial orb arg periapse [radian]
 
-    Assumes a orb arg. periapse either 0 or pi/2 radians.
-    TO DO: Set between [0,2pi] uniformly.
-    But issue with calculating retrograde capture when uniform to be fixed.
+    Generates an orb arg. periapse between 0.1pi or pi/2 radians uniformly.
 
     Parameters
     ----------
@@ -439,7 +437,7 @@ def setup_disk_blackholes_arg_periapse(disk_bh_num):
             Initial BH orb arg periapse [radian] with :obj:`float` type.
     """
 
-    bh_initial_orb_arg_periapse = rng.choice(a=[0., 0.5*np.pi],size=disk_bh_num)
+    bh_initial_orb_arg_periapse = rng.uniform(low=0.1*np.pi, high=0.5*np.pi, size=disk_bh_num)
     return bh_initial_orb_arg_periapse
 
 


### PR DESCRIPTION
- Correcting the order of operations issue in the tau_semi_lat method slows down retrograde evolution.

- Correcting the check for things flipping prograde to only look at the orbital inclination. It was previously setup to let anything with zero eccentricity flip.

- Setting the lower limit of retrograde eccentricities to the critical eccentricity (0.01). Having an eccentricity of exactly 0 causes some issues with the analytical model. Since retrogrades were incorrectly flipped, this was previously not an error we ran into.


To mitigate the red storm, we can artificially reproduce the interaction we think the retrograde dump had with the eccentric population. To do this, Barry and I raised the max eccentricity from 0.3 to 0.9 and raised the number of timesteps from 50 to 70.