### PR TITLE
Eliminating redundant unit conversions

### DIFF
--- a/src/mcfacts/physics/accretion.py
+++ b/src/mcfacts/physics/accretion.py
@@ -167,7 +167,7 @@ def accrete_star_mass(disk_star_pro_masses,
     timestep_duration_yr_si = timestep_duration_yr * u.year
 
     # Calculate Bondi and Hill radii
-    r_bondi = (2 * const.G.to("m^3 / kg s^2") * star_masses_si / (disk_sound_speed_si ** 2)).to("meter")
+    r_bondi = (2 * const.G * star_masses_si / (disk_sound_speed_si ** 2)).to(u.m)
     r_hill_rg = (disk_star_pro_orbs_a * ((disk_star_pro_masses / (3 * (disk_star_pro_masses + smbh_mass))) ** (1./3.)))
     r_hill_m = si_from_r_g(smbh_mass, r_hill_rg, r_g_defined=r_g_in_meters)
 

--- a/src/mcfacts/physics/accretion.py
+++ b/src/mcfacts/physics/accretion.py
@@ -175,10 +175,10 @@ def accrete_star_mass(disk_star_pro_masses,
     min_radius = np.minimum(r_bondi, r_hill_m)
 
     # Calculate the mass accretion rate
-    mdot = ((np.pi / disk_star_luminosity_factor) * disk_density_si * disk_sound_speed_si * (min_radius ** 2)).to("kg/yr")
+    mdot = ((np.pi / disk_star_luminosity_factor) * disk_density_si * disk_sound_speed_si * (min_radius ** 2)).to(u.kg/u.yr)
 
     # Accrete mass onto stars
-    disk_star_pro_new_masses = ((star_masses_si + mdot * timestep_duration_yr_si).to("Msun")).value
+    disk_star_pro_new_masses = ((star_masses_si + mdot * timestep_duration_yr_si).to(u.Msun)).value
 
     # Stars can't accrete over disk_star_initial_mass_cutoff
     disk_star_pro_new_masses[disk_star_pro_new_masses > disk_star_initial_mass_cutoff] = disk_star_initial_mass_cutoff

--- a/src/mcfacts/physics/point_masses.py
+++ b/src/mcfacts/physics/point_masses.py
@@ -40,8 +40,8 @@ def time_of_orbital_shrinkage(mass_1, mass_2, sep_initial, sep_final):
         Time [s] of orbital shrinkage
     """
     # Calculate c and G in SI
-    c = const.c.to('m/s').value
-    G = const.G.to('m^3/(kg s^2)').value
+    c = const.c.value
+    G = const.G.value
     # Assert SI units
     mass_1 = mass_1.to('kg').value
     mass_2 = mass_2.to('kg').value
@@ -82,8 +82,8 @@ def orbital_separation_evolve(mass_1, mass_2, sep_initial, evolve_time):
         Final separation [m] of two bodies
     """
     # Calculate c and G in SI
-    c = const.c.to('m/s').value
-    G = const.G.to('m^3/(kg s^2)').value
+    c = const.c.value
+    G = const.G.value
     # Assert SI units
     mass_1 = mass_1.to('kg').value
     mass_2 = mass_2.to('kg').value
@@ -127,8 +127,8 @@ def orbital_separation_evolve_reverse(mass_1, mass_2, sep_final, evolve_time):
         Initial separation [m] of two bodies
     """
     # Calculate c and G in SI
-    c = const.c.to('m/s').value
-    G = const.G.to('m^3/(kg s^2)').value
+    c = const.c.value
+    G = const.G.value
     # Assert SI units
     mass_1 = mass_1.to('kg').value
     mass_2 = mass_2.to('kg').value
@@ -173,10 +173,6 @@ def si_from_r_g(smbh_mass, distance_rg, r_g_defined=None):
     if r_g_defined is not None:
         r_g = r_g_defined
     else:
-        # Calculate c and G in SI
-        c = const.c.to('m/s')
-        G = const.G.to('m^3/(kg s^2)')
-
         # Assign units to smbh mass
         if hasattr(smbh_mass, 'unit'):
             smbh_mass = smbh_mass.to('solMass')
@@ -187,7 +183,7 @@ def si_from_r_g(smbh_mass, distance_rg, r_g_defined=None):
         smbh_mass = smbh_mass.to('kg')
 
         # Calculate r_g in SI
-        r_g = G*smbh_mass/(c ** 2)
+        r_g = const.G*smbh_mass/(const.c ** 2)
 
     # Calculate distance
     distance = (distance_rg * r_g).to("meter")
@@ -215,9 +211,6 @@ def r_g_from_units(smbh_mass, distance):
     distance_rg : numpy.ndarray
         Distances [r_g]
     """
-    # Calculate c and G in SI
-    c = const.c.to('m/s')
-    G = const.G.to('m^3/(kg s^2)')
     # Assign units to smbh mass
     if hasattr(smbh_mass, 'unit'):
         smbh_mass = smbh_mass.to('solMass')
@@ -226,7 +219,7 @@ def r_g_from_units(smbh_mass, distance):
     # convert smbh mass to kg
     smbh_mass = smbh_mass.to('kg')
     # Calculate r_g in SI
-    r_g = G*smbh_mass/(c ** 2)
+    r_g = const.G*smbh_mass/(const.c ** 2)
     # Calculate distance
     distance_rg = distance.to("meter") / r_g
 

--- a/src/mcfacts/physics/point_masses.py
+++ b/src/mcfacts/physics/point_masses.py
@@ -43,10 +43,10 @@ def time_of_orbital_shrinkage(mass_1, mass_2, sep_initial, sep_final):
     c = const.c.value
     G = const.G.value
     # Assert SI units
-    mass_1 = mass_1.to('kg').value
-    mass_2 = mass_2.to('kg').value
-    sep_initial = sep_initial.to('m').value
-    sep_final = sep_final.to('m').value
+    mass_1 = mass_1.to(u.kg).value
+    mass_2 = mass_2.to(u.kg).value
+    sep_initial = sep_initial.to(u.m).value
+    sep_final = sep_final.to(u.m).value
     # Set up the constant as a single float
     const_G_c = ((64 / 5) * (G ** 3)) * (c ** -5)
     # Calculate the beta array
@@ -213,15 +213,16 @@ def r_g_from_units(smbh_mass, distance):
     """
     # Assign units to smbh mass
     if hasattr(smbh_mass, 'unit'):
-        smbh_mass = smbh_mass.to('solMass')
+        smbh_mass = smbh_mass.to(u.solMass)
     else:
         smbh_mass = smbh_mass * u.solMass
     # convert smbh mass to kg
-    smbh_mass = smbh_mass.to('kg')
+    smbh_mass = smbh_mass.to(u.kg)
+
     # Calculate r_g in SI
     r_g = const.G*smbh_mass/(const.c ** 2)
     # Calculate distance
-    distance_rg = distance.to("meter") / r_g
+    distance_rg = distance.to(u.m) / r_g
 
     # Check to make sure units are okay.
     assert u.dimensionless_unscaled == distance_rg.unit, \
@@ -250,11 +251,11 @@ def r_schwarzschild_of_m(mass):
 
     # Assign units to mass
     if hasattr(mass, 'unit'):
-        mass = mass.to('solMass')
+        mass = mass.to(u.solMass)
     else:
         mass = mass * u.solMass
 
-    r_sch = (2. * const.G * mass / (const.c ** 2)).to("meter")
+    r_sch = (2. * const.G * mass / (const.c ** 2)).to(u.m)
 
     assert np.isfinite(r_sch).all(), \
         "Finite check failure: r_sch"


### PR DESCRIPTION
Several functions, most notably r_g_from_units, perform unnecessary SI unit conversions on astropy.constants.c and G.

Both these imports are already denominated in SI units (m/s and m^3 / kg s^2 respectively), per the [documentation](https://docs.astropy.org/en/stable/units/ref_api.html#module-astropy.units.si), which can also be confirmed in the console.

```
>>> import astropy.constants as const
>>> const.G
    class 'astropy.constants.codata2018.CODATA2018'> name='Gravitational constant' value=6.6743e-11 uncertainty=1.5e-15 unit='m3 / (kg s2)' reference='CODATA 2018'>
>>> const.c
    class 'astropy.constants.codata2018.CODATA2018'> name='Speed of light in vacuum' value=299792458.0 uncertainty=0.0 unit='m / s' reference='CODATA 2018'>
```

Converting them into the same units does not change them, but does burn cycles. In r_g_units alone, this accounts for nearly a tenth of total simulation runtime, owing to the frequency with which it is called.

We remove these extraneous conversions from several functions in point_masses, including orbital_separation_evolve and orbital_separation_evolve_reverse, which do not seem to be used in the simulation at present, but may be used in the future.

In addition, we replace string-based unit indication with unit literals: for astropy's unit conversion, `.to("m")` is semantically identical to `.to(u.m)`, but the former requires string parsing, which slows down the conversion. Across several functions, this shaves a couple seconds off the simulation.

Cumulatively, these optimizations reduce profiled time from 104 to 89 seconds, an ~15% runtime speed improvement.

This PR does not introduce new automated tests, as these changes survived inline testing and all changes were judged to be self-evidently correct. If this is not the case and testing is required, please advise.