### PR TITLE
optimizing copy() and consistency_check()

### DIFF
--- a/src/mcfacts/objects/agn_object_array.py
+++ b/src/mcfacts/objects/agn_object_array.py
@@ -786,16 +786,27 @@ class FilingCabinet:
 
 
     def consistency_check(self):
+        arrs = [(k, a.unique_id) for k, a in self.agn_objects.items() if k not in self.ignore_check]
+
+        total = 0
+        merged = set()
+
+        for _, arr in arrs:
+            total += len(arr)
+            merged.update(arr)
+
+        if len(merged) == total:
+            # early return, no duplicates
+            return
+
+        # a duplicate, let's look for it
         seen: dict[uuid.UUID, str] = {}
 
-        for key, arr in self.agn_objects.items():
-            if key in self.ignore_check:
-                continue
+        for key, arr in arrs:
+            ids = set(arr)
 
-            ids = set(arr.unique_id)
-
-            if len(ids) != len(arr.unique_id):
-                counts = Counter(arr.unique_id)
+            if len(ids) != len(arr):
+                counts = Counter(arr)
                 dupes = [uid for uid, n in counts.items() if n > 1]
                 raise RuntimeError(
                     f"A duplicate entry has been found in the filing cabinet. {dupes} appears more than once in: {key}")
@@ -803,8 +814,9 @@ class FilingCabinet:
             for uid in ids:
                 if uid in seen:
                     raise RuntimeError(
-                        f"A duplicate entry has been found in the filing cabinet. {uid} Found in: {[seen[uid], key]}")
+                        f"A duplicate entry has been found in the filing cabinet. {uid} Found in: {self.list_occurrence(uid)}")
                 seen[uid] = key
+
 
     def update_time(self, new_time: float):
         for key, value in self.agn_objects.items():

--- a/src/mcfacts/objects/agn_object_array.py
+++ b/src/mcfacts/objects/agn_object_array.py
@@ -1,4 +1,5 @@
 import uuid
+from collections import Counter
 from abc import ABC, abstractmethod
 import copy
 from typing import Any, TypeVar, Type
@@ -785,32 +786,25 @@ class FilingCabinet:
 
 
     def consistency_check(self):
-        arrs_to_check = []
+        seen: dict[uuid.UUID, str] = {}
+
         for key, arr in self.agn_objects.items():
-            if key not in self.ignore_check:
-                arrs_to_check.append((key, arr.unique_id))
+            if key in self.ignore_check:
+                continue
 
-        arrs_len = len(arrs_to_check)
+            ids = set(arr.unique_id)
 
-        sets_to_check = [(key, set(arr)) for (key, arr) in arrs_to_check]
+            if len(ids) != len(arr.unique_id):
+                counts = Counter(arr.unique_id)
+                dupes = [uid for uid, n in counts.items() if n > 1]
+                raise RuntimeError(
+                    f"A duplicate entry has been found in the filing cabinet. {dupes} appears more than once in: {key}")
 
-        # check that the length of each array -> set doesn't change, 
-        # i.e. there weren't duplicates within individual arrays
-        for i, (key, s) in enumerate(sets_to_check):
-            if len(arrs_to_check[i][1]) != len(s):
-                raise RuntimeError(f"A duplicate entry has been found in the filing cabinet. Found in: {key}. Len of the array is {len(arrs_to_check[i][1])}, len of the set is {len(s)}")
-            
-        # take pairwise intersections of each one
-        start = 1
-        for i in range(arrs_len-1):
-            for j in range(start, arrs_len):
-                key_i, set_i = sets_to_check[i]
-                key_j, set_j = sets_to_check[j]
-                intersection = set_i.intersection(set_j)
-                if intersection:
-                    raise RuntimeError(f"A duplicate entry has been found in the filing cabinet. {intersection} Found in: {key_i, key_j}")
-
-            start+=1
+            for uid in ids:
+                if uid in seen:
+                    raise RuntimeError(
+                        f"A duplicate entry has been found in the filing cabinet. {uid} Found in: {[seen[uid], key]}")
+                seen[uid] = key
 
     def update_time(self, new_time: float):
         for key, value in self.agn_objects.items():

--- a/src/mcfacts/objects/agn_object_array.py
+++ b/src/mcfacts/objects/agn_object_array.py
@@ -1,6 +1,6 @@
 import uuid
 from abc import ABC, abstractmethod
-from copy import deepcopy
+import copy
 from typing import Any, TypeVar, Type
 
 import numpy as np
