### PR TITLE
fix: updated scipy version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ requires-python = ">= 3.10, < 3.14"
 dependencies = [
     "numpy>=2.0,<2.4.0",
     "matplotlib>=3.5.2",
-    "scipy>=1.11.2",
+    "scipy>=1.11.2,<1.18.0",
     "astropy",
     "pandas",
     "pagn",


### PR DESCRIPTION
pAGN currently does not work with scipy version 1.18 (tested on 1.17.1 and 1.18).

As a result, a fresh install fails to work correctly.