@@ -221,7 +221,13 @@ class AGNObjectArray(ABC):
         return True
 
     def copy(self):
-        return deepcopy(self)
+        new = copy.copy(self)
+
+        for attribute_name, attribute_value in self.get_super_dict().items():
+            if isinstance(attribute_value, np.ndarray):
+                setattr(new, attribute_name, attribute_value.copy())
+
+        return new
 
     @abstractmethod
     def get_super_dict(self) -> dict[str, npt.NDArray[Any]]:

--- a/src/mcfacts/objects/agn_object_array.py
+++ b/src/mcfacts/objects/agn_object_array.py
@@ -208,13 +208,13 @@ class AGNObjectArray(ABC):
             - Updates all attributes in the superclass attribute list to reflect the retained entries.
             - If no entries match the given unique IDs, no changes are made, and the method returns `False`.
         """
-        remove_mask = np.isin(self.unique_id, unique_id)
+        keep_mask = np.isin(self.unique_id, unique_id)
 
-        if len(remove_mask) == 0:
+        if len(keep_mask) == 0:
             return False
 
         for attribute_name, attribute_value in self.get_super_dict().items():
-            setattr(self, attribute_name, attribute_value[remove_mask])
+            setattr(self, attribute_name, attribute_value[keep_mask])
 
         self.consistency_check()
 

--- a/src/mcfacts/objects/agn_object_array.py
+++ b/src/mcfacts/objects/agn_object_array.py
@@ -773,11 +773,11 @@ class FilingCabinet:
     def list_occurrence(self, unique_id: uuid.UUID) -> list[str]:
         occurrence: list[str] = list()
 
-        for key, value in self.agn_objects.items():
+        for key, arr in self.agn_objects.items():
             if key in self.ignore_check:
                 continue
 
-            for entry in value.unique_id:
+            for entry in arr.unique_id:
                 if unique_id == entry:
                     occurrence.append(key)
 
@@ -785,16 +785,32 @@ class FilingCabinet:
 
 
     def consistency_check(self):
-        for key, value in self.agn_objects.items():
-            if key in self.ignore_check:
-                continue
+        arrs_to_check = []
+        for key, arr in self.agn_objects.items():
+            if key not in self.ignore_check:
+                arrs_to_check.append((key, arr.unique_id))
 
-            for entry in value.unique_id:
-                occurrence = self.list_occurrence(entry)
+        arrs_len = len(arrs_to_check)
 
-                if len(occurrence) > 1:
-                    raise RuntimeError(f"A duplicate entry has been found in the filing cabinet. {entry} Found in: {occurrence}")
+        sets_to_check = [(key, set(arr)) for (key, arr) in arrs_to_check]
 
+        # check that the length of each array -> set doesn't change, 
+        # i.e. there weren't duplicates within individual arrays
+        for i, (key, s) in enumerate(sets_to_check):
+            if len(arrs_to_check[i][1]) != len(s):
+                raise RuntimeError(f"A duplicate entry has been found in the filing cabinet. Found in: {key}. Len of the array is {len(arrs_to_check[i][1])}, len of the set is {len(s)}")
+            
+        # take pairwise intersections of each one
+        start = 1
+        for i in range(arrs_len-1):
+            for j in range(start, arrs_len):
+                key_i, set_i = sets_to_check[i]
+                key_j, set_j = sets_to_check[j]
+                intersection = set_i.intersection(set_j)
+                if intersection:
+                    raise RuntimeError(f"A duplicate entry has been found in the filing cabinet. {intersection} Found in: {key_i, key_j}")
+
+            start+=1
 
     def update_time(self, new_time: float):
         for key, value in self.agn_objects.items():


### PR DESCRIPTION
Following PR #389 , the biggest single time sinks in restructure are copy() and consistency_check(). 

Jake observed that copy() deep-copies unnecessarily, since numpy arrays are immutable, so we can instead just use shallow copies, which dramatically reduces our memory use and time spent copying. This brings restructure time down from 76 seconds to 40 seconds.

consistency_check can be sped up considerably by taking a fast-path, just turning all the arrays into sets and making sure their mutual intersection is 0, or that the length of the merged sets is the same as the original arrays. Only in the case where we find a duplicate do we go through with list_occurrences() and actually find where the duplicates are for an informative error message. The fast path doesn't need that information. This brings restructure time down from 40 seconds to 33.

Total improvement is ~2.3x speedup with no difference to the output.
